### PR TITLE
fix: support dynamic OpenRouter embedding models

### DIFF
--- a/shinka/embed/client.py
+++ b/shinka/embed/client.py
@@ -1,34 +1,65 @@
-from typing import Any, Tuple
+from dataclasses import dataclass
 import os
-import openai
+from typing import Any, Tuple
+
 from google import genai
+import openai
+
 from shinka.env import load_shinka_dotenv
+
 from .providers.pricing import get_provider
 
 load_shinka_dotenv()
 
 TIMEOUT = 600
+_OPENROUTER_PREFIX = "openrouter/"
+
+
+@dataclass(frozen=True)
+class ResolvedEmbeddingModel:
+    original_model_name: str
+    api_model_name: str
+    provider: str
+
+
+def resolve_embedding_backend(model_name: str) -> ResolvedEmbeddingModel:
+    """Resolve runtime backend info for embedding model identifiers."""
+    provider = get_provider(model_name)
+    if provider == "azure":
+        api_model_name = model_name.split("azure-", 1)[-1]
+        return ResolvedEmbeddingModel(
+            original_model_name=model_name,
+            api_model_name=api_model_name,
+            provider=provider,
+        )
+    if provider is not None:
+        return ResolvedEmbeddingModel(
+            original_model_name=model_name,
+            api_model_name=model_name,
+            provider=provider,
+        )
+    if model_name.startswith(_OPENROUTER_PREFIX):
+        api_model_name = model_name.split(_OPENROUTER_PREFIX, 1)[-1]
+        if not api_model_name:
+            raise ValueError(
+                "OpenRouter embedding model is missing after 'openrouter/'."
+            )
+        return ResolvedEmbeddingModel(
+            original_model_name=model_name,
+            api_model_name=api_model_name,
+            provider="openrouter",
+        )
+    raise ValueError(f"Embedding model {model_name} not supported.")
 
 
 def get_client_embed(model_name: str) -> Tuple[Any, str]:
-    """Get the client and model for the given embedding model name.
-
-    Args:
-        model_name (str): The name of the embedding model to get the client.
-
-    Raises:
-        ValueError: If the model is not supported.
-
-    Returns:
-        Tuple[Any, str]: The client and model name for the given model.
-    """
-    provider = get_provider(model_name)
+    """Get the client and model for the given embedding model name."""
+    resolved = resolve_embedding_backend(model_name)
+    provider = resolved.provider
 
     if provider == "openai":
         client = openai.OpenAI(timeout=TIMEOUT)
     elif provider == "azure":
-        # Strip azure- prefix from model name
-        model_name = model_name.split("azure-")[-1]
         client = openai.AzureOpenAI(
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),
             api_version=os.getenv("AZURE_API_VERSION"),
@@ -46,28 +77,17 @@ def get_client_embed(model_name: str) -> Tuple[Any, str]:
     else:
         raise ValueError(f"Embedding model {model_name} not supported.")
 
-    return client, model_name
+    return client, resolved.api_model_name
 
 
 def get_async_client_embed(model_name: str) -> Tuple[Any, str]:
-    """Get the async client and model for the given embedding model name.
-
-    Args:
-        model_name (str): The name of the embedding model to get the client.
-
-    Raises:
-        ValueError: If the model is not supported.
-
-    Returns:
-        Tuple[Any, str]: The async client and model name for the given model.
-    """
-    provider = get_provider(model_name)
+    """Get the async client and model for the given embedding model name."""
+    resolved = resolve_embedding_backend(model_name)
+    provider = resolved.provider
 
     if provider == "openai":
         client = openai.AsyncOpenAI()
     elif provider == "azure":
-        # Strip azure- prefix from model name
-        model_name = model_name.split("azure-")[-1]
         client = openai.AsyncAzureOpenAI(
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),
             api_version=os.getenv("AZURE_API_VERSION"),
@@ -77,7 +97,7 @@ def get_async_client_embed(model_name: str) -> Tuple[Any, str]:
         # Gemini doesn't have async client yet, will use thread pool in embedding.py
         client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
     elif provider == "openrouter":
-        client = openai.OpenAI(
+        client = openai.AsyncOpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],
             base_url="https://openrouter.ai/api/v1",
             timeout=TIMEOUT,
@@ -85,4 +105,4 @@ def get_async_client_embed(model_name: str) -> Tuple[Any, str]:
     else:
         raise ValueError(f"Embedding model {model_name} not supported.")
 
-    return client, model_name
+    return client, resolved.api_model_name

--- a/shinka/embed/embedding.py
+++ b/shinka/embed/embedding.py
@@ -4,8 +4,12 @@ from typing import Union, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from .client import get_client_embed, get_async_client_embed
-from .providers.pricing import get_provider, get_model_price
+from .client import (
+    get_async_client_embed,
+    get_client_embed,
+    resolve_embedding_backend,
+)
+from .providers.pricing import get_model_price, model_exists
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +49,17 @@ def _get_google_embeddings_and_cost(
         total_tokens += token_count
 
     return embeddings, total_tokens * price_per_token
+
+
+def _get_embedding_cost(response, model_name: str) -> float:
+    """Compute embedding cost, defaulting to zero for dynamic models without pricing."""
+    if not model_exists(model_name):
+        logger.warning(
+            "Embedding model '%s' has no pricing entry. Defaulting embedding cost to 0.",
+            model_name,
+        )
+        return 0.0
+    return response.usage.total_tokens * get_model_price(model_name)
 
 
 def count_tokens(
@@ -111,7 +126,7 @@ class EmbeddingClient:
         """
         self.model_name = model_name
         self.client, self.model = get_client_embed(model_name)
-        self.provider = get_provider(model_name)
+        self.provider = resolve_embedding_backend(model_name).provider
         self.verbose = verbose
 
     def count_tokens(self, text: Union[str, List[str]]) -> Union[int, List[int]]:
@@ -169,7 +184,7 @@ class EmbeddingClient:
             response = self.client.embeddings.create(
                 model=self.model, input=code, encoding_format="float"
             )
-            cost = response.usage.total_tokens * get_model_price(self.model_name)
+            cost = _get_embedding_cost(response, self.model_name)
             # Extract embedding from response
             if single_code:
                 return response.data[0].embedding, cost
@@ -378,7 +393,7 @@ class AsyncEmbeddingClient:
         """
         self.model_name = model_name
         self.async_client, self.model = get_async_client_embed(model_name)
-        self.provider = get_provider(model_name)
+        self.provider = resolve_embedding_backend(model_name).provider
         self.verbose = verbose
 
     async def embed_async(
@@ -429,7 +444,7 @@ class AsyncEmbeddingClient:
             response = await self.async_client.embeddings.create(
                 model=self.model, input=code, encoding_format="float"
             )
-            cost = response.usage.total_tokens * get_model_price(self.model_name)
+            cost = _get_embedding_cost(response, self.model_name)
             if single_code:
                 return response.data[0].embedding, cost
             else:

--- a/tests/test_embedding_client_backends.py
+++ b/tests/test_embedding_client_backends.py
@@ -1,0 +1,78 @@
+import asyncio
+from types import SimpleNamespace
+
+import openai
+
+from shinka.embed.client import get_async_client_embed, get_client_embed
+from shinka.embed.embedding import AsyncEmbeddingClient, EmbeddingClient
+
+
+def test_get_client_embed_dynamic_openrouter(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+    client, model_name = get_client_embed("openrouter/qwen/qwen3-coder")
+
+    assert model_name == "qwen/qwen3-coder"
+    assert "openrouter.ai" in str(client.base_url)
+
+
+def test_get_async_client_embed_dynamic_openrouter(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+
+    client, model_name = get_async_client_embed("openrouter/qwen/qwen3-coder")
+
+    assert isinstance(client, openai.AsyncOpenAI)
+    assert model_name == "qwen/qwen3-coder"
+    assert "openrouter.ai" in str(client.base_url)
+
+
+def test_sync_openrouter_embedding_unknown_price_defaults_to_zero(monkeypatch):
+    fake_response = SimpleNamespace(
+        data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3])],
+        usage=SimpleNamespace(total_tokens=7),
+    )
+    fake_client = SimpleNamespace(
+        embeddings=SimpleNamespace(
+            create=lambda **kwargs: fake_response,
+        )
+    )
+
+    monkeypatch.setattr(
+        "shinka.embed.embedding.get_client_embed",
+        lambda model_name: (fake_client, "qwen/qwen3-coder"),
+    )
+
+    client = EmbeddingClient(model_name="openrouter/qwen/qwen3-coder")
+
+    embedding, cost = client.get_embedding("one two")
+
+    assert embedding == [0.1, 0.2, 0.3]
+    assert cost == 0.0
+
+
+def test_async_openrouter_embedding_unknown_price_defaults_to_zero(monkeypatch):
+    fake_response = SimpleNamespace(
+        data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3])],
+        usage=SimpleNamespace(total_tokens=7),
+    )
+
+    async def create(**kwargs):
+        return fake_response
+
+    fake_client = SimpleNamespace(
+        embeddings=SimpleNamespace(
+            create=create,
+        )
+    )
+
+    monkeypatch.setattr(
+        "shinka.embed.embedding.get_async_client_embed",
+        lambda model_name: (fake_client, "qwen/qwen3-coder"),
+    )
+
+    client = AsyncEmbeddingClient(model_name="openrouter/qwen/qwen3-coder")
+
+    embedding, cost = asyncio.run(client.embed_async("one two"))
+
+    assert embedding == [0.1, 0.2, 0.3]
+    assert cost == 0.0


### PR DESCRIPTION
## Summary
- add embedding-side backend resolution for dynamic `openrouter/<model>` IDs
- strip the `openrouter/` prefix before embedding API calls
- use `AsyncOpenAI` for async OpenRouter embeddings
- default dynamic embedding cost to `0.0` when pricing metadata is unavailable instead of failing the embedding call
- add regression tests for sync/async OpenRouter embedding clients

## Why
Issue #94 correctly identified the forwarded model-name mismatch, but the embedding path was failing earlier too because dynamic OpenRouter embedding IDs were not resolved at all.

Fixes #94.

## Testing
- `pytest tests/test_embedding_client_backends.py tests/test_gemini_embedding_integration.py tests/test_llm_client_backends.py tests/test_model_resolver.py -q`
- `ruff check shinka/embed/client.py shinka/embed/embedding.py tests/test_embedding_client_backends.py`
- `ruff format --check shinka/embed/client.py shinka/embed/embedding.py tests/test_embedding_client_backends.py`

## Notes
- `pytest -q` in this local environment is blocked by unrelated collection failure in `tests/test_packaging_release.py` because the interpreter is Python 3.9 and lacks `tomllib`.
- `mypy shinka/embed/client.py shinka/embed/embedding.py` reports pre-existing repo/environment typing issues, including missing third-party stubs.
