### PR TITLE
Add support for Claude Sonnet 4.5

### DIFF
--- a/shinka/llm/models/pricing.py
+++ b/shinka/llm/models/pricing.py
@@ -35,6 +35,10 @@ CLAUDE_MODELS = {
         "input_price": 3.0 / M,
         "output_price": 15.0 / M,
     },
+    "claude-sonnet-4-5-20250929": {
+        "input_price": 3.0 / M,
+        "output_price": 15.0 / M,
+    },
 }
 
 OPENAI_MODELS = {
@@ -176,6 +180,7 @@ REASONING_OAI_MODELS = [
 REASONING_CLAUDE_MODELS = [
     "claude-3-7-sonnet-20250219",
     "claude-4-sonnet-20250514",
+    "claude-sonnet-4-5-20250929",
 ]
 
 REASONING_DEEPSEEK_MODELS = [


### PR DESCRIPTION
This PR adds support for the new Claude Sonnet 4.5 model (claude-sonnet-4-5-20250929).

**Changes:**
- Added claude-sonnet-4-5-20250929 to CLAUDE_MODELS with pricing (.00 per million input tokens, cd /Users/arun.parthiban/ShinkaEvolve && gh pr create --base main --head arun-pathiban-ddog:add-claude-sonnet-4.5-support --title "Add support for Claude Sonnet 4.5" --body "This PR adds support for the new Claude Sonnet 4.5 model (claude-sonnet-4-5-20250929).

**Changes:**
- Added claude-sonnet-4-5-20250929 to CLAUDE_MODELS with pricing ($3.00 per million input tokens, $15.00 per million output tokens)
- Added the model to REASONING_CLAUDE_MODELS list for enhanced reasoning capabilities

The model was released on September 29, 2025, and maintains the same competitive pricing as Claude Sonnet 4." --repo SakanaAI/ShinkaEvolve5.00 per million output tokens)
- Added the model to REASONING_CLAUDE_MODELS list for enhanced reasoning capabilities

The model was released on September 29, 2025, and maintains the same competitive pricing as Claude Sonnet 4.