### PR TITLE
fix: Fix database summary when patch_name metadata is missing

### DIFF
--- a/shinka/database/display.py
+++ b/shinka/database/display.py
@@ -122,6 +122,18 @@ class DatabaseDisplay:
             else:
                 time_display = f"{time_val:.1f}s"
 
+        # Safely extract metadata fields for display
+        metadata = program.metadata or {}
+        patch_name_raw = metadata.get("patch_name", "[dim]N/A[/dim]")
+        if patch_name_raw is None:
+            patch_name_raw = "[dim]N/A[/dim]"
+        patch_name = str(patch_name_raw)[:30]
+
+        patch_type_raw = metadata.get("patch_type", "[dim]N/A[/dim]")
+        if patch_type_raw is None:
+            patch_type_raw = "[dim]N/A[/dim]"
+        patch_type = str(patch_type_raw)
+
         # Add the data row
         island_display = (
             f"I-{program.island_idx}" if program.island_idx is not None else "N/A"
@@ -131,8 +143,8 @@ class DatabaseDisplay:
             island_display,
             status_display,
             score_display,
-            program.metadata.get("patch_name", "[dim]N/A[/dim]")[:30],
-            program.metadata.get("patch_type", "[dim]N/A[/dim]"),
+            patch_name,
+            patch_type,
             f"{program.complexity:.1f}",
             cost_display,
             time_display,


### PR DESCRIPTION
got this error when running
```
Traceback (most recent call last):
  File "/home/dex/ShinkaEvolve/shinka/launch_hydra.py", line 28, in main
    evo_runner.run()
  File "/home/dex/ShinkaEvolve/shinka/core/runner.py", line 318, in run
    self._process_completed_job(job)
  File "/home/dex/ShinkaEvolve/shinka/core/runner.py", line 839, in _process_completed_job
    self.db.add(db_program, verbose=True)
  File "/home/dex/ShinkaEvolve/shinka/database/dbase.py", line 97, in wrapper
    return func(*args, **kwargs)
  File "/home/dex/ShinkaEvolve/shinka/database/dbase.py", line 651, in add
    self._print_program_summary(program)
  File "/home/dex/ShinkaEvolve/shinka/database/dbase.py", line 1438, in _print_program_summary
    self._database_display.print_program_summary(program)
  File "/home/dex/ShinkaEvolve/shinka/database/display.py", line 134, in print_program_summary
    program.metadata.get("patch_name", "[dim]N/A[/dim]")[:30],
TypeError: 'NoneType' object is not subscriptable
```