### PR TITLE
fix: improve async runtime scaling and benchmark presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 results/
 results*
 shinka_scale*
+!examples/circle_packing/shinka_scale*.yaml
 examples/mnist_train/
 
 # C extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `shinka-evolve` are documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Improved local async runtime scaling by launching evaluation subprocesses with the active project interpreter, capping per-process numeric-library thread fan-out, and reducing local monitor polling latency.
+- Moved prompt-fitness percentile recomputation off the prompt side-effect hot path and onto a debounced background task using fresh read-only database connections.
+- Updated the circle-packing scaling presets to run for `100` generations and reduced `max_patch_resamples` to `1` for the small / medium / large benchmark configs.
+
+### Fixed
+
+- Fixed adaptive proposal targeting so invalid `proposal_target_hard_cap` values below evaluation capacity no longer silently disable oversubscription.
+- Fixed prompt-percentile background refresh to avoid SQLite thread-affinity failures when recomputing prompt fitness during async runs.
+
 ## 0.0.3 - 2026-04-04
 
 ### Added

--- a/examples/circle_packing/shinka_scale_large.yaml
+++ b/examples/circle_packing/shinka_scale_large.yaml
@@ -1,0 +1,170 @@
+# Throughput-scaling benchmark config.
+# Keep all non-concurrency settings identical across this matrix.
+# Do not compare this file against shinka_long.yaml for scaling conclusions.
+
+# Number of evaluation jobs to run in parallel.
+max_evaluation_jobs: 20
+# Number of proposal-generation jobs to run in parallel.
+max_proposal_jobs: 28
+# Number of database worker jobs handling archive/selection updates.
+max_db_workers: 4
+
+# Database/search-state settings for island evolution and archiving.
+db_config:
+  # Number of independent evolutionary islands.
+  num_islands: 1
+  # Maximum number of individuals stored in the archive.
+  archive_size: 40
+  # Fraction of top performers treated as elites.
+  elite_selection_ratio: 0.3
+  # Number of archive examples sampled as inspirations per proposal.
+  num_archive_inspirations: 1
+  # Number of highest-ranked inspirations forced into the sample.
+  num_top_k_inspirations: 1
+  # Generations between migration events across islands.
+  migration_interval: 10
+  # Fraction of candidates migrated at each migration event.
+  migration_rate: 0.1
+  # Whether to preserve elite individuals within each island.
+  island_elitism: true
+  # Whether to prevent cross-island mixing outside migration rules.
+  enforce_island_separation: true
+  # Strategy used to sample parents for mutation/crossover.
+  parent_selection_strategy: weighted
+  # Temperature/strength parameter for weighted parent selection.
+  parent_selection_lambda: 10
+  # Strategy used when picking entries from the archive.
+  archive_selection_strategy: "crowding"
+  # Strategy used when selecting which island to sample from.
+  island_selection_strategy: equal
+  # Weights for archive ranking criteria.
+  archive_criteria:
+    # Weight assigned to combined task score.
+    combined_score: 1.0
+    # Weight assigned to lines-of-code (negative favors shorter code).
+    loc: -0.3
+
+  # Whether to spawn new islands dynamically on stagnation.
+  enable_dynamic_islands: false
+  # Number of generations without progress before stagnation triggers.
+  stagnation_threshold: 10
+  # Strategy for choosing a seed when spawning a new island.
+  island_spawn_strategy: "best"
+  # Subtree size used when constructing a spawned island lineage.
+  island_spawn_subtree_size: 2
+
+# Evolution loop settings (mutation, model calls, novelty, outputs).
+evo_config:
+  # Allowed patch formats for code evolution.
+  patch_types:
+    - diff
+    - full
+    - cross
+  # Sampling probabilities aligned with patch_types order.
+  patch_type_probs:
+    - 0.6
+    - 0.3
+    - 0.1
+  # Total number of generations to run.
+  num_generations: 100
+  # Max API spend budget for this run (USD).
+  max_api_costs: 5.0
+  # Retries for resampling patch format/content before giving up.
+  max_patch_resamples: 1
+  # Retries for patch application/generation attempts.
+  max_patch_attempts: 1
+  # Retries for novelty-evaluation attempts.
+  max_novelty_attempts: 1
+  # Job executor backend.
+  job_type: local
+  # Programming language of evolved programs.
+  language: python
+  # Candidate LLMs used for proposal generation.
+  llm_models:
+    - "gemini-3-flash-preview"
+    - "gpt-5.4-mini"
+    - "gpt-5.4-nano"
+  # Shared generation kwargs for main proposal LLM calls.
+  llm_kwargs:
+    # Candidate temperatures to sample for generation diversity.
+    temperatures:
+      - 0
+      - 0.5
+      - 1.0
+    # Candidate reasoning effort levels for supported models.
+    reasoning_efforts:
+        - low
+        - medium
+    # Maximum output tokens per main LLM response.
+    max_tokens: 32768
+  # Enable bounded adaptive proposal oversubscription.
+  enable_controlled_oversubscription: true
+  # Proposal-target controller mode.
+  proposal_target_mode: adaptive
+  # Minimum completed timing samples before adaptive targeting kicks in.
+  proposal_target_min_samples: 5
+  # Maximum sampling/evaluation ratio used by the controller.
+  proposal_target_ratio_cap: 2.0
+  # Maximum extra proposals beyond evaluation concurrency.
+  proposal_buffer_max: 2
+  # Absolute cap for adaptive proposal target.
+  proposal_target_hard_cap: 22
+  # EWMA smoothing factor for proposal/eval timing estimates.
+  proposal_target_ewma_alpha: 0.3
+
+  # Interval (in generations) for meta-recommendation updates.
+  meta_rec_interval: 5
+  # LLMs used for meta-analysis/recommendation steps.
+  meta_llm_models:
+    - gpt-5.4-mini
+  # Generation kwargs for meta-analysis LLM calls.
+  meta_llm_kwargs:
+    # Temperatures used for meta-analysis calls.
+    temperatures:
+      - 0
+    # Maximum output tokens per meta-analysis response.
+    max_tokens: 16384
+
+  # Embedding model used for code similarity filtering.
+  embedding_model: text-embedding-3-small
+  # Similarity threshold above which code is treated as near-duplicate.
+  code_embed_sim_threshold: 0.99
+
+  # LLMs used for novelty checking/judgment.
+  novelty_llm_models:
+    - gpt-5.4-nano
+  # Generation kwargs for novelty LLM calls.
+  novelty_llm_kwargs:
+    # Temperatures used for novelty calls.
+    temperatures:
+      - 0
+  # Path to the initial baseline program.
+  init_program_path: initial.py
+
+  # Adaptive policy for choosing among available LLMs.
+  llm_dynamic_selection: ucb1
+  # Hyperparameters for the dynamic LLM selection policy.
+  llm_dynamic_selection_kwargs:
+    # Exploration strength in UCB-style model selection.
+    exploration_coef: 1.0
+    # Cost-penalty weight in model-selection scoring.
+    cost_aware_coef: 0.7
+  # Directory where run outputs, logs, and artifacts are written.
+  results_dir: results/results_circle_scale_large
+
+  # Whether prompt variants are evolved during the run.
+  evolve_prompts: True
+  # Interval (in generations) between prompt-evolution steps.
+  prompt_evolution_interval: 5
+  # Allowed patch formats when mutating prompts.
+  prompt_patch_types: ["diff", "full"]
+  # Sampling probabilities aligned with prompt_patch_types order.
+  prompt_patch_type_probs: [0.5, 0.5]
+  # Maximum number of prompt variants kept in the prompt archive.
+  prompt_archive_size: 10
+  # Interval (in generations) for recomputing prompt percentiles.
+  prompt_percentile_recompute_interval: 1
+  # UCB exploration constant for prompt selection.
+  prompt_ucb_exploration_constant: 2.0
+  # Epsilon-greedy random selection probability for prompt exploration.
+  prompt_epsilon: 0.25

--- a/examples/circle_packing/shinka_scale_medium.yaml
+++ b/examples/circle_packing/shinka_scale_medium.yaml
@@ -1,0 +1,170 @@
+# Throughput-scaling benchmark config.
+# Keep all non-concurrency settings identical across this matrix.
+# Do not compare this file against shinka_long.yaml for scaling conclusions.
+
+# Number of evaluation jobs to run in parallel.
+max_evaluation_jobs: 10
+# Number of proposal-generation jobs to run in parallel.
+max_proposal_jobs: 14
+# Number of database worker jobs handling archive/selection updates.
+max_db_workers: 4
+
+# Database/search-state settings for island evolution and archiving.
+db_config:
+  # Number of independent evolutionary islands.
+  num_islands: 1
+  # Maximum number of individuals stored in the archive.
+  archive_size: 40
+  # Fraction of top performers treated as elites.
+  elite_selection_ratio: 0.3
+  # Number of archive examples sampled as inspirations per proposal.
+  num_archive_inspirations: 1
+  # Number of highest-ranked inspirations forced into the sample.
+  num_top_k_inspirations: 1
+  # Generations between migration events across islands.
+  migration_interval: 10
+  # Fraction of candidates migrated at each migration event.
+  migration_rate: 0.1
+  # Whether to preserve elite individuals within each island.
+  island_elitism: true
+  # Whether to prevent cross-island mixing outside migration rules.
+  enforce_island_separation: true
+  # Strategy used to sample parents for mutation/crossover.
+  parent_selection_strategy: weighted
+  # Temperature/strength parameter for weighted parent selection.
+  parent_selection_lambda: 10
+  # Strategy used when picking entries from the archive.
+  archive_selection_strategy: "crowding"
+  # Strategy used when selecting which island to sample from.
+  island_selection_strategy: equal
+  # Weights for archive ranking criteria.
+  archive_criteria:
+    # Weight assigned to combined task score.
+    combined_score: 1.0
+    # Weight assigned to lines-of-code (negative favors shorter code).
+    loc: -0.3
+
+  # Whether to spawn new islands dynamically on stagnation.
+  enable_dynamic_islands: false
+  # Number of generations without progress before stagnation triggers.
+  stagnation_threshold: 10
+  # Strategy for choosing a seed when spawning a new island.
+  island_spawn_strategy: "best"
+  # Subtree size used when constructing a spawned island lineage.
+  island_spawn_subtree_size: 2
+
+# Evolution loop settings (mutation, model calls, novelty, outputs).
+evo_config:
+  # Allowed patch formats for code evolution.
+  patch_types:
+    - diff
+    - full
+    - cross
+  # Sampling probabilities aligned with patch_types order.
+  patch_type_probs:
+    - 0.6
+    - 0.3
+    - 0.1
+  # Total number of generations to run.
+  num_generations: 100
+  # Max API spend budget for this run (USD).
+  max_api_costs: 5.0
+  # Retries for resampling patch format/content before giving up.
+  max_patch_resamples: 1
+  # Retries for patch application/generation attempts.
+  max_patch_attempts: 1
+  # Retries for novelty-evaluation attempts.
+  max_novelty_attempts: 1
+  # Job executor backend.
+  job_type: local
+  # Programming language of evolved programs.
+  language: python
+  # Candidate LLMs used for proposal generation.
+  llm_models:
+    - "gemini-3-flash-preview"
+    - "gpt-5.4-mini"
+    - "gpt-5.4-nano"
+  # Shared generation kwargs for main proposal LLM calls.
+  llm_kwargs:
+    # Candidate temperatures to sample for generation diversity.
+    temperatures:
+      - 0
+      - 0.5
+      - 1.0
+    # Candidate reasoning effort levels for supported models.
+    reasoning_efforts:
+        - low
+        - medium
+    # Maximum output tokens per main LLM response.
+    max_tokens: 32768
+  # Enable bounded adaptive proposal oversubscription.
+  enable_controlled_oversubscription: true
+  # Proposal-target controller mode.
+  proposal_target_mode: adaptive
+  # Minimum completed timing samples before adaptive targeting kicks in.
+  proposal_target_min_samples: 5
+  # Maximum sampling/evaluation ratio used by the controller.
+  proposal_target_ratio_cap: 2.0
+  # Maximum extra proposals beyond evaluation concurrency.
+  proposal_buffer_max: 2
+  # Absolute cap for adaptive proposal target.
+  proposal_target_hard_cap: 12
+  # EWMA smoothing factor for proposal/eval timing estimates.
+  proposal_target_ewma_alpha: 0.3
+
+  # Interval (in generations) for meta-recommendation updates.
+  meta_rec_interval: 5
+  # LLMs used for meta-analysis/recommendation steps.
+  meta_llm_models:
+    - gpt-5.4-mini
+  # Generation kwargs for meta-analysis LLM calls.
+  meta_llm_kwargs:
+    # Temperatures used for meta-analysis calls.
+    temperatures:
+      - 0
+    # Maximum output tokens per meta-analysis response.
+    max_tokens: 16384
+
+  # Embedding model used for code similarity filtering.
+  embedding_model: text-embedding-3-small
+  # Similarity threshold above which code is treated as near-duplicate.
+  code_embed_sim_threshold: 0.99
+
+  # LLMs used for novelty checking/judgment.
+  novelty_llm_models:
+    - gpt-5.4-nano
+  # Generation kwargs for novelty LLM calls.
+  novelty_llm_kwargs:
+    # Temperatures used for novelty calls.
+    temperatures:
+      - 0
+  # Path to the initial baseline program.
+  init_program_path: initial.py
+
+  # Adaptive policy for choosing among available LLMs.
+  llm_dynamic_selection: ucb1
+  # Hyperparameters for the dynamic LLM selection policy.
+  llm_dynamic_selection_kwargs:
+    # Exploration strength in UCB-style model selection.
+    exploration_coef: 1.0
+    # Cost-penalty weight in model-selection scoring.
+    cost_aware_coef: 0.7
+  # Directory where run outputs, logs, and artifacts are written.
+  results_dir: results/results_circle_scale_medium
+
+  # Whether prompt variants are evolved during the run.
+  evolve_prompts: True
+  # Interval (in generations) between prompt-evolution steps.
+  prompt_evolution_interval: 5
+  # Allowed patch formats when mutating prompts.
+  prompt_patch_types: ["diff", "full"]
+  # Sampling probabilities aligned with prompt_patch_types order.
+  prompt_patch_type_probs: [0.5, 0.5]
+  # Maximum number of prompt variants kept in the prompt archive.
+  prompt_archive_size: 10
+  # Interval (in generations) for recomputing prompt percentiles.
+  prompt_percentile_recompute_interval: 1
+  # UCB exploration constant for prompt selection.
+  prompt_ucb_exploration_constant: 2.0
+  # Epsilon-greedy random selection probability for prompt exploration.
+  prompt_epsilon: 0.25

--- a/examples/circle_packing/shinka_scale_small.yaml
+++ b/examples/circle_packing/shinka_scale_small.yaml
@@ -1,0 +1,170 @@
+# Throughput-scaling benchmark config.
+# Keep all non-concurrency settings identical across this matrix.
+# Do not compare this file against shinka_long.yaml for scaling conclusions.
+
+# Number of evaluation jobs to run in parallel.
+max_evaluation_jobs: 5
+# Number of proposal-generation jobs to run in parallel.
+max_proposal_jobs: 7
+# Number of database worker jobs handling archive/selection updates.
+max_db_workers: 4
+
+# Database/search-state settings for island evolution and archiving.
+db_config:
+  # Number of independent evolutionary islands.
+  num_islands: 1
+  # Maximum number of individuals stored in the archive.
+  archive_size: 40
+  # Fraction of top performers treated as elites.
+  elite_selection_ratio: 0.3
+  # Number of archive examples sampled as inspirations per proposal.
+  num_archive_inspirations: 1
+  # Number of highest-ranked inspirations forced into the sample.
+  num_top_k_inspirations: 1
+  # Generations between migration events across islands.
+  migration_interval: 10
+  # Fraction of candidates migrated at each migration event.
+  migration_rate: 0.1
+  # Whether to preserve elite individuals within each island.
+  island_elitism: true
+  # Whether to prevent cross-island mixing outside migration rules.
+  enforce_island_separation: true
+  # Strategy used to sample parents for mutation/crossover.
+  parent_selection_strategy: weighted
+  # Temperature/strength parameter for weighted parent selection.
+  parent_selection_lambda: 10
+  # Strategy used when picking entries from the archive.
+  archive_selection_strategy: "crowding"
+  # Strategy used when selecting which island to sample from.
+  island_selection_strategy: equal
+  # Weights for archive ranking criteria.
+  archive_criteria:
+    # Weight assigned to combined task score.
+    combined_score: 1.0
+    # Weight assigned to lines-of-code (negative favors shorter code).
+    loc: -0.3
+
+  # Whether to spawn new islands dynamically on stagnation.
+  enable_dynamic_islands: false
+  # Number of generations without progress before stagnation triggers.
+  stagnation_threshold: 10
+  # Strategy for choosing a seed when spawning a new island.
+  island_spawn_strategy: "best"
+  # Subtree size used when constructing a spawned island lineage.
+  island_spawn_subtree_size: 2
+
+# Evolution loop settings (mutation, model calls, novelty, outputs).
+evo_config:
+  # Allowed patch formats for code evolution.
+  patch_types:
+    - diff
+    - full
+    - cross
+  # Sampling probabilities aligned with patch_types order.
+  patch_type_probs:
+    - 0.6
+    - 0.3
+    - 0.1
+  # Total number of generations to run.
+  num_generations: 100
+  # Max API spend budget for this run (USD).
+  max_api_costs: 5.0
+  # Retries for resampling patch format/content before giving up.
+  max_patch_resamples: 1
+  # Retries for patch application/generation attempts.
+  max_patch_attempts: 1
+  # Retries for novelty-evaluation attempts.
+  max_novelty_attempts: 1
+  # Job executor backend.
+  job_type: local
+  # Programming language of evolved programs.
+  language: python
+  # Candidate LLMs used for proposal generation.
+  llm_models:
+    - "gemini-3-flash-preview"
+    - "gpt-5.4-mini"
+    - "gpt-5.4-nano"
+  # Shared generation kwargs for main proposal LLM calls.
+  llm_kwargs:
+    # Candidate temperatures to sample for generation diversity.
+    temperatures:
+      - 0
+      - 0.5
+      - 1.0
+    # Candidate reasoning effort levels for supported models.
+    reasoning_efforts:
+        - low
+        - medium
+    # Maximum output tokens per main LLM response.
+    max_tokens: 32768
+  # Enable bounded adaptive proposal oversubscription.
+  enable_controlled_oversubscription: true
+  # Proposal-target controller mode.
+  proposal_target_mode: adaptive
+  # Minimum completed timing samples before adaptive targeting kicks in.
+  proposal_target_min_samples: 5
+  # Maximum sampling/evaluation ratio used by the controller.
+  proposal_target_ratio_cap: 2.0
+  # Maximum extra proposals beyond evaluation concurrency.
+  proposal_buffer_max: 2
+  # Absolute cap for adaptive proposal target.
+  proposal_target_hard_cap: 7
+  # EWMA smoothing factor for proposal/eval timing estimates.
+  proposal_target_ewma_alpha: 0.3
+
+  # Interval (in generations) for meta-recommendation updates.
+  meta_rec_interval: 5
+  # LLMs used for meta-analysis/recommendation steps.
+  meta_llm_models:
+    - gpt-5.4-mini
+  # Generation kwargs for meta-analysis LLM calls.
+  meta_llm_kwargs:
+    # Temperatures used for meta-analysis calls.
+    temperatures:
+      - 0
+    # Maximum output tokens per meta-analysis response.
+    max_tokens: 16384
+
+  # Embedding model used for code similarity filtering.
+  embedding_model: text-embedding-3-small
+  # Similarity threshold above which code is treated as near-duplicate.
+  code_embed_sim_threshold: 0.99
+
+  # LLMs used for novelty checking/judgment.
+  novelty_llm_models:
+    - gpt-5.4-nano
+  # Generation kwargs for novelty LLM calls.
+  novelty_llm_kwargs:
+    # Temperatures used for novelty calls.
+    temperatures:
+      - 0
+  # Path to the initial baseline program.
+  init_program_path: initial.py
+
+  # Adaptive policy for choosing among available LLMs.
+  llm_dynamic_selection: ucb1
+  # Hyperparameters for the dynamic LLM selection policy.
+  llm_dynamic_selection_kwargs:
+    # Exploration strength in UCB-style model selection.
+    exploration_coef: 1.0
+    # Cost-penalty weight in model-selection scoring.
+    cost_aware_coef: 0.7
+  # Directory where run outputs, logs, and artifacts are written.
+  results_dir: results/results_circle_scale_small
+
+  # Whether prompt variants are evolved during the run.
+  evolve_prompts: True
+  # Interval (in generations) between prompt-evolution steps.
+  prompt_evolution_interval: 5
+  # Allowed patch formats when mutating prompts.
+  prompt_patch_types: ["diff", "full"]
+  # Sampling probabilities aligned with prompt_patch_types order.
+  prompt_patch_type_probs: [0.5, 0.5]
+  # Maximum number of prompt variants kept in the prompt archive.
+  prompt_archive_size: 10
+  # Interval (in generations) for recomputing prompt percentiles.
+  prompt_percentile_recompute_interval: 1
+  # UCB exploration constant for prompt selection.
+  prompt_ucb_exploration_constant: 2.0
+  # Epsilon-greedy random selection probability for prompt exploration.
+  prompt_epsilon: 0.25

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -37,7 +37,7 @@ from shinka.llm import (
     ThompsonSampler,
 )
 from shinka.embed import AsyncEmbeddingClient
-from shinka.launch import JobScheduler, JobConfig
+from shinka.launch import JobScheduler, JobConfig, LocalJobConfig
 from shinka.edit.async_apply import (
     apply_patch_async,
     get_code_embedding_async,
@@ -281,6 +281,7 @@ class ShinkaEvolveRunner:
         self.max_evaluation_jobs = max_evaluation_jobs
         self.max_proposal_jobs = max_proposal_jobs
         self.max_db_workers = max_db_workers
+        self._configure_local_job_runtime(cpu_count)
 
         if self.evo_config.num_generations is None:
             assert self.evo_config.max_api_costs is not None, (
@@ -481,6 +482,8 @@ class ShinkaEvolveRunner:
         self._meta_side_effect_lock = asyncio.Lock()
         self._prompt_side_effect_lock = asyncio.Lock()
         self._best_solution_lock = asyncio.Lock()
+        self._prompt_percentile_recompute_task: Optional[asyncio.Task] = None
+        self._prompt_percentile_recompute_pending = False
 
         # Database retry mechanism
         self.failed_jobs_for_retry: Dict[
@@ -635,6 +638,20 @@ class ShinkaEvolveRunner:
 
         return max_evaluation_jobs, max_proposal_jobs, max_db_workers
 
+    def _configure_local_job_runtime(self, cpu_count: int) -> None:
+        """Tune local evaluation subprocess runtime defaults for scaling."""
+        if not isinstance(self.job_config, LocalJobConfig):
+            return
+
+        if self.job_config.numeric_threads_per_job is None:
+            numeric_threads = max(1, cpu_count // max(1, self.max_evaluation_jobs))
+            self.job_config.numeric_threads_per_job = numeric_threads
+            if self.verbose:
+                logger.info(
+                    "Configured local numeric thread cap per eval process: %s",
+                    numeric_threads,
+                )
+
     async def _get_total_api_costs(self) -> float:
         """Calculate total API costs from all programs and prompt evolution."""
 
@@ -769,6 +786,18 @@ class ShinkaEvolveRunner:
 
         buffer_max = max(0, getattr(self.evo_config, "proposal_buffer_max", 0))
         hard_cap = getattr(self.evo_config, "proposal_target_hard_cap", None)
+        if hard_cap is not None and hard_cap < base_target:
+            if not getattr(
+                self, "_warned_invalid_proposal_target_hard_cap", False
+            ):
+                logger.warning(
+                    "Ignoring proposal_target_hard_cap=%s because it is below "
+                    "max_evaluation_jobs=%s and would disable oversubscription.",
+                    hard_cap,
+                    base_target,
+                )
+                self._warned_invalid_proposal_target_hard_cap = True
+            hard_cap = None
         effective_hard_cap = (
             self.max_proposal_jobs
             if hard_cap is None
@@ -889,6 +918,11 @@ class ShinkaEvolveRunner:
                     )
                 await self._wait_for_background_side_effects()
             await self._shutdown_background_side_effect_worker()
+            if self._prompt_percentile_recompute_task is not None:
+                await asyncio.gather(
+                    self._prompt_percentile_recompute_task,
+                    return_exceptions=True,
+                )
 
             # Perform final operations before cleanup
             if self.verbose:
@@ -1221,37 +1255,87 @@ class ShinkaEvolveRunner:
                 and self.prompt_percentile_recompute_counter >= recompute_interval
             ):
                 self.prompt_percentile_recompute_counter = 0
-                try:
-                    # Get all correct program scores from main database
-                    # This matches what the webUI uses for beat percentage calculation
-                    all_programs = self.db.get_all_programs()
-                    all_correct_scores = [
-                        p.combined_score
-                        for p in all_programs
-                        if p.correct and p.combined_score is not None
-                    ]
-                    # Build mapping from program_id to current score
-                    # This ensures we use actual current scores, not stale stored ones
-                    program_id_to_score = {
-                        p.id: p.combined_score
-                        for p in all_programs
-                        if p.correct and p.combined_score is not None
-                    }
-                    self.prompt_db.recompute_all_percentiles(
-                        all_correct_scores, program_id_to_score
-                    )
-                    logger.info(
-                        f"Recomputed prompt fitness percentiles "
-                        f"(every {recompute_interval} programs, "
-                        f"using {len(all_correct_scores)} correct program scores)"
-                    )
-                except Exception as recompute_err:
-                    logger.warning(
-                        f"Failed to recompute prompt percentiles: {recompute_err}"
-                    )
+                self._schedule_prompt_percentile_recompute(recompute_interval)
 
         except Exception as e:
             logger.error(f"Failed to update prompt fitness: {e}")
+
+    def _schedule_prompt_percentile_recompute(self, recompute_interval: int) -> None:
+        """Debounce global prompt percentile recomputation onto a background task."""
+        if not self.prompt_db:
+            return
+
+        task = self._prompt_percentile_recompute_task
+        if task is not None and not task.done():
+            self._prompt_percentile_recompute_pending = True
+            return
+
+        self._prompt_percentile_recompute_pending = False
+        self._prompt_percentile_recompute_task = asyncio.create_task(
+            self._recompute_prompt_percentiles_async(recompute_interval),
+            name="prompt_percentile_recompute",
+        )
+
+    async def _recompute_prompt_percentiles_async(self, recompute_interval: int) -> None:
+        """Refresh prompt fitness percentiles without blocking side-effect workers."""
+        try:
+            loop = asyncio.get_event_loop()
+            if hasattr(self.db, "config"):
+
+                def load_program_scores_thread_safe() -> Tuple[List[float], Dict[str, float]]:
+                    thread_db = None
+                    try:
+                        thread_db = ProgramDatabase(self.db.config, read_only=True)
+                        all_programs = thread_db.get_all_programs()
+                        all_correct_scores = [
+                            p.combined_score
+                            for p in all_programs
+                            if p.correct and p.combined_score is not None
+                        ]
+                        program_id_to_score = {
+                            p.id: p.combined_score
+                            for p in all_programs
+                            if p.correct and p.combined_score is not None
+                        }
+                        return all_correct_scores, program_id_to_score
+                    finally:
+                        if thread_db is not None:
+                            thread_db.close()
+
+                all_correct_scores, program_id_to_score = await loop.run_in_executor(
+                    None, load_program_scores_thread_safe
+                )
+            else:
+                all_programs = self.db.get_all_programs()
+                all_correct_scores = [
+                    p.combined_score
+                    for p in all_programs
+                    if p.correct and p.combined_score is not None
+                ]
+                program_id_to_score = {
+                    p.id: p.combined_score
+                    for p in all_programs
+                    if p.correct and p.combined_score is not None
+                }
+            self.prompt_db.recompute_all_percentiles(
+                all_correct_scores, program_id_to_score
+            )
+            logger.info(
+                "Recomputed prompt fitness percentiles "
+                "(every %s programs, using %s correct program scores)",
+                recompute_interval,
+                len(all_correct_scores),
+            )
+        except Exception as recompute_err:
+            logger.warning(
+                "Failed to recompute prompt percentiles: %s", recompute_err
+            )
+        finally:
+            rerun_requested = self._prompt_percentile_recompute_pending
+            self._prompt_percentile_recompute_pending = False
+            self._prompt_percentile_recompute_task = None
+            if rerun_requested:
+                self._schedule_prompt_percentile_recompute(recompute_interval)
 
     async def _maybe_evolve_prompt(self):
         """

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -3,7 +3,7 @@ import time
 import threading
 import os
 from pathlib import Path
-from typing import Optional, Tuple, TextIO
+from typing import Optional, Tuple, TextIO, Dict
 from shinka.utils import load_results, parse_time_to_seconds
 import logging
 
@@ -71,7 +71,12 @@ def _stream_output(pipe, file_handle, verbose_prefix=None):
         pipe.close()
 
 
-def submit(log_dir: str, cmd: list[str], verbose: bool = False):
+def submit(
+    log_dir: str,
+    cmd: list[str],
+    verbose: bool = False,
+    env_overrides: Optional[Dict[str, str]] = None,
+):
     """
     Submits a command for local execution with real-time logging.
 
@@ -93,6 +98,8 @@ def submit(log_dir: str, cmd: list[str], verbose: bool = False):
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"  # Force Python to be unbuffered
     env["PYTHONIOENCODING"] = "utf-8"  # Ensure proper encoding
+    if env_overrides:
+        env.update(env_overrides)
 
     # Use PIPE to capture output and redirect to files in real-time
     process = subprocess.Popen(
@@ -138,7 +145,7 @@ def submit(log_dir: str, cmd: list[str], verbose: bool = False):
 def monitor(
     process: ProcessWithLogging,
     results_dir: str,
-    poll_interval: int = 10,
+    poll_interval: float = 0.5,
     verbose: bool = False,
     timeout: Optional[str] = None,
 ):

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -2,6 +2,7 @@ import logging
 import time
 import asyncio
 import shlex
+import sys
 from dataclasses import dataclass, asdict, field
 from typing import Optional, Dict, Any, Tuple, Union, List
 from concurrent.futures import ThreadPoolExecutor
@@ -49,6 +50,8 @@ class LocalJobConfig(JobConfig):
     time: Optional[str] = None
     conda_env: Optional[str] = None
     activate_script: Optional[str] = None
+    python_executable: Optional[str] = None
+    numeric_threads_per_job: Optional[int] = None
 
     def __post_init__(self) -> None:
         _validate_activation_config(self.conda_env, self.activate_script)
@@ -120,6 +123,16 @@ class JobScheduler:
             )
 
     def _build_command(self, exec_fname_t: str, results_dir_t: str) -> List[str]:
+        python_executable = "python"
+        if self.job_type == "local" and isinstance(self.config, LocalJobConfig):
+            if not (
+                _has_value(self.config.conda_env)
+                or _has_value(self.config.activate_script)
+            ):
+                python_executable = (
+                    self.config.python_executable or sys.executable or "python"
+                )
+
         if self.job_type == "slurm_docker":
             assert isinstance(self.config, SlurmDockerJobConfig)
             python_cmd = [
@@ -132,7 +145,7 @@ class JobScheduler:
             ]
         else:
             python_cmd = [
-                "python",
+                python_executable,
                 f"{self.config.eval_program_path}",
                 "--program_path",
                 f"{exec_fname_t}",
@@ -162,6 +175,32 @@ class JobScheduler:
 
         return python_cmd
 
+    def _build_local_env_overrides(self) -> Optional[Dict[str, str]]:
+        """Build environment overrides for local evaluation subprocesses."""
+        if self.job_type != "local" or not isinstance(self.config, LocalJobConfig):
+            return None
+
+        numeric_threads = self.config.numeric_threads_per_job
+        if numeric_threads is None:
+            return None
+
+        normalized_threads = max(1, int(numeric_threads))
+        thread_value = str(normalized_threads)
+        return {
+            "OMP_NUM_THREADS": thread_value,
+            "OMP_THREAD_LIMIT": thread_value,
+            "OMP_DYNAMIC": "FALSE",
+            "OMP_WAIT_POLICY": "PASSIVE",
+            "OPENBLAS_NUM_THREADS": thread_value,
+            "MKL_NUM_THREADS": thread_value,
+            "MKL_DYNAMIC": "FALSE",
+            "NUMEXPR_NUM_THREADS": thread_value,
+            "NUMEXPR_MAX_THREADS": thread_value,
+            "VECLIB_MAXIMUM_THREADS": thread_value,
+            "BLIS_NUM_THREADS": thread_value,
+            "GOTO_NUM_THREADS": thread_value,
+        }
+
     def run(
         self, exec_fname_t: str, results_dir_t: str
     ) -> Tuple[Dict[str, Any], float]:
@@ -171,7 +210,12 @@ class JobScheduler:
 
         if self.job_type == "local":
             assert isinstance(self.config, LocalJobConfig)
-            job_id = submit_local(results_dir_t, cmd, verbose=self.verbose)
+            job_id = submit_local(
+                results_dir_t,
+                cmd,
+                verbose=self.verbose,
+                env_overrides=self._build_local_env_overrides(),
+            )
         elif self.job_type == "slurm_docker":
             assert isinstance(self.config, SlurmDockerJobConfig)
             job_id = submit_slurm_docker(
@@ -226,7 +270,12 @@ class JobScheduler:
         cmd = self._build_command(exec_fname_t, results_dir_t)
         if self.job_type == "local":
             assert isinstance(self.config, LocalJobConfig)
-            return submit_local(results_dir_t, cmd, verbose=self.verbose)
+            return submit_local(
+                results_dir_t,
+                cmd,
+                verbose=self.verbose,
+                env_overrides=self._build_local_env_overrides(),
+            )
         elif self.job_type == "slurm_docker":
             assert isinstance(self.config, SlurmDockerJobConfig)
             return submit_slurm_docker(

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -148,6 +148,13 @@ def _build_runner(**overrides):
     runner._evaluation_seconds_ewma = overrides.get("evaluation_ewma")
     runner.verbose = overrides.get("verbose", False)
     runner.cost_limit_reached = overrides.get("cost_limit_reached", False)
+    runner.prompt_db = overrides.get("prompt_db")
+    runner._prompt_percentile_recompute_task = overrides.get(
+        "_prompt_percentile_recompute_task"
+    )
+    runner._prompt_percentile_recompute_pending = overrides.get(
+        "_prompt_percentile_recompute_pending", False
+    )
     return runner
 
 
@@ -682,6 +689,8 @@ def test_update_prompt_fitness_only_recomputes_after_correct_programs():
             improvement=0.2,
             correct=True,
         )
+        if runner._prompt_percentile_recompute_task is not None:
+            await runner._prompt_percentile_recompute_task
 
         assert len(prompt_db.update_calls) == 3
         assert len(prompt_db.recompute_calls) == 1

--- a/tests/test_pipeline_timing.py
+++ b/tests/test_pipeline_timing.py
@@ -12,6 +12,7 @@ from shinka.core.pipeline_timing import (
 )
 from shinka.core.runtime_slots import LogicalSlotPool
 from shinka.database import Program
+from shinka.launch import LocalJobConfig
 
 
 def test_with_pipeline_timing_adds_boundaries_and_durations():
@@ -58,6 +59,17 @@ def test_with_pipeline_timing_clamps_negative_stage_durations():
     assert metadata["pipeline_accounted_seconds"] == 0.0
     assert metadata["pipeline_seconds"] == 0.0
     assert metadata["pipeline_unaccounted_seconds"] == 0.0
+
+
+def test_configure_local_job_runtime_sets_numeric_thread_cap_from_eval_concurrency():
+    runner = object.__new__(ShinkaEvolveRunner)
+    runner.job_config = LocalJobConfig()
+    runner.max_evaluation_jobs = 10
+    runner.verbose = False
+
+    runner._configure_local_job_runtime(cpu_count=32)
+
+    assert runner.job_config.numeric_threads_per_job == 3
 
 
 def test_with_side_effect_timing_adds_wait_and_end_to_end_fields():

--- a/tests/test_proposal_oversubscription.py
+++ b/tests/test_proposal_oversubscription.py
@@ -63,6 +63,22 @@ def test_compute_proposal_pipeline_target_respects_disable_flag():
     assert target == 5
 
 
+def test_compute_proposal_pipeline_target_ignores_invalid_hard_cap_below_eval_capacity():
+    runner = _build_runner(
+        sampling_ewma=120.0,
+        evaluation_ewma=60.0,
+        timing_samples=8,
+        proposal_buffer_max=2,
+        max_evaluation_jobs=10,
+        max_proposal_jobs=14,
+        proposal_target_hard_cap=7,
+    )
+
+    target = runner._compute_proposal_pipeline_target()
+
+    assert target == 12
+
+
 def test_record_oversubscription_timing_sample_uses_ewma():
     runner = _build_runner()
 

--- a/tests/test_scheduler_env_activation.py
+++ b/tests/test_scheduler_env_activation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import subprocess
+import sys
 
 import pytest
 
@@ -114,6 +115,36 @@ def test_job_scheduler_builds_local_sourced_command() -> None:
     assert cmd[0:2] == ["bash", "-lc"]
     assert 'source ".venv/bin/activate"' in cmd[2]
     assert "evaluate.py" in cmd[2]
+
+
+def test_job_scheduler_uses_current_python_without_activation() -> None:
+    scheduler = JobScheduler(
+        job_type="local",
+        config=LocalJobConfig(eval_program_path="evaluate.py"),
+    )
+
+    cmd = scheduler._build_command("program.py", "results")
+
+    assert cmd[0] == sys.executable
+    assert cmd[1:3] == ["evaluate.py", "--program_path"]
+
+
+def test_job_scheduler_builds_local_numeric_thread_env_overrides() -> None:
+    scheduler = JobScheduler(
+        job_type="local",
+        config=LocalJobConfig(
+            eval_program_path="evaluate.py",
+            numeric_threads_per_job=3,
+        ),
+    )
+
+    env_overrides = scheduler._build_local_env_overrides()
+
+    assert env_overrides is not None
+    assert env_overrides["OMP_NUM_THREADS"] == "3"
+    assert env_overrides["OPENBLAS_NUM_THREADS"] == "3"
+    assert env_overrides["MKL_NUM_THREADS"] == "3"
+    assert env_overrides["NUMEXPR_NUM_THREADS"] == "3"
 
 
 def test_slurm_conda_job_config_allows_activate_script_for_back_compat() -> None:


### PR DESCRIPTION
## What changed
- improve local async runtime scaling by using the active project interpreter for eval subprocesses, capping per-process BLAS/OpenMP threads, and reducing local monitor polling latency
- debounce prompt percentile recomputation off the prompt side-effect hot path using a background task with a fresh read-only DB connection
- harden adaptive proposal targeting when `proposal_target_hard_cap` is misconfigured below eval capacity
- add regression coverage for the scheduler/runtime behavior and prompt-fitness refresh path
- add tracked circle-packing scale benchmark presets and update them to `100` generations with `max_patch_resamples: 1`
- document the runtime + benchmark changes in `CHANGELOG.md`

## Why
The async pipeline was leaving a lot of runtime on the table from our side even when proposal generation latency was dominated by the upstream model:
- local eval subprocesses were sometimes launched with a bare `python`
- numeric libraries inside concurrent eval workers were oversubscribing CPU threads
- local completion polling added avoidable latency
- prompt percentile recomputation could block side effects and hit SQLite thread-affinity issues
- the scale benchmark presets were not tracked in git and still used expensive resample settings

## Benchmark evidence
Sequential `100`-generation circle-packing runs with the tracked presets:
- `small` ([results_circle_scale_small_seq_r1]): runtime `1003.31s`, avg/proposal `10.13s`, eval mean `11.10s`, sampling mean `48.61s`, side-effect apply mean `9.86s`
- `medium` ([results_circle_scale_medium_seq_r1]): runtime `606.71s`, avg/proposal `6.13s`, eval mean `6.08s`, sampling mean `58.56s`, side-effect apply mean `9.42s`
- medium is `39.5%` faster than small on the same `100`-generation workload

Compared with the prior sequential pair that still used `max_patch_resamples: 3`:
- `small`: `1298.39s -> 1003.31s` (`22.7%` faster)
- `medium`: `957.91s -> 606.71s` (`36.7%` faster)

## What still looks bottlenecked
- proposal-side work remains dominant in wall-clock terms
- eval occupancy still underuses the configured ceiling even in medium
- post-persistence side effects still cost about `9-10s` on average

## How to test
- `uv run python -m pytest tests/test_proposal_oversubscription.py tests/test_scheduler_env_activation.py tests/test_pipeline_timing.py tests/test_async_runner_recovery.py -q`
- `uv run ruff check shinka/core/async_runner.py shinka/launch/local.py shinka/launch/scheduler.py tests/test_async_runner_recovery.py tests/test_pipeline_timing.py tests/test_proposal_oversubscription.py tests/test_scheduler_env_activation.py`
- benchmark commands:
  - `cd examples/circle_packing && uv run python run_evo.py --config_path shinka_scale_small.yaml`
  - `cd examples/circle_packing && uv run python run_evo.py --config_path shinka_scale_medium.yaml`

## Commit split
- `fix: improve async runtime scaling`
- `docs: update benchmark scaling presets`
