### PR TITLE
feat: add Gemini embedding 2 support and shinka-convert skill

### DIFF
--- a/shinka/embed/embedding.py
+++ b/shinka/embed/embedding.py
@@ -13,6 +13,40 @@ logger = logging.getLogger(__name__)
 _tiktoken_cache = {}
 
 
+def _get_google_embeddings_and_cost(
+    client,
+    model_name: str,
+    texts: List[str],
+) -> Tuple[List[List[float]], float]:
+    """Embed texts with Gemini and bill using Gemini token counts when available."""
+    embeddings = []
+    total_tokens = 0
+    model = f"models/{model_name}"
+    price_per_token = get_model_price(model_name)
+
+    for text in texts:
+        token_count = None
+        try:
+            token_response = client.models.count_tokens(model=model, contents=text)
+            token_count = getattr(token_response, "total_tokens", None)
+        except Exception as exc:
+            logger.warning(
+                "Gemini token counting failed for %s; falling back to whitespace "
+                "estimate. Error: %s",
+                model_name,
+                exc,
+            )
+
+        result = client.models.embed_content(model=model, contents=text)
+        embeddings.append(result.embeddings[0].values)
+
+        if token_count is None:
+            token_count = len(text.split())
+        total_tokens += token_count
+
+    return embeddings, total_tokens * price_per_token
+
+
 def count_tokens(
     text: Union[str, List[str]],
     model: str = "text-embedding-3-small",
@@ -113,18 +147,11 @@ class EmbeddingClient:
         # Handle Gemini models
         if self.provider == "google":
             try:
-                embeddings = []
-                total_tokens = 0
-
-                for text in code:
-                    result = self.client.models.embed_content(
-                        model=f"models/{self.model}",
-                        contents=text,
-                    )
-                    embeddings.append(result.embeddings[0].values)
-                    total_tokens += len(text.split())
-
-                cost = total_tokens * get_model_price(self.model_name)
+                embeddings, cost = _get_google_embeddings_and_cost(
+                    client=self.client,
+                    model_name=self.model,
+                    texts=code,
+                )
 
                 if single_code:
                     return embeddings[0] if embeddings else [], cost
@@ -376,22 +403,16 @@ class AsyncEmbeddingClient:
         if self.provider == "google":
             import asyncio
 
-            def _sync_gemini_embed():
-                embeddings = []
-                total_tokens = 0
-                for text in code:
-                    result = self.async_client.models.embed_content(
-                        model=f"models/{self.model}",
-                        contents=text,
-                    )
-                    embeddings.append(result.embeddings[0].values)
-                    total_tokens += len(text.split())
-                cost = total_tokens * get_model_price(self.model_name)
-                return embeddings, cost
-
             try:
                 loop = asyncio.get_event_loop()
-                embeddings, cost = await loop.run_in_executor(None, _sync_gemini_embed)
+                embeddings, cost = await loop.run_in_executor(
+                    None,
+                    lambda: _get_google_embeddings_and_cost(
+                        client=self.async_client,
+                        model_name=self.model,
+                        texts=code,
+                    ),
+                )
                 if single_code:
                     return embeddings[0] if embeddings else [], cost
                 else:

--- a/shinka/embed/providers/pricing.csv
+++ b/shinka/embed/providers/pricing.csv
@@ -5,4 +5,4 @@ azure-text-embedding-3-small,azure,0.02
 azure-text-embedding-3-large,azure,0.13
 gemini-embedding-exp-03-07,google,0.0
 gemini-embedding-001,google,0.15
-
+gemini-embedding-2-preview,google,0.20

--- a/skills/shinka-convert/SKILL.md
+++ b/skills/shinka-convert/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: shinka-convert
+description: Convert an existing codebase in the current working directory into a ShinkaEvolve task directory by snapshotting the relevant code, adding evolve blocks, and generating `evaluate.py` plus Shinka runner/config files. Use when the user wants to optimize existing code with Shinka instead of creating a brand-new task from a natural-language description.
+---
+
+# Shinka Convert Skill
+Use this skill to turn an existing project into a Shinka-ready task.
+
+This is the alternative starting point to `shinka-setup`:
+- `shinka-setup`: new task from natural-language task description
+- `shinka-convert`: existing codebase to Shinka task conversion
+
+After conversion, the user should still be able to use `shinka-run`.
+
+## When to Use
+Invoke this skill when the user:
+- Wants to optimize an existing script or repo with Shinka/ShinkaEvolve
+- Mentions adapting current code to Shinka output signatures, `metrics.json`, `correct.json`, or `EVOLVE-BLOCK` markers
+- Wants a sidecar Shinka task generated from the current working directory
+
+Do not use this skill when:
+- The user wants a brand-new task scaffold from only a natural-language description
+- `evaluate.py` and `initial.<ext>` already exist and the user only wants to launch evolution; use `shinka-run`
+
+## User Inputs
+Start from freeform instructions, then ask follow-ups only if high-impact details are missing.
+
+Collect:
+- What behavior or file/function to optimize
+- Score direction and main metric
+- Constraints: correctness, runtime, memory, determinism, style, allowed edits
+- Whether original source must remain untouched
+- Any required data/assets/dependencies
+
+## Default Output
+Generate a sidecar task directory at `./shinka_task/` unless the user requests another path.
+
+The task directory should contain:
+- `evaluate.py`
+- `run_evo.py`
+- `shinka.yaml`
+- `initial.<ext>`
+- A copied snapshot of the minimal runnable source subtree needed for evaluation
+
+Do not edit the original source tree unless the user explicitly requests in-place conversion.
+
+## Workflow
+1. Inspect the current working directory.
+   - Identify language, entrypoints, package/module layout, dependencies, and current outputs.
+   - Prefer concrete evidence from the code over guesses.
+2. Infer the evolvable region from the user's instructions.
+   - If ambiguous, ask targeted follow-ups.
+   - Keep the mutable region as small as practical.
+3. Choose the minimal runnable snapshot scope.
+   - Copy only the source subtree needed to execute the task in isolation.
+   - Avoid repo-wide snapshots unless imports/runtime make that necessary.
+4. Create the sidecar task directory.
+   - Default: `./shinka_task/`
+   - Avoid overwriting an existing task dir without consent.
+5. Rewrite the snapshot into a stable Shinka contract.
+   - Preserve original behavior outside the evolvable region.
+   - Keep CLI behavior intact where practical.
+   - Ensure the evolvable candidate entry file is named `initial.<ext>` so `shinka-run` can detect it.
+   - Add tight `EVOLVE-BLOCK-START` / `EVOLVE-BLOCK-END` markers.
+6. Generate the evaluator path.
+   - Python: prefer exposing `run_experiment(...)` and use `run_shinka_eval`.
+   - Non-Python: use `subprocess` and write `metrics.json` plus `correct.json`.
+7. Generate `run_evo.py` and `shinka.yaml`.
+   - Ensure `init_program_path` and `language` match the candidate file.
+   - Keep the output directly compatible with `shinka-run`.
+8. Smoke test before handoff.
+   - Run `python evaluate.py --program_path <initial file> --results_dir /tmp/shinka_convert_smoke`
+   - Confirm evaluator runs without exceptions.
+   - Confirm required metrics/correctness outputs are written.
+9. Ask the user for the next step.
+   - Either run evolution manually
+   - Or use the `shinka-run` skill
+
+## Conversion Strategy by Language
+### Python
+- Preferred path: expose `run_experiment(...)` in the snapshot and evaluate via `run_shinka_eval`
+- If the existing code is CLI-only, add a thin wrapper in the snapshot rather than forcing a subprocess evaluator unless imports are too brittle
+- Keep imports relative to the copied task snapshot stable
+
+### Non-Python
+- Keep the candidate program executable in its own runtime
+- Use Python `evaluate.py` as the Shinka entrypoint
+- Write `metrics.json` and `correct.json` in `results_dir`
+
+## Required Evaluator Contract
+Metrics must include:
+- `combined_score`
+- `public`
+- `private`
+- `extra_data`
+- `text_feedback`
+
+Correctness must include:
+- `correct`
+- `error`
+
+Higher `combined_score` values indicate better performance unless the user explicitly defines an inverted metric that you transform during aggregation.
+
+## Python Conversion Template
+Prefer shaping the copied program like this:
+
+```py
+from __future__ import annotations
+
+# EVOLVE-BLOCK-START
+def optimize_me(...):
+    ...
+# EVOLVE-BLOCK-END
+
+def run_experiment(random_seed: int | None = None, **kwargs):
+    ...
+    return score, text_feedback
+```
+
+And the evaluator:
+
+```py
+from shinka.core import run_shinka_eval
+
+def main(program_path: str, results_dir: str):
+    metrics, correct, err = run_shinka_eval(
+        program_path=program_path,
+        results_dir=results_dir,
+        experiment_fn_name="run_experiment",
+        num_runs=3,
+        get_experiment_kwargs=get_kwargs,
+        aggregate_metrics_fn=aggregate_fn,
+        validate_fn=validate_fn,
+    )
+    if not correct:
+        raise RuntimeError(err or "Evaluation failed")
+```
+
+## Non-Python Conversion Template
+Use `evaluate.py` to run the candidate and write outputs:
+
+```py
+import json
+import os
+from pathlib import Path
+
+def main(program_path: str, results_dir: str):
+    os.makedirs(results_dir, exist_ok=True)
+    metrics = {
+        "combined_score": 0.0,
+        "public": {},
+        "private": {},
+        "extra_data": {},
+        "text_feedback": "",
+    }
+    correct = {"correct": False, "error": ""}
+
+    (Path(results_dir) / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    (Path(results_dir) / "correct.json").write_text(json.dumps(correct, indent=2))
+```
+
+## Bundled Assets
+- Use `scripts/run_evo.py` as the starting runner template
+- Use `scripts/shinka.yaml` as the starting config template
+
+## Notes
+- Keep evolve regions tight; do not make the whole project mutable by default
+- Preserve correctness checks outside the evolve region where possible
+- Prefer deterministic evaluation and stable seeds
+- If the converted task is ready, offer to continue with `shinka-run`

--- a/skills/shinka-convert/agents/openai.yaml
+++ b/skills/shinka-convert/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Shinka Convert"
+  short_description: "Convert existing code into a Shinka task"
+  default_prompt: "Use $shinka-convert to turn the current working directory into a Shinka-ready task directory that I can later run with `shinka-run`."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/shinka-convert/scripts/run_evo.py
+++ b/skills/shinka-convert/scripts/run_evo.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import yaml
+
+from shinka.core import EvolutionConfig, ShinkaEvolveRunner
+from shinka.database import DatabaseConfig
+from shinka.launch import LocalJobConfig
+
+TASK_SYS_MSG = """You are optimizing code converted from an existing codebase.
+Preserve the task contract and keep changes focused on the intended EVOLVE-BLOCK regions.
+Do not break evaluation outputs, result file schemas, or imports required by the task snapshot."""
+
+
+async def main(config_path: str):
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    config["evo_config"]["task_sys_msg"] = TASK_SYS_MSG
+    evo_config = EvolutionConfig(**config["evo_config"])
+    job_config = LocalJobConfig(
+        eval_program_path="evaluate.py",
+        time="05:00:00",
+    )
+    db_config = DatabaseConfig(**config["db_config"])
+
+    runner = ShinkaEvolveRunner(
+        evo_config=evo_config,
+        job_config=job_config,
+        db_config=db_config,
+        max_evaluation_jobs=config["max_evaluation_jobs"],
+        max_proposal_jobs=config["max_proposal_jobs"],
+        max_db_workers=config["max_db_workers"],
+        debug=False,
+        verbose=True,
+    )
+    await runner.run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config_path", type=str, default="shinka.yaml")
+    args = parser.parse_args()
+    asyncio.run(main(args.config_path))

--- a/skills/shinka-convert/scripts/shinka.yaml
+++ b/skills/shinka-convert/scripts/shinka.yaml
@@ -1,0 +1,48 @@
+max_evaluation_jobs: 5
+max_proposal_jobs: 5
+max_db_workers: 4
+
+db_config:
+  db_path: evolution_db.sqlite
+  num_islands: 2
+  archive_size: 40
+  elite_selection_ratio: 0.3
+  num_archive_inspirations: 4
+  num_top_k_inspirations: 2
+  migration_interval: 10
+  migration_rate: 0.1
+  island_elitism: true
+  enforce_island_separation: true
+  parent_selection_strategy: weighted
+  parent_selection_lambda: 10
+
+evo_config:
+  patch_types: [diff, full, cross]
+  patch_type_probs: [0.6, 0.3, 0.1]
+  num_generations: 100
+  max_api_costs: 0.1
+  max_patch_resamples: 3
+  max_patch_attempts: 3
+  max_novelty_attempts: 3
+  job_type: local
+  language: python
+  llm_models: ["gemini-3-flash-preview", "gpt-5-mini", "gpt-5-nano"]
+  llm_kwargs:
+    temperatures: [0, 0.5, 1.0]
+    reasoning_efforts: [min, low]
+    max_tokens: 32768
+  meta_rec_interval: 40
+  meta_llm_models: ["gpt-5-mini"]
+  meta_llm_kwargs:
+    temperatures: [0]
+    max_tokens: 16384
+  embedding_model: text-embedding-3-small
+  code_embed_sim_threshold: 0.99
+  novelty_llm_models: ["gpt-5-nano"]
+  novelty_llm_kwargs:
+    temperatures: [0]
+  init_program_path: initial.py
+  llm_dynamic_selection: ucb1
+  llm_dynamic_selection_kwargs:
+    exploration_coef: 1
+  results_dir: results/results_task

--- a/tests/test_gemini_embedding_integration.py
+++ b/tests/test_gemini_embedding_integration.py
@@ -1,0 +1,125 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from shinka.embed import client as embed_client
+from shinka.embed.embedding import AsyncEmbeddingClient, EmbeddingClient
+from shinka.embed.providers.pricing import (
+    get_model_price,
+    get_provider,
+    model_exists,
+)
+
+
+MODEL_NAME = "gemini-embedding-2-preview"
+
+
+class _FakeGoogleModels:
+    def __init__(self, total_tokens=11, count_tokens_exc=None):
+        self.total_tokens = total_tokens
+        self.count_tokens_exc = count_tokens_exc
+        self.calls = []
+
+    def count_tokens(self, *, model, contents, config=None):
+        self.calls.append(("count_tokens", model, contents))
+        if self.count_tokens_exc is not None:
+            raise self.count_tokens_exc
+        return SimpleNamespace(total_tokens=self.total_tokens)
+
+    def embed_content(self, *, model, contents, config=None):
+        self.calls.append(("embed_content", model, contents))
+        return SimpleNamespace(
+            embeddings=[SimpleNamespace(values=[0.1, 0.2, 0.3])]
+        )
+
+
+class _FakeGoogleClient:
+    def __init__(self, models):
+        self.models = models
+
+
+def test_new_gemini_embedding_model_is_registered():
+    assert model_exists(MODEL_NAME)
+    assert get_provider(MODEL_NAME) == "google"
+    assert get_model_price(MODEL_NAME) == pytest.approx(0.20 / 1_000_000)
+
+
+def test_get_client_embed_resolves_new_model_to_google(monkeypatch):
+    captured = {}
+
+    class FakeGenAIClient:
+        def __init__(self, api_key=None):
+            captured["api_key"] = api_key
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    monkeypatch.setattr(embed_client.genai, "Client", FakeGenAIClient)
+
+    client, model_name = embed_client.get_client_embed(MODEL_NAME)
+
+    assert isinstance(client, FakeGenAIClient)
+    assert model_name == MODEL_NAME
+    assert captured["api_key"] == "test-key"
+
+
+def test_sync_google_embedding_uses_token_count_for_cost(monkeypatch):
+    fake_models = _FakeGoogleModels(total_tokens=11)
+    fake_client = _FakeGoogleClient(fake_models)
+
+    monkeypatch.setattr(
+        "shinka.embed.embedding.get_client_embed",
+        lambda model_name: (fake_client, model_name),
+    )
+
+    client = EmbeddingClient(model_name=MODEL_NAME)
+
+    embedding, cost = client.get_embedding("one two")
+
+    assert embedding == [0.1, 0.2, 0.3]
+    assert cost == pytest.approx(11 * (0.20 / 1_000_000))
+    assert fake_models.calls == [
+        ("count_tokens", f"models/{MODEL_NAME}", "one two"),
+        ("embed_content", f"models/{MODEL_NAME}", "one two"),
+    ]
+
+
+def test_async_google_embedding_uses_token_count_for_cost(monkeypatch):
+    fake_models = _FakeGoogleModels(total_tokens=17)
+    fake_client = _FakeGoogleClient(fake_models)
+
+    monkeypatch.setattr(
+        "shinka.embed.embedding.get_async_client_embed",
+        lambda model_name: (fake_client, model_name),
+    )
+
+    client = AsyncEmbeddingClient(model_name=MODEL_NAME)
+
+    embedding, cost = asyncio.run(client.embed_async("one two"))
+
+    assert embedding == [0.1, 0.2, 0.3]
+    assert cost == pytest.approx(17 * (0.20 / 1_000_000))
+    assert fake_models.calls == [
+        ("count_tokens", f"models/{MODEL_NAME}", "one two"),
+        ("embed_content", f"models/{MODEL_NAME}", "one two"),
+    ]
+
+
+def test_sync_google_embedding_falls_back_when_token_count_fails(monkeypatch):
+    fake_models = _FakeGoogleModels(total_tokens=99, count_tokens_exc=RuntimeError("boom"))
+    fake_client = _FakeGoogleClient(fake_models)
+
+    monkeypatch.setattr(
+        "shinka.embed.embedding.get_client_embed",
+        lambda model_name: (fake_client, model_name),
+    )
+
+    client = EmbeddingClient(model_name=MODEL_NAME)
+
+    embedding, cost = client.get_embedding("one two")
+
+    assert embedding == [0.1, 0.2, 0.3]
+    assert cost == pytest.approx(2 * (0.20 / 1_000_000))
+    assert fake_models.calls == [
+        ("count_tokens", f"models/{MODEL_NAME}", "one two"),
+        ("embed_content", f"models/{MODEL_NAME}", "one two"),
+    ]


### PR DESCRIPTION
## What changed
- add `gemini-embedding-2-preview` pricing and use Gemini token counts for embedding cost calculation, with a whitespace fallback if `count_tokens` fails
- cover the Gemini embedding integration path with new regression tests for pricing and fallback behavior
- add a new `shinka-convert` skill with `run_evo.py`, `shinka.yaml`, and OpenAI agent template scaffolding for converting existing codebases into Shinka tasks

## Why
- Gemini embedding cost accounting was using a rough whitespace estimate only; this makes billing follow Gemini token counts when available
- the new tests lock in the pricing/support path for the Gemini embedding 2 preview model
- the convert skill fills the gap between `shinka-setup` for greenfield tasks and `shinka-run` for already-prepared task dirs

## How to test
- `pytest`
- `ruff check .`
- `mypy shinka`

## Notes
- pre-push hook ran all commands above successfully in a fresh local `.venv`
- manual repo-wide `ruff check .` from an existing shared env reported pre-existing unrelated lint findings outside this branch; the hook-installed env passed and branch-scoped lint on changed Python files also passed