### PR TITLE
feat: add shinka convert tooling and refresh launch defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *$py.class
 .DS_Store
 results/
+examples/mnist_train/
 
 # C extensions
 *.so

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 ---
 
-**Mar 2026 Update**: Refactored evolution API and unified runner `ShinkaEvolveRunner` (replacing legacy `EvolutionRunner`/`AsyncEvolutionRunner` references).
+**Mar 2026 Update**: Refactored API and unified runner `ShinkaEvolveRunner` (replacing `EvolutionRunner`).
 
-**Feb 2026 Update**: Added [agent skill files](docs/agentic_usage.md) for using `shinka` within coding agents for task generation ([`shinka-setup`](skills/shinka-setup/SKILL.md)), evolution ([`shinka-run`](skills/shinka-run/SKILL.md)), and result inspection ([`shinka-inspect`](skills/shinka-inspect/SKILL.md)).
+**Feb 2026 Update**: Added [agent skill files](docs/agentic_usage.md) for using `shinka` within coding agents for new task generation ([`shinka-setup`](skills/shinka-setup/SKILL.md)), converting your repo ([`shinka-convert`](skills/shinka-convert/SKILL.md)),  evolution ([`shinka-run`](skills/shinka-run/SKILL.md)), and result inspection ([`shinka-inspect`](skills/shinka-inspect/SKILL.md)).
 
 **Jan 2026 Update**: ShinkaEvolve was accepted at ICLR 2026 and we have [released v1.1](docs/release_notes.md) with many new features.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ from shinka.launch import LocalJobConfig
 
 # Minimal - only specify what's required
 job_conf = LocalJobConfig(eval_program_path="evaluate.py")
+# Or source a uv/venv environment per job:
+# job_conf = LocalJobConfig(
+#     eval_program_path="evaluate.py",
+#     activate_script=".venv/bin/activate",
+# )
 db_conf = DatabaseConfig()
 evo_conf = EvolutionConfig(init_program_path="initial.py")
 
@@ -108,30 +113,30 @@ Class defaults below come from `shinka/core/config.py` (`EvolutionConfig`). Hydr
 
 | Key | Default Value | Type | Explanation |
 |-----|---------------|------|-------------|
-| `task_sys_msg` | `None` | `Optional[str]` | System message describing the optimization task |
-| `patch_types` | `["diff"]` | `List[str]` | Types of patches to generate: "diff", "full", "cross" |
-| `patch_type_probs` | `[1.0]` | `List[float]` | Probabilities for each patch type |
-| `num_generations` | `10` | `int` | Number of evolution generations to run |
+| `task_sys_msg` | `"You are an expert optimization and algorithm design assistant. Improve the program while preserving correctness and immutable regions."` | `Optional[str]` | System message describing the optimization task |
+| `patch_types` | `["diff", "full", "cross"]` | `List[str]` | Types of patches to generate: "diff", "full", "cross" |
+| `patch_type_probs` | `[0.6, 0.3, 0.1]` | `List[float]` | Probabilities for each patch type |
+| `num_generations` | `50` | `int` | Number of evolution generations to run |
 | `max_proposal_jobs` | `1` | `int` | Maximum number of concurrent proposal generation jobs |
 | `max_db_workers` | `4` | `int` | Maximum number of async DB worker threads |
 | `max_patch_resamples` | `3` | `int` | Max times to resample a patch if it fails |
-| `max_patch_attempts` | `5` | `int` | Max attempts to generate a valid patch |
+| `max_patch_attempts` | `1` | `int` | Max attempts to generate a valid patch |
 | `job_type` | `"local"` | `str` | Job execution type: "local", "slurm_docker", "slurm_conda" |
 | `language` | `"python"` | `str` | Programming language for evolution |
-| `llm_models` | `["azure-gpt-4.1-mini"]` | `List[str]` | List of LLM models for code generation |
-| `llm_dynamic_selection` | `None` | `Optional[Union[str, BanditBase]]` | Dynamic model selection strategy |
-| `llm_dynamic_selection_kwargs` | `{}` | `dict` | Kwargs for dynamic selection |
-| `llm_kwargs` | `{}` | `dict` | Additional kwargs for LLM calls |
-| `meta_rec_interval` | `None` | `Optional[int]` | Interval for meta-recommendations |
+| `llm_models` | `["gpt-5-mini", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gpt-5.4"]` | `List[str]` | List of LLM models for code generation |
+| `llm_dynamic_selection` | `"ucb"` | `Optional[Union[str, BanditBase]]` | Dynamic model selection strategy |
+| `llm_dynamic_selection_kwargs` | `{"cost_aware_coef": 0.5}` | `dict` | Kwargs for dynamic selection |
+| `llm_kwargs` | `{"temperatures": [0.0, 0.5, 1.0], "max_tokens": 16384}` | `dict` | Additional kwargs for LLM calls |
+| `meta_rec_interval` | `10` | `Optional[int]` | Interval for meta-recommendations |
 | `meta_llm_models` | `None` | `Optional[List[str]]` | LLM models for meta-recommendations |
 | `meta_llm_kwargs` | `{}` | `dict` | Kwargs for meta-recommendation LLMs |
 | `meta_max_recommendations` | `5` | `int` | Max number of meta-recommendations |
 | `sample_single_meta_rec` | `True` | `bool` | Sample a single recommendation from meta output when enabled |
-| `embedding_model` | `None` | `Optional[str]` | Model for code embeddings |
+| `embedding_model` | `"text-embedding-3-small"` | `Optional[str]` | Model for code embeddings |
 | `init_program_path` | `"initial.py"` | `Optional[str]` | Path to initial program to evolve |
 | `results_dir` | `None` | `Optional[str]` | Directory to save results (auto-generated if None) |
 | `max_novelty_attempts` | `3` | `int` | Max attempts for novelty generation |
-| `code_embed_sim_threshold` | `1.0` | `float` | Similarity threshold for code embeddings |
+| `code_embed_sim_threshold` | `0.99` | `float` | Similarity threshold for code embeddings |
 | `novelty_llm_models` | `None` | `Optional[List[str]]` | LLM models for novelty judgment |
 | `novelty_llm_kwargs` | `{}` | `dict` | Kwargs for novelty LLMs |
 | `use_text_feedback` | `False` | `bool` | Whether to use text feedback in evolution |
@@ -159,13 +164,13 @@ Class defaults below come from `shinka/database/dbase.py` (`DatabaseConfig`). Hy
 | Key | Default Value | Type | Explanation |
 |-----|---------------|------|-------------|
 | `db_path` | `None` | `Optional[str]` | Database file path (auto-generated if None) |
-| `num_islands` | `4` | `int` | Number of evolution islands for diversity |
-| `archive_size` | `100` | `int` | Global archive size cap |
+| `num_islands` | `2` | `int` | Number of evolution islands for diversity |
+| `archive_size` | `40` | `int` | Global archive size cap |
 | `elite_selection_ratio` | `0.3` | `float` | Proportion of elite programs for inspiration |
-| `num_archive_inspirations` | `5` | `int` | Number of archive programs to use as inspiration |
-| `num_top_k_inspirations` | `2` | `int` | Number of top-k programs for inspiration |
+| `num_archive_inspirations` | `1` | `int` | Number of archive programs to use as inspiration |
+| `num_top_k_inspirations` | `1` | `int` | Number of top-k programs for inspiration |
 | `migration_interval` | `10` | `int` | Generations between island migrations |
-| `migration_rate` | `0.1` | `float` | Proportion of island population to migrate |
+| `migration_rate` | `0.0` | `float` | Proportion of island population to migrate |
 | `island_elitism` | `True` | `bool` | Keep best programs on their original islands |
 | `enforce_island_separation` | `True` | `bool` | Enforce full separation between islands |
 | `island_selection_strategy` | `"uniform"` | `str` | Island sampler (`"uniform"`, `"equal"`, `"proportional"`, `"weighted"`) |
@@ -173,7 +178,7 @@ Class defaults below come from `shinka/database/dbase.py` (`DatabaseConfig`). Hy
 | `stagnation_threshold` | `100` | `int` | Generations without improvement before spawning a new island |
 | `island_spawn_strategy` | `"initial"` | `str` | New-island seed strategy (`"initial"`, `"best"`, `"archive_random"`) |
 | `island_spawn_subtree_size` | `1` | `int` | Number of programs copied when spawning an island |
-| `parent_selection_strategy` | `"power_law"` | `str` | Parent selection: "weighted", "power_law", "beam_search" |
+| `parent_selection_strategy` | `"weighted"` | `str` | Parent selection: "weighted", "power_law", "beam_search" |
 | `exploitation_alpha` | `1.0` | `float` | Power-law exponent (0=uniform, 1=power-law) |
 | `exploitation_ratio` | `0.2` | `float` | Chance to pick parent from archive |
 | `parent_selection_lambda` | `10.0` | `float` | Sharpness of sigmoid for weighted selection |
@@ -193,6 +198,7 @@ Class defaults below come from `shinka/database/dbase.py` (`DatabaseConfig`). Hy
 | `extra_cmd_args` | `{}` | `Dict[str, Any]` | Additional command line arguments |
 | `time` | `None` | `Optional[str]` | Time limit for job execution |
 | `conda_env` | `None` | `Optional[str]` | Conda environment to run jobs in |
+| `activate_script` | `None` | `Optional[str]` | Sourceable env script path, e.g. `.venv/bin/activate` |
 
 **SlurmDockerJobConfig** (for SLURM with Docker):
 | Key | Default Value | Type | Explanation |
@@ -208,18 +214,21 @@ Class defaults below come from `shinka/database/dbase.py` (`DatabaseConfig`). Hy
 | `gpus` | `1` | `int` | Number of GPUs to request |
 | `mem` | `"8G"` | `Optional[str]` | Memory to request |
 
-**SlurmCondaJobConfig** (for SLURM with Conda):
+**SlurmCondaJobConfig / SlurmEnvJobConfig** (for SLURM with sourced or Conda environments):
 | Key | Default Value | Type | Explanation |
 |-----|---------------|------|-------------|
 | `eval_program_path` | `"evaluate.py"` | `Optional[str]` | Path to evaluation script |
 | `extra_cmd_args` | `{}` | `Dict[str, Any]` | Additional command line arguments |
 | `conda_env` | `""` | `str` | Conda environment name |
+| `activate_script` | `None` | `Optional[str]` | Sourceable env script path, e.g. `.venv/bin/activate` |
 | `modules` | `[]` | `Optional[List[str]]` | Environment modules to load |
 | `partition` | `"gpu"` | `str` | SLURM partition to use |
 | `time` | `"01:00:00"` | `str` | Job time limit |
 | `cpus` | `1` | `int` | Number of CPUs to request |
 | `gpus` | `1` | `int` | Number of GPUs to request |
 | `mem` | `"8G"` | `Optional[str]` | Memory to request |
+
+`conda_env` and `activate_script` are mutually exclusive.
 
 </details>
 
@@ -310,8 +319,8 @@ def solve_problem(params):
 `shinka` Launcher utilizes [Hydra](https://hydra.cc/) to configure and launch evolutionary experiments effortlessly. It supports concise configuration via Hydra's powerful override syntax, making it easy to manage and iterate scientific explorations.
 
 ```bash
-# Run with pre-configured variant
-shinka_launch variant=circle_packing_example
+# Run with the shared default baseline
+shinka_launch
 
 # Run with custom parameters
 shinka_launch \
@@ -344,9 +353,10 @@ shinka_run \
     --results_dir results/circle_agent_custom \
     --num_generations 50 \
     --max-evaluation-jobs 6 \
-    --set db.num_islands=3 \
+    --set db.num_islands=2 \
     --set job.time=00:10:00 \
-    --set evo.llm_models='["gpt-5-mini","gpt-5-nano"]'
+    --set job.activate_script=.venv/bin/activate \
+    --set evo.llm_models='["gpt-5-mini","gemini-3-flash-preview"]'
 
 # Load optional YAML config (relative to --task-dir), then override via --set
 shinka_run \
@@ -354,7 +364,7 @@ shinka_run \
     --config-fname shinka_small.yaml \
     --results_dir results/circle_agent_from_yaml \
     --num_generations 50 \
-    --set db.num_islands=3
+    --set db.num_islands=2
 ```
 
 `--task-dir` must contain `evaluate.py` and `initial.<ext>`.  
@@ -375,7 +385,7 @@ Launch the WebUI alongside your evolution experiment:
 
 ```bash
 # Start your evolution experiment
-shinka_launch variant=circle_packing_example
+shinka_launch
 
 # In another terminal, launch the WebUI
 shinka_visualize --port 8888 --open

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,10 +1,10 @@
 defaults:
   - _self_
-  - database@_global_: island_small
-  - evolution@_global_: small_budget
+  - database@_global_: island_medium
+  - evolution@_global_: medium_budget
   - task@_global_: circle_packing
   - cluster@_global_: local
-  - variant@_global_: circle_packing_example
+  - variant@_global_: default
 
 verbose: false
 results_dir: results

--- a/configs/database/island_medium.yaml
+++ b/configs/database/island_medium.yaml
@@ -4,12 +4,12 @@ db_config:
   db_path: "evolution_db.sqlite"
   num_islands: 2
   archive_size: 40
-  exploitation_ratio: 0.2
   elite_selection_ratio: 0.3
-  num_archive_inspirations: 4
-  num_top_k_inspirations: 2
+  num_archive_inspirations: 1
+  num_top_k_inspirations: 1
   migration_interval: 10
   migration_rate: 0.0
   island_elitism: true
+  enforce_island_separation: true
   parent_selection_strategy: "weighted"
   parent_selection_lambda: 10.0

--- a/configs/evolution/medium_budget.yaml
+++ b/configs/evolution/medium_budget.yaml
@@ -1,4 +1,4 @@
-max_evaluation_jobs: 10
+max_evaluation_jobs: 2
 
 evo_config:
   _target_: shinka.core.EvolutionConfig
@@ -10,19 +10,19 @@ evo_config:
     - 0.6
     - 0.3
     - 0.1
-  num_generations: 100
+  num_generations: 50
   max_proposal_jobs: 1
   max_db_workers: 4
   max_patch_resamples: 3
-  max_patch_attempts: 3
+  max_patch_attempts: 1
   llm_models:
-    - "gemini-2.5-pro"
-    - "gemini-2.5-flash"
-    - "gpt-4.1-mini"
-    - "gpt-4.1-nano"
-    - "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    - "o4-mini"
+    - "gpt-5-mini"
+    - "gemini-3-flash-preview"
+    - "gemini-3.1-pro-preview"
+    - "gpt-5.4"
   llm_dynamic_selection: ucb
+  llm_dynamic_selection_kwargs:
+    cost_aware_coef: 0.5
   llm_kwargs:
     temperatures:
       - 0.0
@@ -30,11 +30,6 @@ evo_config:
       - 1.0
     max_tokens: 16384
   meta_rec_interval: 10
-  meta_llm_models:
-    - "gpt-4.1"
-  meta_llm_kwargs:
-    temperatures:
-      - 0.0
   embedding_model: "text-embedding-3-small"
+  code_embed_sim_threshold: 0.99
   results_dir: ${output_dir}
-  

--- a/docs/agentic_usage.md
+++ b/docs/agentic_usage.md
@@ -129,8 +129,8 @@ shinka_run \
   --results_dir results/my_task_agent \
   --num_generations 20 \
   --set evo.max_api_costs=0.5 \
-  --set evo.llm_models='["gpt-5-mini","gpt-5-nano"]' \
-  --set db.num_islands=3 \
+  --set evo.llm_models='["gpt-5-mini","gemini-3-flash-preview"]' \
+  --set db.num_islands=2 \
   --set db.parent_selection_strategy=weighted
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,30 +21,30 @@ Configuration values are resolved in this order (later wins):
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `task_sys_msg` | `Optional[str]` | `None` | Task-specific system prompt. |
-| `patch_types` | `List[str]` | `['diff']` | Patch formats; supports `diff`, `full`, `cross`. |
-| `patch_type_probs` | `List[float]` | `[1.0]` | Sampling probabilities for `patch_types` (must sum to 1). |
-| `num_generations` | `int` | `10` | Target number of generations. |
+| `task_sys_msg` | `Optional[str]` | `"You are an expert optimization and algorithm design assistant. Improve the program while preserving correctness and immutable regions."` | Task-specific system prompt. |
+| `patch_types` | `List[str]` | `['diff', 'full', 'cross']` | Patch formats; supports `diff`, `full`, `cross`. |
+| `patch_type_probs` | `List[float]` | `[0.6, 0.3, 0.1]` | Sampling probabilities for `patch_types` (must sum to 1). |
+| `num_generations` | `int` | `50` | Target number of generations. |
 | `max_proposal_jobs` | `int` | `1` | Max concurrent proposal-generation tasks. |
 | `max_db_workers` | `int` | `4` | Max async DB worker threads. |
 | `max_patch_resamples` | `int` | `3` | Max patch resample loops per novelty attempt. |
-| `max_patch_attempts` | `int` | `5` | Max attempts to produce a syntactically valid patch. |
+| `max_patch_attempts` | `int` | `1` | Max attempts to produce a syntactically valid patch. |
 | `job_type` | `str` | `'local'` | Job backend: `local`, `slurm_docker`, `slurm_conda`. |
 | `language` | `str` | `'python'` | Language tag for prompts + file handling. |
-| `llm_models` | `List[str]` | `['azure-gpt-4.1-mini']` | Mutation model pool. |
-| `llm_dynamic_selection` | `Optional[Union[str, BanditBase]]` | `None` | Dynamic model selection (`fixed`, `ucb`, `ucb1`, `thompson`, or bandit object). |
-| `llm_dynamic_selection_kwargs` | `dict` | `{}` | kwargs forwarded to selected bandit. |
-| `llm_kwargs` | `dict` | `{}` | kwargs forwarded to LLM calls. |
-| `meta_rec_interval` | `Optional[int]` | `None` | Generation interval for meta recommendations. |
+| `llm_models` | `List[str]` | `['gpt-5-mini', 'gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gpt-5.4']` | Mutation model pool. |
+| `llm_dynamic_selection` | `Optional[Union[str, BanditBase]]` | `'ucb'` | Dynamic model selection (`fixed`, `ucb`, `ucb1`, `thompson`, or bandit object). |
+| `llm_dynamic_selection_kwargs` | `dict` | `{'cost_aware_coef': 0.5}` | kwargs forwarded to selected bandit. |
+| `llm_kwargs` | `dict` | `{'temperatures': [0.0, 0.5, 1.0], 'max_tokens': 16384}` | kwargs forwarded to LLM calls. |
+| `meta_rec_interval` | `Optional[int]` | `10` | Generation interval for meta recommendations. |
 | `meta_llm_models` | `Optional[List[str]]` | `None` | Model pool for meta-recommendations. |
 | `meta_llm_kwargs` | `dict` | `{}` | kwargs for meta-recommendation LLM calls. |
 | `meta_max_recommendations` | `int` | `5` | Max recommendations produced per meta step. |
 | `sample_single_meta_rec` | `bool` | `True` | Whether to sample one recommendation when multiple exist. |
-| `embedding_model` | `Optional[str]` | `None` | Embedding model for code similarity. |
+| `embedding_model` | `Optional[str]` | `'text-embedding-3-small'` | Embedding model for code similarity. |
 | `init_program_path` | `Optional[str]` | `'initial.py'` | Initial program path. |
 | `results_dir` | `Optional[str]` | `None` | Results directory; auto-assigned when `None`. |
 | `max_novelty_attempts` | `int` | `3` | Max novelty loops per generation. |
-| `code_embed_sim_threshold` | `float` | `1.0` | Similarity threshold used by novelty checks. |
+| `code_embed_sim_threshold` | `float` | `0.99` | Similarity threshold used by novelty checks. |
 | `novelty_llm_models` | `Optional[List[str]]` | `None` | Optional novelty-judge model pool. |
 | `novelty_llm_kwargs` | `dict` | `{}` | kwargs for novelty-judge LLM calls. |
 | `use_text_feedback` | `bool` | `False` | Include text feedback in mutation prompts. |
@@ -67,13 +67,13 @@ Configuration values are resolved in this order (later wins):
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `db_path` | `Optional[str]` | `None` | SQLite DB path. |
-| `num_islands` | `int` | `4` | Number of islands. |
-| `archive_size` | `int` | `100` | Global archive size cap. |
+| `num_islands` | `int` | `2` | Number of islands. |
+| `archive_size` | `int` | `40` | Global archive size cap. |
 | `elite_selection_ratio` | `float` | `0.3` | Fraction of elite inspirations. |
-| `num_archive_inspirations` | `int` | `5` | Number of archive inspirations sampled. |
-| `num_top_k_inspirations` | `int` | `2` | Number of top-k inspirations sampled. |
+| `num_archive_inspirations` | `int` | `1` | Number of archive inspirations sampled. |
+| `num_top_k_inspirations` | `int` | `1` | Number of top-k inspirations sampled. |
 | `migration_interval` | `int` | `10` | Generations between migration events. |
-| `migration_rate` | `float` | `0.1` | Fraction of programs migrated at migration events. |
+| `migration_rate` | `float` | `0.0` | Fraction of programs migrated at migration events. |
 | `island_elitism` | `bool` | `True` | Preserve best programs on islands. |
 | `enforce_island_separation` | `bool` | `True` | Restrict inspiration sampling to source island. |
 | `island_selection_strategy` | `str` | `'uniform'` | Island sampler: `uniform`, `equal`, `proportional`, `weighted`. |
@@ -81,7 +81,7 @@ Configuration values are resolved in this order (later wins):
 | `stagnation_threshold` | `int` | `100` | No-improvement generations before spawn. |
 | `island_spawn_strategy` | `str` | `'initial'` | Spawn seed: `initial`, `best`, `archive_random`. |
 | `island_spawn_subtree_size` | `int` | `1` | Number of copied programs when spawning. |
-| `parent_selection_strategy` | `str` | `'power_law'` | Parent selector: `weighted`, `power_law`, `beam_search`. |
+| `parent_selection_strategy` | `str` | `'weighted'` | Parent selector: `weighted`, `power_law`, `beam_search`. |
 | `exploitation_alpha` | `float` | `1.0` | Power-law strength for parent selection. |
 | `exploitation_ratio` | `float` | `0.2` | Probability of selecting from archive. |
 | `parent_selection_lambda` | `float` | `10.0` | Sigmoid sharpness for weighted parent selection. |
@@ -104,6 +104,7 @@ Configuration values are resolved in this order (later wins):
 |-----------|------|---------|-------------|
 | `time` | `Optional[str]` | `None` | Optional timeout (`HH:MM:SS`). |
 | `conda_env` | `Optional[str]` | `None` | Optional conda env for local execution. |
+| `activate_script` | `Optional[str]` | `None` | Optional sourceable env script, e.g. `.venv/bin/activate`. |
 
 `SlurmDockerJobConfig` adds:
 
@@ -118,17 +119,20 @@ Configuration values are resolved in this order (later wins):
 | `gpus` | `int` | `1` | GPU request. |
 | `mem` | `Optional[str]` | `'8G'` | Memory request. |
 
-`SlurmCondaJobConfig` adds:
+`SlurmCondaJobConfig` / `SlurmEnvJobConfig` add:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `conda_env` | `str` | `''` | Conda environment name. |
+| `activate_script` | `Optional[str]` | `None` | Sourceable env script path, e.g. `.venv/bin/activate`. |
 | `modules` | `Optional[List[str]]` | `None` | Modules to load (normalized to `[]` at runtime). |
 | `partition` | `str` | `'gpu'` | SLURM partition. |
 | `time` | `str` | `'01:00:00'` | SLURM time limit. |
 | `cpus` | `int` | `1` | CPU request. |
 | `gpus` | `int` | `1` | GPU request. |
 | `mem` | `Optional[str]` | `'8G'` | Memory request. |
+
+`conda_env` and `activate_script` are mutually exclusive.
 
 ## Hydra Presets In `configs/`
 
@@ -157,32 +161,30 @@ evo_config:
 #### `configs/evolution/medium_budget.yaml`
 
 ```yaml
-max_evaluation_jobs: 10
+max_evaluation_jobs: 2
 
 evo_config:
   patch_types: ["diff", "full", "cross"]
   patch_type_probs: [0.6, 0.3, 0.1]
-  num_generations: 100
+  num_generations: 50
   max_proposal_jobs: 1
   max_db_workers: 4
   max_patch_resamples: 3
-  max_patch_attempts: 3
+  max_patch_attempts: 1
   llm_models:
-    - "gemini-2.5-pro"
-    - "gemini-2.5-flash"
-    - "gpt-4.1-mini"
-    - "gpt-4.1-nano"
-    - "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    - "o4-mini"
+    - "gpt-5-mini"
+    - "gemini-3-flash-preview"
+    - "gemini-3.1-pro-preview"
+    - "gpt-5.4"
   llm_dynamic_selection: ucb
+  llm_dynamic_selection_kwargs:
+    cost_aware_coef: 0.5
   llm_kwargs:
     temperatures: [0.0, 0.5, 1.0]
     max_tokens: 16384
   meta_rec_interval: 10
-  meta_llm_models: ["gpt-4.1"]
-  meta_llm_kwargs:
-    temperatures: [0.0]
   embedding_model: "text-embedding-3-small"
+  code_embed_sim_threshold: 0.99
   results_dir: ${output_dir}
 ```
 
@@ -244,13 +246,13 @@ db_config:
   db_path: "evolution_db.sqlite"
   num_islands: 2
   archive_size: 40
-  exploitation_ratio: 0.2
   elite_selection_ratio: 0.3
-  num_archive_inspirations: 4
-  num_top_k_inspirations: 2
+  num_archive_inspirations: 1
+  num_top_k_inspirations: 1
   migration_interval: 10
   migration_rate: 0.0
   island_elitism: true
+  enforce_island_separation: true
   parent_selection_strategy: "weighted"
   parent_selection_lambda: 10.0
 ```
@@ -302,21 +304,16 @@ Both define task-specific `evaluate_function`, `distributed_job_config`, and `ev
 ```yaml
 defaults:
   - _self_
-  - database@_global_: island_small
-  - evolution@_global_: small_budget
+  - database@_global_: island_medium
+  - evolution@_global_: medium_budget
   - task@_global_: circle_packing
   - cluster@_global_: local
-  - variant@_global_: circle_packing_example
+  - variant@_global_: default
 ```
 
-Then `variant=circle_packing_example` overrides to:
-
-- `database=island_large`
-- `evolution=large_budget`
-- `task=circle_packing`
-- `cluster=local`
-
-So default `shinka_launch` behavior is effectively the `circle_packing_example` preset stack unless you override.
+So default `shinka_launch` behavior is a neutral medium shared baseline on the
+`circle_packing` task with `variant=default`. Example-heavy stacks remain
+available via explicit variants such as `variant=circle_packing_example`.
 
 ## `shinka_run` Config File Schema
 
@@ -382,7 +379,7 @@ shinka_run \
   --results_dir results/circle_agent \
   --num_generations 40 \
   --max-evaluation-jobs 6 \
-  --set evo.llm_models='["gpt-5-mini","gpt-5-nano"]' \
+  --set evo.llm_models='["gpt-5-mini","gemini-3-flash-preview"]' \
   --set evo.llm_dynamic_selection=ucb \
-  --set db.num_islands=3
+  --set db.num_islands=2
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -137,8 +137,8 @@ uv pip sync pyproject.toml
 The easiest way to get started is using the Hydra-based CLI launcher:
 
 ```bash
-# Run circle packing example with default settings
-shinka_launch variant=circle_packing_example
+# Run circle packing with the shared default baseline
+shinka_launch
 
 # Run with custom parameters
 shinka_launch \
@@ -189,21 +189,21 @@ from shinka.launch import LocalJobConfig
 # Configure the job execution environment
 job_config = LocalJobConfig(
     eval_program_path="examples/circle_packing/evaluate.py",
-    conda_env="my_special_env",  # Optional: run in specific conda environment
+    activate_script=".venv/bin/activate",  # Optional: source uv/venv env for each job
 )
 
 # Configure the evolution database
 db_config = DatabaseConfig(
-    archive_size=20,
-    num_archive_inspirations=4,
+    archive_size=40,
+    num_archive_inspirations=1,
     num_islands=2,
     migration_interval=10,
 )
 
 # Configure the evolution parameters
 evo_config = EvolutionConfig(
-    num_generations=10,
-    llm_models=["azure-gpt-4.1"],
+    num_generations=50,
+    llm_models=["gpt-5-mini", "gemini-3-flash-preview"],
     init_program_path="examples/circle_packing/initial.py",
     language="python",
     task_sys_msg="You are optimizing circle packing...",
@@ -250,7 +250,7 @@ examples/circle_packing/
 
 ```bash
 # Using CLI launcher (recommended)
-shinka_launch variant=circle_packing_example
+shinka_launch
 
 # Or with custom settings
 shinka_launch \
@@ -394,7 +394,7 @@ When you specify an existing `results_dir` that contains a database, Shinka will
 ```bash
 # Resume an existing run and extend to 50 generations
 shinka_launch \
-    variant=circle_packing_example \
+    variant=default \
     evo_config.results_dir=results_20250101_120000 \
     evo_config.num_generations=50
 
@@ -458,7 +458,17 @@ job_config = LocalJobConfig(
 # Uses the currently active Python environment
 ```
 
-#### Option 2: Use Specific Conda Environment
+#### Option 2: Source a Specific Python Environment Script
+```python
+job_config = LocalJobConfig(
+    eval_program_path="evaluate.py",
+    activate_script=".venv/bin/activate"  # Runs after `source .venv/bin/activate`
+)
+```
+
+Use this for uv/venv-style workflows where the job should bootstrap from a sourceable activation script.
+
+#### Option 3: Use Specific Conda Environment
 ```python
 job_config = LocalJobConfig(
     eval_program_path="evaluate.py",
@@ -470,6 +480,7 @@ This is particularly useful when:
 - Different experiments require different dependency versions
 - You want to isolate evaluation environments from your main development environment
 - Testing compatibility across multiple Python/package versions
+- `conda_env` and `activate_script` should not be set together
 
 ### Creating Custom Tasks
 

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -31,7 +31,7 @@ The WebUI serves as a dashboard for monitoring Shinka evolution experiments, pro
 
 ```bash
 # Start your evolution experiment
-shinka_launch variant=circle_packing_example
+shinka_launch
 
 # In another terminal, launch the WebUI
 shinka_visualize --port 8888 --open

--- a/shinka/cli/run.py
+++ b/shinka/cli/run.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import fields
+from dataclasses import asdict, fields
 from pathlib import Path
 from typing import Any, Dict, Optional, Union, get_args, get_origin
 
@@ -13,11 +13,6 @@ from shinka.core import ShinkaEvolveRunner, EvolutionConfig
 from shinka.database import DatabaseConfig
 from shinka.launch import LocalJobConfig
 from shinka.cli.run_config import load_optional_yaml_config
-
-DEFAULT_TASK_SYS_MSG = (
-    "You are an expert optimization and algorithm design assistant. "
-    "Improve the program while preserving correctness and immutable regions."
-)
 
 SUPPORTED_INITIAL_EXTENSIONS: dict[str, str] = {
     ".py": "python",
@@ -66,20 +61,21 @@ def _build_parser() -> argparse.ArgumentParser:
         "  bool values: true,false,1,0,yes,no (case-insensitive)\n\n"
         "Common evo settings via --set:\n"
         "  budget: --set evo.max_api_costs=0.5\n"
-        '  models: --set evo.llm_models=\'["gpt-5-mini","gpt-5-nano"]\'\n'
+        "  models: --set "
+        "evo.llm_models='[\"gpt-5-mini\",\"gemini-3-flash-preview\"]'\n"
         '  patching: --set evo.patch_types=\'["diff","full"]\' '
         "--set evo.patch_type_probs='[0.7,0.3]'\n"
-        '  llm kwargs: --set evo.llm_kwargs=\'{"temperatures":[0.2,0.8],'
-        '"reasoning_efforts":["medium"],"max_tokens":16384}\'\n'
+        '  llm kwargs: --set evo.llm_kwargs=\'{"temperatures":[0.0,0.5,1.0],'
+        '"max_tokens":16384}\'\n'
         "  quality controls: --set evo.max_patch_resamples=3 "
-        "--set evo.max_patch_attempts=3 --set evo.max_novelty_attempts=3\n"
+        "--set evo.max_patch_attempts=1 --set evo.max_novelty_attempts=3\n"
         "  embeddings: --set evo.embedding_model=text-embedding-3-small "
-        "--set evo.code_embed_sim_threshold=0.995\n\n"
+        "--set evo.code_embed_sim_threshold=0.99\n\n"
         "Common db settings via --set:\n"
-        "  islands: --set db.num_islands=3\n"
+        "  islands: --set db.num_islands=2\n"
         "  parent selection: --set db.parent_selection_strategy=weighted\n"
-        "  archive: --set db.archive_size=60 --set db.num_archive_inspirations=5\n"
-        "  migration: --set db.migration_interval=10 --set db.migration_rate=0.1\n\n"
+        "  archive: --set db.archive_size=40 --set db.num_archive_inspirations=1\n"
+        "  migration: --set db.migration_interval=10 --set db.migration_rate=0.0\n\n"
         "Examples:\n"
         "  Minimal:\n"
         "    shinka_run --task-dir examples/circle_packing "
@@ -87,9 +83,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "  With overrides:\n"
         "    shinka_run --task-dir examples/circle_packing "
         "--results_dir results/circle_custom --num_generations 50 "
-        "--set db.num_islands=3 --set db.parent_selection_strategy=weighted "
+        "--set db.num_islands=2 --set db.parent_selection_strategy=weighted "
         "--set job.time=00:10:00 "
-        '--set evo.llm_models=\'["gpt-5-mini","gpt-5-nano"]\'\n\n'
+        "--set job.activate_script=.venv/bin/activate "
+        "--set "
+        "evo.llm_models='[\"gpt-5-mini\",\"gemini-3-flash-preview\"]'\n\n"
         "Failure behavior:\n"
         "  - unknown namespace/field: non-zero exit\n"
         "  - invalid value type: non-zero exit\n"
@@ -353,37 +351,23 @@ def _build_default_evo_values(
     results_dir: Path,
     num_generations: int,
 ) -> Dict[str, Any]:
-    return {
-        "task_sys_msg": DEFAULT_TASK_SYS_MSG,
-        "patch_types": ["diff", "full", "cross"],
-        "patch_type_probs": [0.6, 0.3, 0.1],
-        "num_generations": num_generations,
-        "max_proposal_jobs": 1,
-        "max_db_workers": 4,
-        "max_patch_resamples": 3,
-        "max_patch_attempts": 3,
-        "job_type": "local",
-        "language": language,
-        "llm_models": ["gpt-5-mini"],
-        "llm_kwargs": {
-            "temperatures": [0.2, 0.6, 1.0],
-            "reasoning_efforts": ["medium"],
-            "max_tokens": 16384,
-        },
-        "embedding_model": "text-embedding-3-small",
-        "code_embed_sim_threshold": 0.995,
-        "init_program_path": str(init_program_path),
-        "results_dir": str(results_dir),
-        "max_novelty_attempts": 3,
-    }
+    return asdict(
+        EvolutionConfig(
+            num_generations=num_generations,
+            job_type="local",
+            language=language,
+            init_program_path=str(init_program_path),
+            results_dir=str(results_dir),
+        )
+    )
 
 
 def _build_default_db_values() -> Dict[str, Any]:
-    return {}
+    return asdict(DatabaseConfig())
 
 
 def _build_default_job_values(evaluate_path: Path) -> Dict[str, Any]:
-    return {"eval_program_path": str(evaluate_path)}
+    return asdict(LocalJobConfig(eval_program_path=str(evaluate_path)))
 
 
 def _validate_task_dir(task_dir: Path) -> tuple[Path, Path]:

--- a/shinka/core/config.py
+++ b/shinka/core/config.py
@@ -2,36 +2,48 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 from shinka.llm import BanditBase
+from shinka.defaults import (
+    DEFAULT_TASK_SYS_MSG,
+    default_llm_dynamic_selection_kwargs,
+    default_llm_kwargs,
+    default_llm_models,
+    default_patch_type_probs,
+    default_patch_types,
+    default_prompt_patch_type_probs,
+    default_prompt_patch_types,
+)
 
 FOLDER_PREFIX = "gen"
 
 
 @dataclass
 class EvolutionConfig:
-    task_sys_msg: Optional[str] = None
-    patch_types: List[str] = field(default_factory=lambda: ["diff"])
-    patch_type_probs: List[float] = field(default_factory=lambda: [1.0])
-    num_generations: int = 10
+    task_sys_msg: Optional[str] = DEFAULT_TASK_SYS_MSG
+    patch_types: List[str] = field(default_factory=default_patch_types)
+    patch_type_probs: List[float] = field(default_factory=default_patch_type_probs)
+    num_generations: int = 50
     max_proposal_jobs: int = 1
     max_db_workers: int = 4
     max_patch_resamples: int = 3
-    max_patch_attempts: int = 5
+    max_patch_attempts: int = 1
     job_type: str = "local"
     language: str = "python"
-    llm_models: List[str] = field(default_factory=lambda: ["azure-gpt-4.1-mini"])
-    llm_dynamic_selection: Optional[Union[str, BanditBase]] = None
-    llm_dynamic_selection_kwargs: dict = field(default_factory=lambda: {})
-    llm_kwargs: dict = field(default_factory=lambda: {})
-    meta_rec_interval: Optional[int] = None
+    llm_models: List[str] = field(default_factory=default_llm_models)
+    llm_dynamic_selection: Optional[Union[str, BanditBase]] = "ucb"
+    llm_dynamic_selection_kwargs: dict = field(
+        default_factory=default_llm_dynamic_selection_kwargs
+    )
+    llm_kwargs: dict = field(default_factory=default_llm_kwargs)
+    meta_rec_interval: Optional[int] = 10
     meta_llm_models: Optional[List[str]] = None
     meta_llm_kwargs: dict = field(default_factory=lambda: {})
     meta_max_recommendations: int = 5
     sample_single_meta_rec: bool = True
-    embedding_model: Optional[str] = None
+    embedding_model: Optional[str] = "text-embedding-3-small"
     init_program_path: Optional[str] = "initial.py"
     results_dir: Optional[str] = None
     max_novelty_attempts: int = 3
-    code_embed_sim_threshold: float = 1.0
+    code_embed_sim_threshold: float = 0.99
     novelty_llm_models: Optional[List[str]] = None
     novelty_llm_kwargs: dict = field(default_factory=lambda: {})
     use_text_feedback: bool = False
@@ -40,8 +52,10 @@ class EvolutionConfig:
 
     # Meta-prompt evolution settings.
     evolve_prompts: bool = False
-    prompt_patch_types: List[str] = field(default_factory=lambda: ["diff", "full"])
-    prompt_patch_type_probs: List[float] = field(default_factory=lambda: [0.7, 0.3])
+    prompt_patch_types: List[str] = field(default_factory=default_prompt_patch_types)
+    prompt_patch_type_probs: List[float] = field(
+        default_factory=default_prompt_patch_type_probs
+    )
     prompt_evolution_interval: Optional[int] = None
     prompt_archive_size: int = 10
     prompt_llm_models: Optional[List[str]] = None

--- a/shinka/core/sampler.py
+++ b/shinka/core/sampler.py
@@ -19,6 +19,7 @@ from shinka.prompts import (
     format_error_output_section,
 )
 from shinka.prompts.prompts_init import INIT_SYSTEM_MSG, INIT_USER_MSG
+from shinka.defaults import default_patch_type_probs, default_patch_types
 import logging
 
 logger = logging.getLogger(__name__)
@@ -37,9 +38,9 @@ class PromptSampler:
         ] = "ascending",
     ):
         if patch_types is None:
-            patch_types = ["diff"]
+            patch_types = default_patch_types()
         if patch_type_probs is None:
-            patch_type_probs = [1.0]
+            patch_type_probs = default_patch_type_probs()
 
         self.task_sys_msg = task_sys_msg
         self.language = language

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -15,6 +15,7 @@ from .islands import CombinedIslandManager
 from .island_sampler import create_island_sampler, IslandSampler
 from .display import DatabaseDisplay
 from shinka.embed import EmbeddingClient
+from shinka.defaults import default_archive_criteria
 
 logger = logging.getLogger(__name__)
 
@@ -51,17 +52,17 @@ def clean_nan_values(obj: Any) -> Any:
 @dataclass
 class DatabaseConfig:
     db_path: Optional[str] = None  # Path to SQLite database file
-    num_islands: int = 4
-    archive_size: int = 100
+    num_islands: int = 2
+    archive_size: int = 40
 
     # Inspiration parameters
     elite_selection_ratio: float = 0.3  # Prop of elites inspirations
-    num_archive_inspirations: int = 5  # No. inspiration programs
-    num_top_k_inspirations: int = 2  # No. top-k inspiration programs
+    num_archive_inspirations: int = 1  # No. inspiration programs
+    num_top_k_inspirations: int = 1  # No. top-k inspiration programs
 
     # Island model/migration parameters
     migration_interval: int = 10  # Migrate every N generations
-    migration_rate: float = 0.1  # Prop. of island pop. to migrate
+    migration_rate: float = 0.0  # Prop. of island pop. to migrate
     island_elitism: bool = True  # Keep best prog on their islands
     enforce_island_separation: bool = (
         True  # Enforce full island separation for inspirations
@@ -78,7 +79,7 @@ class DatabaseConfig:
 
     # Parent selection parameters
     parent_selection_strategy: str = (
-        "power_law"  # "weighted"/"power_law" / "beam_search"
+        "weighted"  # "weighted"/"power_law" / "beam_search"
     )
 
     # Power-law parent selection parameters
@@ -97,11 +98,7 @@ class DatabaseConfig:
     #   Positive weight = higher is better (e.g., combined_score)
     #   Negative weight = lower is better (e.g., loc, complexity)
     # Weights represent relative importance after rank normalization
-    archive_criteria: Dict[str, float] = field(
-        default_factory=lambda: {
-            "combined_score": 1.0,  # Primary: maximize fitness
-        }
-    )
+    archive_criteria: Dict[str, float] = field(default_factory=default_archive_criteria)
 
 
 def db_retry(max_retries=5, initial_delay=0.1, backoff_factor=2):

--- a/shinka/defaults.py
+++ b/shinka/defaults.py
@@ -1,0 +1,50 @@
+"""Canonical shared defaults for Shinka configs and CLIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_TASK_SYS_MSG = (
+    "You are an expert optimization and algorithm design assistant. "
+    "Improve the program while preserving correctness and immutable regions."
+)
+
+
+def default_patch_types() -> list[str]:
+    return ["diff", "full", "cross"]
+
+
+def default_patch_type_probs() -> list[float]:
+    return [0.6, 0.3, 0.1]
+
+
+def default_llm_models() -> list[str]:
+    return [
+        "gpt-5-mini",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "gpt-5.4",
+    ]
+
+
+def default_llm_dynamic_selection_kwargs() -> dict[str, Any]:
+    return {"cost_aware_coef": 0.5}
+
+
+def default_llm_kwargs() -> dict[str, Any]:
+    return {
+        "temperatures": [0.0, 0.5, 1.0],
+        "max_tokens": 16384,
+    }
+
+
+def default_prompt_patch_types() -> list[str]:
+    return ["diff", "full"]
+
+
+def default_prompt_patch_type_probs() -> list[float]:
+    return [0.7, 0.3]
+
+
+def default_archive_criteria() -> dict[str, float]:
+    return {"combined_score": 1.0}

--- a/shinka/launch/__init__.py
+++ b/shinka/launch/__init__.py
@@ -1,5 +1,10 @@
 from .scheduler import JobScheduler, JobConfig
-from .scheduler import LocalJobConfig, SlurmDockerJobConfig, SlurmCondaJobConfig
+from .scheduler import (
+    LocalJobConfig,
+    SlurmDockerJobConfig,
+    SlurmCondaJobConfig,
+    SlurmEnvJobConfig,
+)
 from .local import ProcessWithLogging
 
 __all__ = [
@@ -8,5 +13,6 @@ __all__ = [
     "LocalJobConfig",
     "SlurmDockerJobConfig",
     "SlurmCondaJobConfig",
+    "SlurmEnvJobConfig",
     "ProcessWithLogging",
 ]

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import asyncio
+import shlex
 from dataclasses import dataclass, asdict, field
 from typing import Optional, Dict, Any, Tuple, Union, List
 from concurrent.futures import ThreadPoolExecutor
@@ -14,6 +15,18 @@ from .slurm import (
 from shinka.utils import parse_time_to_seconds
 
 logger = logging.getLogger(__name__)
+
+
+def _has_value(value: Optional[str]) -> bool:
+    return value is not None and value.strip() != ""
+
+
+def _validate_activation_config(
+    conda_env: Optional[str],
+    activate_script: Optional[str],
+) -> None:
+    if _has_value(conda_env) and _has_value(activate_script):
+        raise ValueError("conda_env and activate_script are mutually exclusive")
 
 
 @dataclass
@@ -35,6 +48,10 @@ class LocalJobConfig(JobConfig):
 
     time: Optional[str] = None
     conda_env: Optional[str] = None
+    activate_script: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        _validate_activation_config(self.conda_env, self.activate_script)
 
 
 @dataclass
@@ -56,6 +73,7 @@ class SlurmCondaJobConfig(JobConfig):
     """Configuration for SLURM jobs using Conda environment"""
 
     conda_env: str = ""
+    activate_script: Optional[str] = None
     modules: Optional[List[str]] = None
     partition: str = "gpu"
     time: str = "01:00:00"
@@ -64,8 +82,12 @@ class SlurmCondaJobConfig(JobConfig):
     mem: Optional[str] = "8G"
 
     def __post_init__(self):
+        _validate_activation_config(self.conda_env, self.activate_script)
         if self.modules is None:
             self.modules = []
+
+
+SlurmEnvJobConfig = SlurmCondaJobConfig
 
 
 class JobScheduler:
@@ -84,6 +106,8 @@ class JobScheduler:
         self.config = config
         self.verbose = verbose
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        if self.job_type == "slurm_env":
+            self.job_type = "slurm_conda"
 
         if self.job_type == "local":
             self.monitor = monitor_local
@@ -92,14 +116,13 @@ class JobScheduler:
         else:
             raise ValueError(
                 f"Unknown job type: {job_type}. "
-                f"Must be 'local', 'slurm_docker', or 'slurm_conda'"
+                f"Must be 'local', 'slurm_docker', 'slurm_conda', or 'slurm_env'"
             )
 
     def _build_command(self, exec_fname_t: str, results_dir_t: str) -> List[str]:
-        # Docker requires workspace to be mounted
         if self.job_type == "slurm_docker":
             assert isinstance(self.config, SlurmDockerJobConfig)
-            cmd = [
+            python_cmd = [
                 "python",
                 f"/workspace/{self.config.eval_program_path}",
                 "--program_path",
@@ -108,38 +131,36 @@ class JobScheduler:
                 results_dir_t,
             ]
         else:
-            # For local jobs, check if conda environment is specified
-            if (
-                self.job_type == "local"
-                and isinstance(self.config, LocalJobConfig)
-                and self.config.conda_env
-            ):
-                # Use conda run to execute in specific environment
-                cmd = [
+            python_cmd = [
+                "python",
+                f"{self.config.eval_program_path}",
+                "--program_path",
+                f"{exec_fname_t}",
+                "--results_dir",
+                results_dir_t,
+            ]
+        if self.config.extra_cmd_args:
+            for k, v in self.config.extra_cmd_args.items():
+                python_cmd.extend([f"--{k}", str(v)])
+
+        if self.job_type == "local" and isinstance(self.config, LocalJobConfig):
+            if _has_value(self.config.conda_env):
+                return [
                     "conda",
                     "run",
                     "-n",
-                    self.config.conda_env,
-                    "python",
-                    f"{self.config.eval_program_path}",
-                    "--program_path",
-                    f"{exec_fname_t}",
-                    "--results_dir",
-                    results_dir_t,
+                    self.config.conda_env.strip(),
+                    *python_cmd,
                 ]
-            else:
-                cmd = [
-                    "python",
-                    f"{self.config.eval_program_path}",
-                    "--program_path",
-                    f"{exec_fname_t}",
-                    "--results_dir",
-                    results_dir_t,
+            if _has_value(self.config.activate_script):
+                activate_script = self.config.activate_script.strip().replace('"', '\\"')
+                return [
+                    "bash",
+                    "-lc",
+                    f'set -e; source "{activate_script}"; exec {shlex.join(python_cmd)}',
                 ]
-        if self.config.extra_cmd_args:
-            for k, v in self.config.extra_cmd_args.items():
-                cmd.extend([f"--{k}", str(v)])
-        return cmd
+
+        return python_cmd
 
     def run(
         self, exec_fname_t: str, results_dir_t: str
@@ -177,6 +198,7 @@ class JobScheduler:
                 self.config.gpus,
                 self.config.mem,
                 self.config.conda_env,
+                self.config.activate_script,
                 self.config.modules,
                 verbose=self.verbose,
             )
@@ -231,6 +253,7 @@ class JobScheduler:
                 self.config.gpus,
                 self.config.mem,
                 self.config.conda_env,
+                self.config.activate_script,
                 self.config.modules,
                 verbose=self.verbose,
             )

--- a/shinka/launch/slurm.py
+++ b/shinka/launch/slurm.py
@@ -28,6 +28,44 @@ CACHE_MANIFEST = DOCKER_CACHE_DIR / "cache_manifest.json"
 LOCAL_JOBS: dict[str, dict] = {}
 
 
+def _has_value(value: Optional[str]) -> bool:
+    return value is not None and value.strip() != ""
+
+
+def _escape_double_quotes(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+def _build_activation_commands(
+    conda_env: Optional[str] = None,
+    activate_script: Optional[str] = None,
+    *,
+    separator: str = "\n",
+) -> str:
+    if _has_value(conda_env) and _has_value(activate_script):
+        raise ValueError("conda_env and activate_script are mutually exclusive")
+
+    commands: list[str] = []
+    if _has_value(activate_script):
+        quoted_path = _escape_double_quotes(activate_script.strip())
+        commands.extend(
+            [
+                f'echo "Activating sourced environment: {quoted_path}"',
+                f'source "{quoted_path}"',
+            ]
+        )
+    elif _has_value(conda_env):
+        env_name = conda_env.strip()
+        commands.extend(
+            [
+                f'echo "Activating conda environment: {env_name}"',
+                "source $(conda info --base)/etc/profile.d/conda.sh",
+                f"conda activate {env_name}",
+            ]
+        )
+    return separator.join(commands)
+
+
 def load_cache_manifest():
     """Load the cache manifest file."""
     if CACHE_MANIFEST.exists():
@@ -123,12 +161,8 @@ module --quiet purge
 
 echo "Job running on $(hostname) under Slurm job $SLURM_JOB_ID"
 
-# Activate conda environment
-if [ -n "{conda_env}" ]; then
-    echo "Activating conda environment: {conda_env}"
-    source $(conda info --base)/etc/profile.d/conda.sh
-    conda activate {conda_env}
-fi
+# Activate Python environment when configured
+{activation_commands}
 
 {cmd}
 
@@ -243,6 +277,7 @@ def submit_conda(
     gpus: int,
     mem: Optional[str],
     conda_env: str = "",
+    activate_script: Optional[str] = None,
     modules: Optional[list[str]] = None,
     verbose: bool = False,
     local: bool = False,
@@ -258,6 +293,7 @@ def submit_conda(
             gpus=gpus,
             mem=mem,
             conda_env=conda_env,
+            activate_script=activate_script,
             modules=modules,
             verbose=verbose,
             **sbatch_kwargs,
@@ -270,6 +306,10 @@ def submit_conda(
         modules = []
 
     module_load_commands = "\n".join([f"module load {module}" for module in modules])
+    activation_commands = _build_activation_commands(
+        conda_env=conda_env,
+        activate_script=activate_script,
+    )
 
     if mem is not None:
         sbatch_kwargs["mem"] = mem
@@ -286,7 +326,7 @@ def submit_conda(
         cpus=cpus,
         gpus=gpus,
         additional_sbatch_params=additional_sbatch_params,
-        conda_env=conda_env,
+        activation_commands=activation_commands,
         module_load_commands=module_load_commands,
         cmd=" ".join(cmd),
     )
@@ -396,6 +436,7 @@ def submit_local_conda(
     gpus: int,
     mem: Optional[str],
     conda_env: str = "",
+    activate_script: Optional[str] = None,
     modules: Optional[list[str]] = None,
     verbose: bool = False,
     **kwargs,
@@ -406,12 +447,20 @@ def submit_local_conda(
     os.makedirs(log_dir, exist_ok=True)
     modules = modules or []
     loads = "; ".join([f"module load {m}" for m in modules])
-    full_cmd = (
-        f"module --quiet purge; {loads}; "
-        f"source $(conda info --base)/etc/profile.d/conda.sh; "
-        f"conda activate {conda_env}; "
-        f"{' '.join(cmd)} >> {log_dir}/job_log.out "
-        f"2>> {log_dir}/job_log.err"
+    activation_commands = _build_activation_commands(
+        conda_env=conda_env,
+        activate_script=activate_script,
+        separator="; ",
+    )
+    full_cmd = "; ".join(
+        segment
+        for segment in [
+            "module --quiet purge",
+            loads,
+            activation_commands,
+            f"{' '.join(cmd)} >> {log_dir}/job_log.out 2>> {log_dir}/job_log.err",
+        ]
+        if segment
     )
     launch_local_subprocess(job_id, ["bash", "-lc", full_cmd], gpus)
     if verbose:

--- a/skills/shinka-convert/SKILL.md
+++ b/skills/shinka-convert/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: shinka-convert
+description: Convert an existing codebase in the current working directory into a ShinkaEvolve task directory by snapshotting the relevant code, adding evolve blocks, and generating `evaluate.py` plus Shinka runner/config files. Use when the user wants to optimize existing code with Shinka instead of creating a brand-new task from a natural-language description.
+---
+
+# Shinka Convert Skill
+Use this skill to turn an existing project into a Shinka-ready task.
+
+This is the alternative starting point to `shinka-setup`:
+- `shinka-setup`: new task from natural-language task description
+- `shinka-convert`: existing codebase to Shinka task conversion
+
+After conversion, the user should still be able to use `shinka-run`.
+
+## When to Use
+Invoke this skill when the user:
+- Wants to optimize an existing script or repo with Shinka/ShinkaEvolve
+- Mentions adapting current code to Shinka output signatures, `metrics.json`, `correct.json`, or `EVOLVE-BLOCK` markers
+- Wants a sidecar Shinka task generated from the current working directory
+
+Do not use this skill when:
+- The user wants a brand-new task scaffold from only a natural-language description
+- `evaluate.py` and `initial.<ext>` already exist and the user only wants to launch evolution; use `shinka-run`
+
+## User Inputs
+Start from freeform instructions, then ask follow-ups only if high-impact details are missing.
+
+Collect:
+- What behavior or file/function to optimize
+- Score direction and main metric
+- Constraints: correctness, runtime, memory, determinism, style, allowed edits
+- Whether original source must remain untouched
+- Any required data/assets/dependencies
+
+## Default Output
+Generate a sidecar task directory at `./shinka_task/` unless the user requests another path.
+
+The task directory should contain:
+- `evaluate.py`
+- `run_evo.py`
+- `shinka.yaml`
+- `initial.<ext>`
+- A copied snapshot of the minimal runnable source subtree needed for evaluation
+
+Do not edit the original source tree unless the user explicitly requests in-place conversion.
+
+## Workflow
+1. Inspect the current working directory.
+   - Identify language, entrypoints, package/module layout, dependencies, and current outputs.
+   - Prefer concrete evidence from the code over guesses.
+2. Infer the evolvable region from the user's instructions.
+   - If ambiguous, ask targeted follow-ups.
+   - Keep the mutable region as small as practical.
+3. Choose the minimal runnable snapshot scope.
+   - Copy only the source subtree needed to execute the task in isolation.
+   - Avoid repo-wide snapshots unless imports/runtime make that necessary.
+4. Create the sidecar task directory.
+   - Default: `./shinka_task/`
+   - Avoid overwriting an existing task dir without consent.
+5. Rewrite the snapshot into a stable Shinka contract.
+   - Preserve original behavior outside the evolvable region.
+   - Keep CLI behavior intact where practical.
+   - Ensure the evolvable candidate entry file is named `initial.<ext>` so `shinka-run` can detect it.
+   - Add tight `EVOLVE-BLOCK-START` / `EVOLVE-BLOCK-END` markers.
+6. Generate the evaluator path.
+   - Python: prefer exposing `run_experiment(...)` and use `run_shinka_eval`.
+   - Non-Python: use `subprocess` and write `metrics.json` plus `correct.json`.
+7. Generate `run_evo.py` and `shinka.yaml`.
+   - Ensure `init_program_path` and `language` match the candidate file.
+   - Keep the output directly compatible with `shinka-run`.
+8. Smoke test before handoff.
+   - Run `python evaluate.py --program_path <initial file> --results_dir /tmp/shinka_convert_smoke`
+   - Confirm evaluator runs without exceptions.
+   - Confirm required metrics/correctness outputs are written.
+9. Ask the user for the next step.
+   - Either run evolution manually
+   - Or use the `shinka-run` skill
+
+## Conversion Strategy by Language
+### Python
+- Preferred path: expose `run_experiment(...)` in the snapshot and evaluate via `run_shinka_eval`
+- If the existing code is CLI-only, add a thin wrapper in the snapshot rather than forcing a subprocess evaluator unless imports are too brittle
+- Keep imports relative to the copied task snapshot stable
+
+### Non-Python
+- Keep the candidate program executable in its own runtime
+- Use Python `evaluate.py` as the Shinka entrypoint
+- Write `metrics.json` and `correct.json` in `results_dir`
+
+## Required Evaluator Contract
+Metrics must include:
+- `combined_score`
+- `public`
+- `private`
+- `extra_data`
+- `text_feedback`
+
+Correctness must include:
+- `correct`
+- `error`
+
+Higher `combined_score` values indicate better performance unless the user explicitly defines an inverted metric that you transform during aggregation.
+
+## Python Conversion Template
+Prefer shaping the copied program like this:
+
+```py
+from __future__ import annotations
+
+# EVOLVE-BLOCK-START
+def optimize_me(...):
+    ...
+# EVOLVE-BLOCK-END
+
+def run_experiment(random_seed: int | None = None, **kwargs):
+    ...
+    return score, text_feedback
+```
+
+And the evaluator:
+
+```py
+from shinka.core import run_shinka_eval
+
+def main(program_path: str, results_dir: str):
+    metrics, correct, err = run_shinka_eval(
+        program_path=program_path,
+        results_dir=results_dir,
+        experiment_fn_name="run_experiment",
+        num_runs=3,
+        get_experiment_kwargs=get_kwargs,
+        aggregate_metrics_fn=aggregate_fn,
+        validate_fn=validate_fn,
+    )
+    if not correct:
+        raise RuntimeError(err or "Evaluation failed")
+```
+
+## Non-Python Conversion Template
+Use `evaluate.py` to run the candidate and write outputs:
+
+```py
+import json
+import os
+from pathlib import Path
+
+def main(program_path: str, results_dir: str):
+    os.makedirs(results_dir, exist_ok=True)
+    metrics = {
+        "combined_score": 0.0,
+        "public": {},
+        "private": {},
+        "extra_data": {},
+        "text_feedback": "",
+    }
+    correct = {"correct": False, "error": ""}
+
+    (Path(results_dir) / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    (Path(results_dir) / "correct.json").write_text(json.dumps(correct, indent=2))
+```
+
+## Bundled Assets
+- Use `scripts/run_evo.py` as the starting runner template
+- Use `scripts/shinka.yaml` as the starting config template
+
+## Notes
+- Keep evolve regions tight; do not make the whole project mutable by default
+- Preserve correctness checks outside the evolve region where possible
+- Prefer deterministic evaluation and stable seeds
+- If the converted task is ready, offer to continue with `shinka-run`

--- a/skills/shinka-convert/agents/openai.yaml
+++ b/skills/shinka-convert/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Shinka Convert"
-  short_description: "Convert existing code into a Shinka task"
-  default_prompt: "Use $shinka-convert to turn the current working directory into a Shinka-ready task directory that I can later run with `shinka-run`."
-
-policy:
-  allow_implicit_invocation: true

--- a/skills/shinka-convert/agents/openai.yaml
+++ b/skills/shinka-convert/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Shinka Convert"
+  short_description: "Convert existing code into a Shinka task"
+  default_prompt: "Use $shinka-convert to turn the current working directory into a Shinka-ready task directory that I can later run with `shinka-run`."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/shinka-convert/scripts/run_evo.py
+++ b/skills/shinka-convert/scripts/run_evo.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import yaml
+
+from shinka.core import EvolutionConfig, ShinkaEvolveRunner
+from shinka.database import DatabaseConfig
+from shinka.launch import LocalJobConfig
+
+TASK_SYS_MSG = """You are optimizing code converted from an existing codebase.
+Preserve the task contract and keep changes focused on the intended EVOLVE-BLOCK regions.
+Do not break evaluation outputs, result file schemas, or imports required by the task snapshot."""
+
+
+async def main(config_path: str):
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    config["evo_config"]["task_sys_msg"] = TASK_SYS_MSG
+    evo_config = EvolutionConfig(**config["evo_config"])
+    job_config = LocalJobConfig(
+        eval_program_path="evaluate.py",
+        time="05:00:00",
+    )
+    db_config = DatabaseConfig(**config["db_config"])
+
+    runner = ShinkaEvolveRunner(
+        evo_config=evo_config,
+        job_config=job_config,
+        db_config=db_config,
+        max_evaluation_jobs=config["max_evaluation_jobs"],
+        max_proposal_jobs=config["max_proposal_jobs"],
+        max_db_workers=config["max_db_workers"],
+        debug=False,
+        verbose=True,
+    )
+    await runner.run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config_path", type=str, default="shinka.yaml")
+    args = parser.parse_args()
+    asyncio.run(main(args.config_path))

--- a/skills/shinka-convert/scripts/shinka.yaml
+++ b/skills/shinka-convert/scripts/shinka.yaml
@@ -1,0 +1,48 @@
+max_evaluation_jobs: 5
+max_proposal_jobs: 5
+max_db_workers: 4
+
+db_config:
+  db_path: evolution_db.sqlite
+  num_islands: 2
+  archive_size: 40
+  elite_selection_ratio: 0.3
+  num_archive_inspirations: 4
+  num_top_k_inspirations: 2
+  migration_interval: 10
+  migration_rate: 0.1
+  island_elitism: true
+  enforce_island_separation: true
+  parent_selection_strategy: weighted
+  parent_selection_lambda: 10
+
+evo_config:
+  patch_types: [diff, full, cross]
+  patch_type_probs: [0.6, 0.3, 0.1]
+  num_generations: 100
+  max_api_costs: 0.1
+  max_patch_resamples: 3
+  max_patch_attempts: 3
+  max_novelty_attempts: 3
+  job_type: local
+  language: python
+  llm_models: ["gemini-3-flash-preview", "gpt-5-mini", "gpt-5-nano"]
+  llm_kwargs:
+    temperatures: [0, 0.5, 1.0]
+    reasoning_efforts: [min, low]
+    max_tokens: 32768
+  meta_rec_interval: 40
+  meta_llm_models: ["gpt-5-mini"]
+  meta_llm_kwargs:
+    temperatures: [0]
+    max_tokens: 16384
+  embedding_model: text-embedding-3-small
+  code_embed_sim_threshold: 0.99
+  novelty_llm_models: ["gpt-5-nano"]
+  novelty_llm_kwargs:
+    temperatures: [0]
+  init_program_path: initial.py
+  llm_dynamic_selection: ucb1
+  llm_dynamic_selection_kwargs:
+    exploration_coef: 1
+  results_dir: results/results_task

--- a/tests/test_launch_hydra_async.py
+++ b/tests/test_launch_hydra_async.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hydra import compose, initialize
 from omegaconf import OmegaConf
 
 import shinka.launch_hydra as launch_hydra
@@ -40,3 +41,30 @@ def test_launch_hydra_uses_async_runner(monkeypatch):
     assert _DummyRunner.last_kwargs["max_evaluation_jobs"] == 7
     assert _DummyRunner.last_kwargs["max_proposal_jobs"] == 3
     assert _DummyRunner.last_kwargs["max_db_workers"] == 5
+
+
+def test_default_launch_config_uses_neutral_shared_defaults():
+    with initialize(version_base=None, config_path="../configs"):
+        cfg = compose(config_name="config")
+
+    assert cfg.variant_suffix == "_default"
+    assert cfg.exp_name == "shinka_circle_packing"
+    assert cfg.max_evaluation_jobs == 2
+    assert cfg.evo_config.num_generations == 50
+    assert cfg.evo_config.max_patch_attempts == 1
+    assert cfg.evo_config.llm_models == [
+        "gpt-5-mini",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "gpt-5.4",
+    ]
+    assert cfg.evo_config.llm_dynamic_selection == "ucb"
+    assert cfg.evo_config.llm_dynamic_selection_kwargs.cost_aware_coef == 0.5
+    assert cfg.evo_config.meta_rec_interval == 10
+    assert cfg.evo_config.code_embed_sim_threshold == 0.99
+    assert cfg.db_config.num_islands == 2
+    assert cfg.db_config.archive_size == 40
+    assert cfg.db_config.num_archive_inspirations == 1
+    assert cfg.db_config.num_top_k_inspirations == 1
+    assert cfg.db_config.migration_rate == 0.0
+    assert cfg.db_config.parent_selection_strategy == "weighted"

--- a/tests/test_scheduler_env_activation.py
+++ b/tests/test_scheduler_env_activation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from shinka.launch import JobScheduler, LocalJobConfig, SlurmCondaJobConfig
+from shinka.launch.scheduler import SlurmEnvJobConfig
+from shinka.launch.slurm import submit_conda, submit_local_conda
+
+
+def test_slurm_env_config_rejects_conda_and_activate_script() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        SlurmEnvJobConfig(conda_env="shinka", activate_script=".venv/bin/activate")
+
+
+def test_local_job_config_rejects_conda_and_activate_script() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        LocalJobConfig(conda_env="shinka", activate_script=".venv/bin/activate")
+
+
+def test_submit_conda_sources_activate_script(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        assert cmd[0] == "sbatch"
+        script_path = Path(cmd[1])
+        captured["script"] = script_path.read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="Submitted batch job 123\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("shinka.launch.slurm.subprocess.run", fake_run)
+
+    job_id = submit_conda(
+        log_dir=str(tmp_path / "logs"),
+        cmd=["python", "evaluate.py"],
+        time="00:10:00",
+        partition="gpu",
+        cpus=1,
+        gpus=0,
+        mem="8G",
+        activate_script=".venv/bin/activate",
+    )
+
+    assert job_id == "123"
+    assert 'source ".venv/bin/activate"' in captured["script"]
+    assert "conda activate" not in captured["script"]
+
+
+def test_submit_local_conda_sources_activate_script(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_launch(job_id: str, cmd: list[str], gpus: int) -> None:
+        captured["job_id"] = job_id
+        captured["cmd"] = cmd
+        captured["gpus"] = gpus
+
+    monkeypatch.setattr("shinka.launch.slurm.launch_local_subprocess", fake_launch)
+
+    job_id = submit_local_conda(
+        log_dir=str(tmp_path / "logs"),
+        cmd=["python", "evaluate.py"],
+        time="00:10:00",
+        partition="gpu",
+        cpus=1,
+        gpus=0,
+        mem="8G",
+        activate_script=".venv/bin/activate",
+    )
+
+    assert job_id.startswith("local-conda-")
+    assert captured["cmd"][0:2] == ["bash", "-lc"]
+    assert 'source ".venv/bin/activate"' in captured["cmd"][2]
+    assert "conda activate" not in captured["cmd"][2]
+
+
+def test_job_scheduler_accepts_slurm_env_alias() -> None:
+    scheduler = JobScheduler(
+        job_type="slurm_env",
+        config=SlurmEnvJobConfig(
+            eval_program_path="evaluate.py",
+            activate_script=".venv/bin/activate",
+        ),
+    )
+
+    assert scheduler.monitor is not None
+
+
+def test_job_scheduler_builds_local_sourced_command() -> None:
+    scheduler = JobScheduler(
+        job_type="local",
+        config=LocalJobConfig(
+            eval_program_path="evaluate.py",
+            activate_script=".venv/bin/activate",
+        ),
+    )
+
+    cmd = scheduler._build_command("program.py", "results")
+
+    assert cmd[0:2] == ["bash", "-lc"]
+    assert 'source ".venv/bin/activate"' in cmd[2]
+    assert "evaluate.py" in cmd[2]
+
+
+def test_slurm_conda_job_config_allows_activate_script_for_back_compat() -> None:
+    config = SlurmCondaJobConfig(activate_script=".venv/bin/activate")
+
+    assert config.activate_script == ".venv/bin/activate"

--- a/tests/test_scheduler_env_activation.py
+++ b/tests/test_scheduler_env_activation.py
@@ -59,12 +59,14 @@ def test_submit_local_conda_sources_activate_script(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured_cmd: list[str] = []
+    captured_gpus = -1
 
     def fake_launch(job_id: str, cmd: list[str], gpus: int) -> None:
-        captured["job_id"] = job_id
-        captured["cmd"] = cmd
-        captured["gpus"] = gpus
+        assert job_id.startswith("local-conda-")
+        captured_cmd.extend(cmd)
+        nonlocal captured_gpus
+        captured_gpus = gpus
 
     monkeypatch.setattr("shinka.launch.slurm.launch_local_subprocess", fake_launch)
 
@@ -80,9 +82,10 @@ def test_submit_local_conda_sources_activate_script(
     )
 
     assert job_id.startswith("local-conda-")
-    assert captured["cmd"][0:2] == ["bash", "-lc"]
-    assert 'source ".venv/bin/activate"' in captured["cmd"][2]
-    assert "conda activate" not in captured["cmd"][2]
+    assert captured_cmd[0:2] == ["bash", "-lc"]
+    assert 'source ".venv/bin/activate"' in captured_cmd[2]
+    assert "conda activate" not in captured_cmd[2]
+    assert captured_gpus == 0
 
 
 def test_job_scheduler_accepts_slurm_env_alias() -> None:

--- a/tests/test_shinka_run_cli.py
+++ b/tests/test_shinka_run_cli.py
@@ -93,9 +93,33 @@ def test_shinka_run_happy_path_with_authoritative_overrides(tmp_path, monkeypatc
 
     assert evo_config.results_dir == str(results_dir.resolve())
     assert evo_config.num_generations == 7
+    assert evo_config.task_sys_msg is not None
+    assert evo_config.patch_types == ["diff", "full", "cross"]
+    assert evo_config.patch_type_probs == [0.6, 0.3, 0.1]
     assert evo_config.max_proposal_jobs == 1
     assert evo_config.max_db_workers == 4
+    assert evo_config.max_patch_attempts == 1
+    assert evo_config.llm_models == [
+        "gpt-5-mini",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "gpt-5.4",
+    ]
+    assert evo_config.llm_dynamic_selection == "ucb"
+    assert evo_config.llm_dynamic_selection_kwargs == {"cost_aware_coef": 0.5}
+    assert evo_config.llm_kwargs == {
+        "temperatures": [0.0, 0.5, 1.0],
+        "max_tokens": 16384,
+    }
+    assert evo_config.meta_rec_interval == 10
+    assert evo_config.embedding_model == "text-embedding-3-small"
+    assert evo_config.code_embed_sim_threshold == pytest.approx(0.99)
     assert db_config.num_islands == 2
+    assert db_config.archive_size == 40
+    assert db_config.num_archive_inspirations == 1
+    assert db_config.num_top_k_inspirations == 1
+    assert db_config.migration_rate == pytest.approx(0.0)
+    assert db_config.parent_selection_strategy == "weighted"
     assert job_config.time == "00:03:00"
     assert "def run" in init_program_str
     assert "def main" in evaluate_str
@@ -126,6 +150,29 @@ def test_shinka_run_parses_json_overrides(tmp_path, monkeypatch):
     job_config = _DummyRunner.last_kwargs["job_config"]
     assert evo_config.llm_models == ["gpt-5-mini", "gpt-5-nano"]
     assert job_config.extra_cmd_args == {"seed": 42}
+
+
+def test_shinka_run_parses_activate_script_override(tmp_path, monkeypatch):
+    _reset_dummy_runner()
+    task_dir = _make_task_dir(tmp_path)
+    results_dir = tmp_path / "results_activate_script"
+    monkeypatch.setattr(cli_run, "ShinkaEvolveRunner", _DummyRunner)
+
+    cli_run.main(
+        [
+            "--task-dir",
+            str(task_dir),
+            "--results_dir",
+            str(results_dir),
+            "--num_generations",
+            "3",
+            "--set",
+            "job.activate_script=.venv/bin/activate",
+        ]
+    )
+
+    job_config = _DummyRunner.last_kwargs["job_config"]
+    assert job_config.activate_script == ".venv/bin/activate"
 
 
 def test_shinka_run_loads_optional_config_yaml_with_precedence(tmp_path, monkeypatch):
@@ -260,3 +307,44 @@ def test_shinka_run_requires_evaluate_file(tmp_path):
             ]
         )
     assert exc_info.value.code == 2
+
+
+def test_dataclass_defaults_match_shared_baseline():
+    evo_config = cli_run.EvolutionConfig()
+    db_config = cli_run.DatabaseConfig()
+    job_config = cli_run.LocalJobConfig()
+
+    assert evo_config.task_sys_msg is not None
+    assert evo_config.patch_types == ["diff", "full", "cross"]
+    assert evo_config.patch_type_probs == [0.6, 0.3, 0.1]
+    assert evo_config.num_generations == 50
+    assert evo_config.max_patch_attempts == 1
+    assert evo_config.llm_models == [
+        "gpt-5-mini",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "gpt-5.4",
+    ]
+    assert evo_config.llm_dynamic_selection == "ucb"
+    assert evo_config.llm_dynamic_selection_kwargs == {"cost_aware_coef": 0.5}
+    assert evo_config.llm_kwargs == {
+        "temperatures": [0.0, 0.5, 1.0],
+        "max_tokens": 16384,
+    }
+    assert evo_config.meta_rec_interval == 10
+    assert evo_config.embedding_model == "text-embedding-3-small"
+    assert evo_config.code_embed_sim_threshold == pytest.approx(0.99)
+
+    assert db_config.num_islands == 2
+    assert db_config.archive_size == 40
+    assert db_config.num_archive_inspirations == 1
+    assert db_config.num_top_k_inspirations == 1
+    assert db_config.migration_interval == 10
+    assert db_config.migration_rate == pytest.approx(0.0)
+    assert db_config.parent_selection_strategy == "weighted"
+    assert db_config.parent_selection_lambda == pytest.approx(10.0)
+    assert db_config.enable_dynamic_islands is False
+
+    assert job_config.time is None
+    assert job_config.conda_env is None
+    assert job_config.activate_script is None


### PR DESCRIPTION
## Summary
- add the `shinka-convert` skill plus bundled `run_evo.py` and `shinka.yaml` templates for sidecar task conversion workflows
- centralize shared Shinka defaults, switch the default Hydra stack to the medium shared baseline, and sync CLI/help text with those defaults
- add `activate_script` support for local and Slurm job configs so uv/venv environments can be sourced per job, with regression coverage
- refresh README/docs around the new baseline and agent workflows, ignore MNIST training artifacts, and remove the obsolete `skills/shinka-convert/agents/openai.yaml` manifest

## Why
- makes existing-repo conversion a first-class agent workflow
- gives `shinka_launch` and `shinka_run` more realistic shared defaults out of the box
- lets jobs run from sourceable virtualenv activation scripts instead of requiring Conda-only setup

## Testing
- `ruff check .`
- `mypy .`
- `pytest --cov=shinka`
