### PR TITLE
Add performance/cost optimistic ucb estimate and automatic scaling logic.

### DIFF
--- a/shinka/core/runner.py
+++ b/shinka/core/runner.py
@@ -1107,6 +1107,9 @@ class EvolutionRunner:
                     # error_attempt is already set from apply_patch or default
                     pass
 
+        if self.llm_selection is not None:
+            self.llm_selection.update_cost(model_name, total_costs)
+  
         # Only consider the diff summary for the original source file
         original_filename = f"original.{self.lang_ext}"
         if original_filename in diff_summary:


### PR DESCRIPTION
This PR adds cost-aware exploration to the UCB-based model selection.

The idea is to maintain a separate *optimistic estimate* of model cost, analogous to the optimistic performance estimate already used by UCB. From these, we derive an alternative performance/dollar UCB score and interpolate it with the original performance-based score.

* `cost_aware_coef ∈ [0, 1]` trades off the original performance score with the performance/$ score

  * `0` preserves the current behavior (default)
  * `1` fully optimizes for performance per dollar

The interpolation is dynamically normalized using the median observed cost, so that `cost_aware_coef ≈ 0.5` yields an approximately balanced tradeoff between performance and performance/$.

* `cost_exploration_coef` controls how optimistic the cost estimate is, analogous to `exploration_coef` for performance.