### PR TITLE
Fix Windows path handling in visualization server. Normalize backslashes to forward slashes for JavaScript compatibility

### DIFF
--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -101,6 +101,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     if f.lower().endswith((".db", ".sqlite")):
                         full_path = os.path.join(root, f)
                         client_path = os.path.relpath(full_path, self.search_root)
+                        # Normalize Windows paths to use forward slashes for consistency
+                        # with JavaScript path parsing in the frontend
+                        if os.name == 'nt':  # Windows
+                            client_path = client_path.replace('\\', '/')
                         display_name = f"{Path(f).stem} - {Path(client_path).parent}"
 
                         # Extract date for sorting


### PR DESCRIPTION
## Fix Windows path handling in visualization server

### Problem
On Windows, the visualization server fails to properly display databases in the dropdown selector. The issue occurs because `os.path.relpath()` returns paths with backslashes (e.g., `kspdg\20260124_154350\shinka_evo_db.sqlite`), but the JavaScript frontend expects forward slashes and splits paths using `/`.

This causes the path parsing logic to fail when trying to extract the 3-level structure:
- Task name (e.g., `abcdfg`)
- Timestamp (e.g., `20260124_154350`)
- Database filename (e.g., `shinka_evo_db.sqlite`)

### Solution
Normalize Windows paths to use forward slashes before sending them to the client. This fix:
- Only applies on Windows (`os.name == 'nt'`)
- Converts backslashes to forward slashes for consistency with JavaScript path parsing
- Does not affect Unix/Linux/macOS behavior
- Forward slashes work correctly on all platforms, including Windows

### Changes
- Modified `visualization.py` in the `handle_list_databases` method to normalize Windows paths

### Testing
Tested on Windows 11 with Python 3.12. After this fix:
- Databases appear correctly in the dropdown selector
- Path parsing works as expected
- Visualization loads successfully

### Notes
Forward slashes are the standard path separator for web/JavaScript and work correctly on all platforms, including Windows (Windows has supported forward slashes in paths since DOS 2.0).
