### PR TITLE
Add OpenRouter support with robust pricing and embeddings

### DIFF
--- a/shinka/llm/client.py
+++ b/shinka/llm/client.py
@@ -78,6 +78,26 @@ def get_client_llm(model_name: str, structured_output: bool = False) -> Tuple[An
                 client,
                 mode=instructor.Mode.GEMINI_JSON,
             )
+
+    elif "/" in model_name and not model_name.startswith("bedrock/"):
+        api_key = os.getenv("OPENROUTER_API_KEY")
+        if not api_key:
+            raise ValueError(
+                f"Model '{model_name}' detected as OpenRouter model, "
+                "but OPENROUTER_API_KEY is not set in environment variables."
+            )
+        client = openai.OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=api_key,
+            default_headers={
+                "HTTP-Referer": os.getenv(
+                    "SHINKA_SITE_URL", "https://github.com/SakanaAI/ShinkaEvolve"
+                ),
+                "X-Title": os.getenv("SHINKA_APP_NAME", "ShinkaEvolve"),
+            },
+        )
+        if structured_output:
+            client = instructor.from_openai(client, mode=instructor.Mode.JSON)
     else:
         raise ValueError(f"Model {model_name} not supported.")
 

--- a/shinka/llm/models/__init__.py
+++ b/shinka/llm/models/__init__.py
@@ -2,6 +2,7 @@ from .anthropic import query_anthropic
 from .openai import query_openai
 from .deepseek import query_deepseek
 from .gemini import query_gemini
+from .openrouter import query_openrouter
 from .result import QueryResult
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "query_openai",
     "query_deepseek",
     "query_gemini",
+    "query_openrouter",
     "QueryResult",
 ]

--- a/shinka/llm/models/openrouter.py
+++ b/shinka/llm/models/openrouter.py
@@ -1,0 +1,92 @@
+import backoff
+import openai
+from .result import QueryResult
+from .pricing import get_openrouter_model_price 
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def backoff_handler(details):
+    exc = details.get("exception")
+    if exc:
+        logger.warning(
+            f"OpenRouter Query - Retry {details['tries']} error: {exc}. Wait {details['wait']:0.1f}s..."
+        )
+
+@backoff.on_exception(
+    backoff.expo,
+    (
+        openai.APIConnectionError,
+        openai.APIStatusError,
+        openai.RateLimitError,
+        openai.APITimeoutError,
+    ),
+    max_tries=20,
+    max_value=20,
+    on_backoff=backoff_handler,
+)
+def query_openrouter(
+    client,
+    model,
+    msg,
+    system_msg,
+    msg_history,
+    output_model,
+    model_posteriors=None,
+    **kwargs,
+) -> QueryResult:
+    
+    unsupported_params = ['max_output_tokens', 'reasoning', 'thinking', 'extra_body']
+    filtered_kwargs = {k: v for k, v in kwargs.items() if k not in unsupported_params}
+    
+    new_msg_history = msg_history + [{"role": "user", "content": msg}]
+
+    if output_model is None:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "system", "content": system_msg}, *new_msg_history],
+            **filtered_kwargs,
+        )
+        content = response.choices[0].message.content
+        new_msg_history.append({"role": "assistant", "content": content})
+    else:
+        response = client.chat.completions.create(
+            model=model,
+            response_model=output_model,
+            messages=[{"role": "system", "content": system_msg}, *new_msg_history],
+            **filtered_kwargs,
+        )
+        content = response.model_dump_json()
+        new_msg_history.append({"role": "assistant", "content": content})
+
+    try:
+        input_price, output_price = get_openrouter_model_price(model, os.getenv("OPENROUTER_API_KEY"))
+    except Exception as e:
+        logger.error(f"CRITICAL: Failed to get pricing for {model} after retries: {e}")
+        
+        input_price, output_price = 1.0 / 1_000_000, 1.0 / 1_000_000 
+
+    input_tokens = response.usage.prompt_tokens
+    output_tokens = response.usage.completion_tokens
+    
+    input_cost = input_price * input_tokens
+    output_cost = output_price * output_tokens
+    total_cost = input_cost + output_cost
+
+    return QueryResult(
+        content=content,
+        msg=msg,
+        system_msg=system_msg,
+        new_msg_history=new_msg_history,
+        model_name=model,
+        kwargs=kwargs,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost=total_cost,
+        input_cost=input_cost,
+        output_cost=output_cost,
+        thought="",
+        model_posteriors=model_posteriors,
+    )

--- a/shinka/llm/query.py
+++ b/shinka/llm/query.py
@@ -20,6 +20,7 @@ from .models import (
     query_openai,
     query_deepseek,
     query_gemini,
+    query_openrouter,
     QueryResult,
 )
 import logging
@@ -175,6 +176,7 @@ def sample_model_kwargs(
             or kwargs_dict["model_name"] in REASONING_BEDROCK_MODELS
             or kwargs_dict["model_name"] in DEEPSEEK_MODELS
             or kwargs_dict["model_name"] in REASONING_DEEPSEEK_MODELS
+            or "/" in kwargs_dict["model_name"] 
         ):
             kwargs_dict["max_tokens"] = random.choice(max_tokens)
         else:
@@ -204,6 +206,8 @@ def query(
         query_fn = query_deepseek
     elif model_name in GEMINI_MODELS.keys():
         query_fn = query_gemini
+    elif "/" in model_name and not model_name.startswith("bedrock/"):
+        query_fn = query_openrouter
     else:
         raise ValueError(f"Model {model_name} not supported.")
     result = query_fn(


### PR DESCRIPTION
## Hello!

This PR introduces full support for **OpenRouter** as an LLM provider. It enables the use of any model available via OpenRouter (e.g., `xiaomi/mimo-v2-flash`, `google/gemini-3-flash-preview`) by simply specifying the model name with a slash (e.g., `provider/model-name`).

The implementation includes support for both **Chat Completions** and **Embeddings**, featuring dynamic pricing fetching, caching, and error handling.

### 🛠 Key Changes

#### 1. OpenRouter Integration (`shinka/llm/models/openrouter.py`)
- Implemented `query_openrouter` function using OpenAI-compatible API.
- Added **argument filtering**: Automatically removes unsupported parameters (e.g., `max_output_tokens`, `reasoning`) before sending requests to prevent API errors.
- Integrated `backoff` decorator for automatic retries on network failures or rate limits (as it was in other files at models/).

#### 2. Dynamic Pricing & Caching (`shinka/llm/models/pricing.py`)
- Implemented `get_openrouter_model_price` to fetch real-time token costs from OpenRouter API.
- Added **caching mechanism** (`_OPENROUTER_PRICING_CACHE`) to minimize API calls.
- **Safety Fallback**: If pricing cannot be fetched after retries, the cost defaults to `1.0 for 1 m tokens` to prevent skewing evolution metrics with false data and not to deplete the balance at openrouter

#### 3. Embeddings Support (`shinka/llm/embedding.py`)
- Added detection logic for OpenRouter embedding models.
- Implemented specific pricing fetcher for embeddings to handle OpenRouter's specific endpoints.
- Uses standard `openai` client routing for seamless integration.

#### 4. Client & Query Logic (`client.py`, `query.py`)
- Updated model detection logic: models containing `/` (except `bedrock/`) are automatically routed to OpenRouter.


### ✅ Verification
- Tested with standard LLM models via OpenRouter (e.g., `xiaomi/mimo-v2-flash`).
- Tested with embedding models.
- Verified that network errors trigger retries without crashing the main process.

### 📸 Evidence of execution (with num_generations=10)
<img width="2880" height="1920" alt="screenshot0" src="https://github.com/user-attachments/assets/0d721ead-292e-4a70-b943-2b41adcc3c0e" />
<img width="2880" height="1920" alt="screenshot1" src="https://github.com/user-attachments/assets/ae4f6b6e-7e0c-4683-8eff-ea9b50bef243" />
<img width="2880" height="1920" alt="screenshot2" src="https://github.com/user-attachments/assets/38959f39-bd1f-490c-8955-096ef58ebe3a" />
<img width="2880" height="1920" alt="screenshot3" src="https://github.com/user-attachments/assets/302be38c-29e1-4552-988e-7a1710fe8fa7" />


## Have a nice day!