### PR TITLE
Add shinka_models and validate run model availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `shinka-evolve` are documented in this file.
 
+## Unreleased
+
+### Added
+
+- Added a new `shinka_models` CLI that inspects the current environment plus discovered `.env` files and reports which priced LLM and embedding models are available to use.
+
+### Changed
+
+- Changed `shinka_models` default output to a compact JSON object with separate `embedding` and `llm` model lists, while `--verbose` now emits provider-level availability details with the same top-level lists.
+- Updated the `shinka-run` skill so run planning must validate mutation, meta-recommendation, prompt-evolution, and embedding models against `shinka_models` before launching evolution.
+
 ## 0.0.3 - 2026-04-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 
 [project.scripts]
 shinka_launch = "shinka.cli.launch:main"
+shinka_models = "shinka.cli.models:main"
 shinka_run = "shinka.cli.run:main"
 shinka_visualize = "shinka.webui.visualization:main"
 

--- a/shinka/cli/models.py
+++ b/shinka/cli/models.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""CLI for listing environment-available LLM and embedding models."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from shinka.embed.providers.pricing import (
+    get_all_providers as get_all_embedding_providers,
+)
+from shinka.embed.providers.pricing import (
+    get_models_by_provider as get_embedding_models_by_provider,
+)
+from shinka.env import load_shinka_dotenv
+from shinka.llm.providers.pricing import get_all_providers, get_models_by_provider
+
+PROVIDER_ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "azure": ("AZURE_OPENAI_API_KEY", "AZURE_API_ENDPOINT", "AZURE_API_VERSION"),
+    "bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION_NAME"),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "google": ("GEMINI_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    description = (
+        "Inspect current environment variables and discovered .env files, then "
+        "emit JSON for pricing.csv LLM and embedding models that are usable in the "
+        "current environment."
+    )
+    epilog = (
+        "Output shape:\n"
+        "  {\n"
+        '    "embedding": [...],\n'
+        '    "llm": [...]\n'
+        "  }\n\n"
+        "Verbose output shape:\n"
+        "  {\n"
+        '    "available_providers": [\n'
+        '      {"provider": "google", "env_vars": {"GEMINI_API_KEY": true}, '
+        '"llm_models": [...], "embedding_models": [...]}\n'
+        "    ],\n"
+        '    "embedding": [...],\n'
+        '    "llm": [...]\n'
+        "  }\n\n"
+        "Readiness checks are strict and provider-specific:\n"
+        "  anthropic: ANTHROPIC_API_KEY\n"
+        "  azure: AZURE_OPENAI_API_KEY + AZURE_API_ENDPOINT + AZURE_API_VERSION\n"
+        "  bedrock: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_REGION_NAME\n"
+        "  deepseek: DEEPSEEK_API_KEY\n"
+        "  google: GEMINI_API_KEY\n"
+        "  openai: OPENAI_API_KEY\n"
+        "  openrouter: OPENROUTER_API_KEY\n\n"
+        "Security:\n"
+        "  only availability booleans are printed; API key values are never shown\n\n"
+        "Default output:\n"
+        "  JSON object with separate embedding and llm lists\n"
+        "Verbose output:\n"
+        "  full JSON payload with provider details and the same top-level lists"
+    )
+    parser = argparse.ArgumentParser(
+        prog="shinka_models",
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the full JSON payload instead of only the available model list.",
+    )
+    return parser
+
+
+def _env_var_status(env_var_names: tuple[str, ...]) -> dict[str, bool]:
+    return {
+        env_var_name: bool(os.getenv(env_var_name, "").strip())
+        for env_var_name in sorted(env_var_names)
+    }
+
+
+def _build_provider_entry(provider: str) -> dict[str, Any] | None:
+    env_var_names = PROVIDER_ENV_REQUIREMENTS.get(provider)
+    if env_var_names is None:
+        return None
+
+    env_vars = _env_var_status(env_var_names)
+    if not all(env_vars.values()):
+        return None
+
+    llm_models = sorted(get_models_by_provider(provider))
+    embedding_models = sorted(get_embedding_models_by_provider(provider))
+    if not llm_models and not embedding_models:
+        return None
+
+    return {
+        "provider": provider,
+        "env_vars": env_vars,
+        "llm_models": llm_models,
+        "embedding_models": embedding_models,
+    }
+
+
+def _build_payload() -> dict[str, Any]:
+    all_providers = sorted(
+        set(get_all_providers()) | set(get_all_embedding_providers())
+    )
+    available_providers = [
+        provider_entry
+        for provider in all_providers
+        if (provider_entry := _build_provider_entry(provider)) is not None
+    ]
+    llm_models = sorted(
+        model
+        for provider_entry in available_providers
+        for model in provider_entry["llm_models"]
+    )
+    embedding_models = sorted(
+        model
+        for provider_entry in available_providers
+        for model in provider_entry["embedding_models"]
+    )
+    return {
+        "available_providers": available_providers,
+        "embedding": embedding_models,
+        "llm": llm_models,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_shinka_dotenv()
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    payload = _build_payload()
+    output = payload if args.verbose else {
+        "embedding": payload["embedding"],
+        "llm": payload["llm"],
+    }
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shinka/embed/providers/pricing.py
+++ b/shinka/embed/providers/pricing.py
@@ -69,6 +69,11 @@ def get_all_models() -> list:
     return _PRICING_DF.index.tolist()
 
 
+def get_all_providers() -> list:
+    """Get the distinct providers represented in pricing data."""
+    return _PRICING_DF["provider"].drop_duplicates().tolist()
+
+
 def get_models_by_provider(provider: str) -> list:
     """Get list of embedding models for a given provider."""
     return _PRICING_DF[_PRICING_DF["provider"] == provider].index.tolist()

--- a/shinka/llm/providers/pricing.py
+++ b/shinka/llm/providers/pricing.py
@@ -157,6 +157,16 @@ def get_provider(model_name: str) -> Optional[str]:
     return _PRICING_DF.loc[model_name, "provider"]
 
 
+def get_all_providers() -> list[str]:
+    """Get the distinct providers represented in pricing data."""
+    return _PRICING_DF["provider"].drop_duplicates().tolist()
+
+
+def get_models_by_provider(provider: str) -> list[str]:
+    """Get list of models for a given provider."""
+    return _PRICING_DF[_PRICING_DF["provider"] == provider].index.tolist()
+
+
 def has_fixed_temperature(model_name: str) -> bool:
     """Check if a model requires temperature fixed to 1.0."""
     if model_name not in _PRICING_DF.index:

--- a/skills/shinka-run/SKILL.md
+++ b/skills/shinka-run/SKILL.md
@@ -45,10 +45,12 @@ Validate the exact run config against `shinka_models`:
 - Meta recommendation models: if `evo.meta_rec_interval` is set and `evo.meta_llm_models` is set, every meta model must appear in the `llm` list.
 - Prompt evolution models: if `evo.evolve_prompts=true`, use `evo.prompt_llm_models` when provided, otherwise `evo.llm_models`; every selected model must appear in the `llm` list.
 - Embedding model: if `evo.embedding_model` is set, it must appear in the `embedding` list.
+- Local OpenAI-compatible models are allowed for LLMs and embeddings via `local/<model>@http(s)://host[:port]/v1`, and these local models are not expected to appear in `shinka_models`.
 
 Important runtime rules:
 - Do not assume meta recommendations fall back to `evo.llm_models`. In the current runner, meta recommendations are only enabled when `evo.meta_llm_models` is explicitly set.
 - Prompt evolution does fall back to `evo.llm_models` when `evo.prompt_llm_models` is unset.
+- Treat `local/<model>@http(s)://host[:port]/v1` values as an explicit exception to the `shinka_models` membership check. Instead, confirm the local endpoint URL and serving status separately before running.
 - If any required model is missing from `shinka_models`, stop and ask the user to either change the config or set the missing credentials first.
 
 4. Confirm first-batch configuration with the user

--- a/skills/shinka-run/SKILL.md
+++ b/skills/shinka-run/SKILL.md
@@ -34,12 +34,30 @@ Confirm `evaluate.py` and `initial.<ext>` exist.
 shinka_run --help
 ```
 
-3. Confirm first-batch configuration with the user
+3. Check model availability before proposing a run
+```bash
+shinka_models
+shinka_models --verbose
+```
+
+Validate the exact run config against `shinka_models`:
+- Mutation models: every entry in `evo.llm_models` must appear in the `llm` list.
+- Meta recommendation models: if `evo.meta_rec_interval` is set and `evo.meta_llm_models` is set, every meta model must appear in the `llm` list.
+- Prompt evolution models: if `evo.evolve_prompts=true`, use `evo.prompt_llm_models` when provided, otherwise `evo.llm_models`; every selected model must appear in the `llm` list.
+- Embedding model: if `evo.embedding_model` is set, it must appear in the `embedding` list.
+
+Important runtime rules:
+- Do not assume meta recommendations fall back to `evo.llm_models`. In the current runner, meta recommendations are only enabled when `evo.meta_llm_models` is explicitly set.
+- Prompt evolution does fall back to `evo.llm_models` when `evo.prompt_llm_models` is unset.
+- If any required model is missing from `shinka_models`, stop and ask the user to either change the config or set the missing credentials first.
+
+4. Confirm first-batch configuration with the user
 - Minimum: budget scope, generation count, critical overrides.
+- Explicitly confirm the mutation LLMs, meta recommendation LLMs, prompt evolution LLMs, and embedding model after checking them against `shinka_models`.
 - If unclear, ask before running.
 - Do not override any non-confirmed arguments.
 
-4. Launch main run with explicit knobs
+5. Launch main run with explicit knobs
 ```bash
 shinka_run \
   --task-dir <task_dir> \
@@ -48,7 +66,10 @@ shinka_run \
   --set db.num_islands=3 \
   --set job.time=00:10:00 \
   --set evo.task_sys_msg='<task-specific system message guiding search>'\
-  --set evo.llm_models='["gpt-5-mini","gpt-5-nano"]'\
+  --set evo.llm_models='["gpt-5-mini","gpt-5-nano"]' \
+  --set evo.meta_llm_models='["gpt-5-mini"]' \
+  --set evo.prompt_llm_models='["gpt-5-mini"]' \
+  --set evo.embedding_model='text-embedding-3-small' \
   # Concurrency settings for parallel sampling and evaluation
   --max-evaluation-jobs 2 \
   --max-proposal-jobs 2 \

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -53,6 +53,7 @@ def test_project_metadata_targets_pypi_release():
     assert project["license"] == "Apache-2.0"
     assert project["scripts"] == {
         "shinka_launch": "shinka.cli.launch:main",
+        "shinka_models": "shinka.cli.models:main",
         "shinka_run": "shinka.cli.run:main",
         "shinka_visualize": "shinka.webui.visualization:main",
     }

--- a/tests/test_shinka_models_cli.py
+++ b/tests/test_shinka_models_cli.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+import shinka.cli.models as cli_models
+from shinka.env import load_shinka_dotenv as real_load_shinka_dotenv
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LLM_PRICING_CSV = REPO_ROOT / "shinka" / "llm" / "providers" / "pricing.csv"
+EMBED_PRICING_CSV = REPO_ROOT / "shinka" / "embed" / "providers" / "pricing.csv"
+PROVIDER_ENV_VARS = {
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "azure": ("AZURE_OPENAI_API_KEY", "AZURE_API_ENDPOINT", "AZURE_API_VERSION"),
+    "bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION_NAME"),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "google": ("GEMINI_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+}
+
+
+def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_var_names in PROVIDER_ENV_VARS.values():
+        for env_var_name in env_var_names:
+            monkeypatch.delenv(env_var_name, raising=False)
+
+
+def _models_for_provider(provider: str, pricing_csv: Path) -> list[str]:
+    with pricing_csv.open(newline="", encoding="utf-8") as handle:
+        rows = csv.DictReader(handle)
+        return sorted(
+            row["model_name"].strip()
+            for row in rows
+            if row["provider"].strip() == provider
+        )
+
+
+def _llm_models_for_provider(provider: str) -> list[str]:
+    return _models_for_provider(provider, LLM_PRICING_CSV)
+
+
+def _embedding_models_for_provider(provider: str) -> list[str]:
+    return _models_for_provider(provider, EMBED_PRICING_CSV)
+
+
+def _all_models_for_provider(provider: str) -> list[str]:
+    return sorted(
+        set(_llm_models_for_provider(provider) + _embedding_models_for_provider(provider))
+    )
+
+
+def _run_cli(
+    capsys: pytest.CaptureFixture[str], argv: list[str] | None = None
+) -> tuple[int, list[str] | dict]:
+    exit_code = cli_models.main([] if argv is None else argv)
+    output = capsys.readouterr().out
+    return exit_code, json.loads(output)
+
+
+def test_shinka_models_help_describes_json_output(capsys: pytest.CaptureFixture[str]):
+    with pytest.raises(SystemExit) as exc_info:
+        cli_models.main(["--help"])
+
+    assert exc_info.value.code == 0
+    help_output = capsys.readouterr().out
+    assert "Inspect current environment variables and discovered .env files" in help_output
+    assert "available_providers" in help_output
+    assert '"embedding": [...]' in help_output
+    assert '"llm": [...]' in help_output
+    assert "--verbose" in help_output
+    assert "current environment" in help_output
+    assert ".env" in help_output
+    assert "--api-key" not in help_output
+
+
+def test_shinka_models_lists_google_models_when_gemini_key_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+
+    exit_code, payload = _run_cli(capsys)
+
+    expected_embedding_models = _embedding_models_for_provider("google")
+    expected_llm_models = _llm_models_for_provider("google")
+    assert exit_code == 0
+    assert payload == {
+        "embedding": expected_embedding_models,
+        "llm": expected_llm_models,
+    }
+
+
+def test_shinka_models_verbose_prints_full_payload(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+
+    exit_code, payload = _run_cli(capsys, ["--verbose"])
+
+    expected_llm_models = _llm_models_for_provider("google")
+    expected_embedding_models = _embedding_models_for_provider("google")
+    assert exit_code == 0
+    assert payload == {
+        "available_providers": [
+            {
+                "env_vars": {"GEMINI_API_KEY": True},
+                "embedding_models": expected_embedding_models,
+                "llm_models": expected_llm_models,
+                "provider": "google",
+            }
+        ],
+        "embedding": expected_embedding_models,
+        "llm": expected_llm_models,
+    }
+
+
+def test_shinka_models_loads_dotenv_before_checking_provider_availability(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    package_root = tmp_path / "package-root"
+    launch_dir = tmp_path / "launch-dir"
+    package_root.mkdir()
+    launch_dir.mkdir()
+    (launch_dir / ".env").write_text("GEMINI_API_KEY=from-dotenv\n", encoding="utf-8")
+    monkeypatch.chdir(launch_dir)
+    monkeypatch.setattr(
+        cli_models,
+        "load_shinka_dotenv",
+        lambda: real_load_shinka_dotenv(package_root=package_root, cwd=launch_dir),
+    )
+
+    exit_code, payload = _run_cli(capsys)
+
+    assert exit_code == 0
+    assert payload == {
+        "embedding": _embedding_models_for_provider("google"),
+        "llm": _llm_models_for_provider("google"),
+    }
+
+
+def test_shinka_models_requires_full_bedrock_environment(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+
+    exit_code, payload = _run_cli(capsys)
+
+    assert exit_code == 0
+    assert payload == {"embedding": [], "llm": []}
+
+
+def test_shinka_models_lists_bedrock_models_when_all_required_env_vars_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("AWS_REGION_NAME", "us-west-2")
+
+    exit_code, payload = _run_cli(capsys)
+
+    expected_embedding_models = _embedding_models_for_provider("bedrock")
+    expected_llm_models = _llm_models_for_provider("bedrock")
+    assert exit_code == 0
+    assert payload == {
+        "embedding": expected_embedding_models,
+        "llm": expected_llm_models,
+    }
+
+
+def test_shinka_models_lists_sorted_union_for_multiple_available_providers(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+
+    exit_code, payload = _run_cli(capsys)
+
+    google_embedding_models = _embedding_models_for_provider("google")
+    google_llm_models = _llm_models_for_provider("google")
+    openai_embedding_models = _embedding_models_for_provider("openai")
+    openai_llm_models = _llm_models_for_provider("openai")
+    assert exit_code == 0
+    assert payload == {
+        "embedding": sorted([*google_embedding_models, *openai_embedding_models]),
+        "llm": sorted([*google_llm_models, *openai_llm_models]),
+    }
+
+
+def test_shinka_models_returns_empty_payload_when_no_provider_keys_are_available(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+
+    exit_code, payload = _run_cli(capsys)
+
+    assert exit_code == 0
+    assert payload == {"embedding": [], "llm": []}
+
+
+def test_shinka_models_never_prints_api_key_values(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    secret_value = "super-secret-gemini-key"
+    monkeypatch.setenv("GEMINI_API_KEY", secret_value)
+
+    exit_code = cli_models.main([])
+    raw_output = capsys.readouterr().out
+    payload = json.loads(raw_output)
+
+    expected_embedding_models = _embedding_models_for_provider("google")
+    expected_llm_models = _llm_models_for_provider("google")
+    assert exit_code == 0
+    assert secret_value not in raw_output
+    assert payload == {
+        "embedding": expected_embedding_models,
+        "llm": expected_llm_models,
+    }


### PR DESCRIPTION
## What changed
- add a new `shinka_models` CLI that inspects env + `.env` availability and reports priced LLM and embedding models
- make default `shinka_models` output a compact JSON object with `embedding` and `llm` lists, with `--verbose` exposing provider-level detail
- expose provider helpers in pricing modules and register the new CLI entrypoint
- update the `shinka-run` skill so mutation, meta-recommendation, prompt-evolution, and embedding models must be checked against `shinka_models`
- add changelog entries for the new model-availability tooling

## Why
Shinka already depends on multiple provider credentials, but selecting models for mutation, prompt evolution, meta analysis, and embeddings was easy to misconfigure. This adds a grounded local source of truth for available models and teaches the run skill to validate planned configs against it before launch.

## How to test
- `.venv/bin/pytest tests/test_shinka_models_cli.py tests/test_packaging_release.py -q`
- `uv run ruff check tests --exclude tests/file.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
- `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`

## Context
- default `shinka_models` output is now `{ "embedding": [...], "llm": [...] }`
- `shinka_models --verbose` includes per-provider booleans only; API key values are never printed
- meta recommendations in the current async runner only activate when `evo.meta_llm_models` is explicitly set, so the skill now reflects that runtime behavior exactly