### PR TITLE
feat: support per-model local api key envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 ### Added
 
 - Added a new `shinka_models` CLI that inspects the current environment plus discovered `.env` files and reports which priced LLM and embedding models are available to use.
+- Added per-model `api_key_env` support for local OpenAI-compatible LLM and embedding backends, allowing credentials to be selected inline via `local/<model>@http(s)://...?...api_key_env=ENV_VAR`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Class defaults below come from `shinka/core/config.py` (`EvolutionConfig`). Hydr
 | `meta_llm_kwargs` | `{}` | `dict` | Kwargs for meta-recommendation LLMs |
 | `meta_max_recommendations` | `5` | `int` | Max number of meta-recommendations |
 | `sample_single_meta_rec` | `True` | `bool` | Sample a single recommendation from meta output when enabled |
-| `embedding_model` | `"text-embedding-3-small"` | `Optional[str]` | Model for code embeddings. Also accepts `local/<model>@http(s)://host[:port]/v1` for local OpenAI-compatible embedding servers. |
+| `embedding_model` | `"text-embedding-3-small"` | `Optional[str]` | Model for code embeddings. Also accepts `local/<model>@http(s)://host[:port]/v1` for local OpenAI-compatible embedding servers, with optional `?api_key_env=ENV_VAR` for per-model credentials. |
 | `init_program_path` | `"initial.py"` | `Optional[str]` | Path to initial program to evolve |
 | `results_dir` | `None` | `Optional[str]` | Directory to save results (auto-generated if None) |
 | `max_novelty_attempts` | `3` | `int` | Max attempts for novelty generation |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Concurrency is configured on `ShinkaEvolveRunner`, not on `EvolutionConfig`.
 | `meta_llm_kwargs` | `dict` | `{}` | kwargs for meta-recommendation LLM calls. |
 | `meta_max_recommendations` | `int` | `5` | Max recommendations produced per meta step. |
 | `sample_single_meta_rec` | `bool` | `True` | Whether to sample one recommendation when multiple exist. |
-| `embedding_model` | `Optional[str]` | `'text-embedding-3-small'` | Embedding model for code similarity. Also supports `local/<model>@http(s)://host[:port]/v1` for local OpenAI-compatible embedding endpoints. |
+| `embedding_model` | `Optional[str]` | `'text-embedding-3-small'` | Embedding model for code similarity. Also supports `local/<model>@http(s)://host[:port]/v1` for local OpenAI-compatible embedding endpoints, with optional `?api_key_env=ENV_VAR` for per-model credentials. |
 | `init_program_path` | `Optional[str]` | `'initial.py'` | Initial program path. |
 | `results_dir` | `Optional[str]` | `None` | Results directory; auto-assigned when `None`. |
 | `max_novelty_attempts` | `int` | `3` | Max novelty loops per generation. |

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -93,6 +93,7 @@ OPENAI_API_KEY=sk-proj-your-key-here
 ANTHROPIC_API_KEY=your-anthropic-key-here  # Optional
 OPENROUTER_API_KEY=sk-or-v1-...             # Optional (for openrouter/* models)
 LOCAL_OPENAI_API_KEY=local                  # Optional (for local/*@http(s)://... models)
+CUSTOM_API_KEY=...                          # Optional (for local/*@...?...api_key_env=CUSTOM_API_KEY)
 ```
 
 ### Step 4: Verify Installation
@@ -248,6 +249,7 @@ evo_config = EvolutionConfig(
     llm_models=[
         "openrouter/qwen/qwen3-coder",
         "local/qwen2.5-coder@http://localhost:11434/v1",
+        "local/dummy-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY",
     ],
     embedding_model="local/text-embeddings-inference@http://localhost:8080/v1",
 )

--- a/docs/support_local_models.md
+++ b/docs/support_local_models.md
@@ -55,6 +55,20 @@ LOCAL_OPENAI_API_KEY=local
 
 If not set, Shinka uses `"local"` as a default token.
 
+For a per-model custom key env var, append `api_key_env` to the endpoint URL:
+
+```yaml
+evo_config:
+  llm_models:
+    - local/dummy-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY
+```
+
+```bash
+CUSTOM_API_KEY=...
+```
+
+Shinka strips `api_key_env` from the runtime base URL before creating the client.
+
 ## Local Embeddings
 
 The same inline local format also works for `embedding_model`.
@@ -62,6 +76,13 @@ The same inline local format also works for `embedding_model`.
 ```yaml
 evo_config:
   embedding_model: local/text-embeddings-inference@http://localhost:8080/v1
+```
+
+You can also use the same `api_key_env` query parameter for embeddings:
+
+```yaml
+evo_config:
+  embedding_model: local/dummy-embed@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY
 ```
 
 Common local embedding backends:
@@ -79,6 +100,7 @@ Common local embedding backends:
 - If a model has no pricing entry and the provider does not return cost metadata, Shinka records cost as `0.0`.
 - Local OpenAI-compatible backend path currently uses chat-completions style calls.
 - Local embedding backends use the OpenAI-compatible `/v1/embeddings` path.
+- `api_key_env` must reference a single environment variable name, for example `CUSTOM_API_KEY`.
 - Structured output is not supported yet for `local/...@...` models.
 
 ## Applies to Which Clients

--- a/shinka/embed/client.py
+++ b/shinka/embed/client.py
@@ -1,20 +1,21 @@
 from dataclasses import dataclass
 import os
-import re
 from typing import Any, Optional, Tuple
-from urllib.parse import urlparse
 
 from google import genai
 import openai
 
 from shinka.env import load_shinka_dotenv
+from shinka.local_openai_config import (
+    parse_local_openai_model,
+    resolve_local_openai_api_key,
+)
 
 from .providers.pricing import get_provider
 
 load_shinka_dotenv()
 
 TIMEOUT = 600
-_LOCAL_MODEL_PATTERN = re.compile(r"^local/(?P<model>[^@]+)@(?P<url>https?://.+)$")
 _OPENROUTER_PREFIX = "openrouter/"
 
 
@@ -24,6 +25,7 @@ class ResolvedEmbeddingModel:
     api_model_name: str
     provider: str
     base_url: Optional[str] = None
+    api_key_env_name: Optional[str] = None
 
 
 def resolve_embedding_backend(model_name: str) -> ResolvedEmbeddingModel:
@@ -57,20 +59,14 @@ def resolve_embedding_backend(model_name: str) -> ResolvedEmbeddingModel:
             base_url=None,
         )
 
-    local_match = _LOCAL_MODEL_PATTERN.match(model_name)
+    local_match = parse_local_openai_model(model_name)
     if local_match:
-        api_model_name = local_match.group("model")
-        base_url = local_match.group("url")
-        parsed = urlparse(base_url)
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            raise ValueError(
-                f"Invalid local model URL '{base_url}'. Expected http(s)://host[:port]/..."
-            )
         return ResolvedEmbeddingModel(
             original_model_name=model_name,
-            api_model_name=api_model_name,
+            api_model_name=local_match.api_model_name,
             provider="local_openai",
-            base_url=base_url,
+            base_url=local_match.base_url,
+            api_key_env_name=local_match.api_key_env_name,
         )
 
     raise ValueError(
@@ -104,7 +100,7 @@ def get_client_embed(model_name: str) -> Tuple[Any, str]:
         )
     elif provider == "local_openai":
         client = openai.OpenAI(
-            api_key=os.getenv("LOCAL_OPENAI_API_KEY", "local"),
+            api_key=resolve_local_openai_api_key(resolved.api_key_env_name),
             base_url=resolved.base_url,
             timeout=TIMEOUT,
         )
@@ -138,7 +134,7 @@ def get_async_client_embed(model_name: str) -> Tuple[Any, str]:
         )
     elif provider == "local_openai":
         client = openai.AsyncOpenAI(
-            api_key=os.getenv("LOCAL_OPENAI_API_KEY", "local"),
+            api_key=resolve_local_openai_api_key(resolved.api_key_env_name),
             base_url=resolved.base_url,
             timeout=TIMEOUT,
         )

--- a/shinka/llm/client.py
+++ b/shinka/llm/client.py
@@ -5,6 +5,7 @@ import openai
 import instructor
 from google import genai
 from shinka.env import load_shinka_dotenv
+from shinka.local_openai_config import resolve_local_openai_api_key
 from .providers.model_resolver import resolve_model_backend
 
 load_shinka_dotenv()
@@ -95,7 +96,7 @@ def get_client_llm(
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
     elif provider == "local_openai":
         client = openai.OpenAI(
-            api_key=os.getenv("LOCAL_OPENAI_API_KEY", "local"),
+            api_key=resolve_local_openai_api_key(resolved.api_key_env_name),
             base_url=resolved.base_url,
             timeout=TIMEOUT,
         )
@@ -175,7 +176,7 @@ def get_async_client_llm(
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
     elif provider == "local_openai":
         client = openai.AsyncOpenAI(
-            api_key=os.getenv("LOCAL_OPENAI_API_KEY", "local"),
+            api_key=resolve_local_openai_api_key(resolved.api_key_env_name),
             base_url=resolved.base_url,
             timeout=TIMEOUT,
         )

--- a/shinka/llm/providers/model_resolver.py
+++ b/shinka/llm/providers/model_resolver.py
@@ -1,13 +1,9 @@
 from dataclasses import dataclass
-import re
 from typing import Optional
-from urllib.parse import urlparse
 
+from shinka.local_openai_config import parse_local_openai_model
 from .pricing import get_provider
 
-_LOCAL_MODEL_PATTERN = re.compile(
-    r"^local/(?P<model>[^@]+)@(?P<url>https?://.+)$"
-)
 _OPENROUTER_PREFIX = "openrouter/"
 
 
@@ -17,6 +13,7 @@ class ResolvedModel:
     api_model_name: str
     provider: str
     base_url: Optional[str] = None
+    api_key_env_name: Optional[str] = None
 
 
 def resolve_model_backend(model_name: str) -> ResolvedModel:
@@ -52,20 +49,14 @@ def resolve_model_backend(model_name: str) -> ResolvedModel:
             base_url=None,
         )
 
-    local_match = _LOCAL_MODEL_PATTERN.match(model_name)
+    local_match = parse_local_openai_model(model_name)
     if local_match:
-        api_model_name = local_match.group("model")
-        base_url = local_match.group("url")
-        parsed = urlparse(base_url)
-        if parsed.scheme not in ("http", "https") or not parsed.netloc:
-            raise ValueError(
-                f"Invalid local model URL '{base_url}'. Expected http(s)://host[:port]/..."
-            )
         return ResolvedModel(
             original_model_name=model_name,
-            api_model_name=api_model_name,
+            api_model_name=local_match.api_model_name,
             provider="local_openai",
-            base_url=base_url,
+            base_url=local_match.base_url,
+            api_key_env_name=local_match.api_key_env_name,
         )
 
     raise ValueError(

--- a/shinka/local_openai_config.py
+++ b/shinka/local_openai_config.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import re
+from typing import Optional
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+_LOCAL_MODEL_PATTERN = re.compile(r"^local/(?P<model>[^@]+)@(?P<url>https?://.+)$")
+_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_API_KEY_ENV_QUERY_PARAM = "api_key_env"
+
+
+@dataclass(frozen=True)
+class ResolvedLocalOpenAIModel:
+    original_model_name: str
+    api_model_name: str
+    base_url: str
+    api_key_env_name: Optional[str] = None
+
+
+def parse_local_openai_model(
+    model_name: str,
+) -> Optional[ResolvedLocalOpenAIModel]:
+    """Parse dynamic local OpenAI-compatible model identifiers."""
+    local_match = _LOCAL_MODEL_PATTERN.match(model_name)
+    if not local_match:
+        return None
+
+    api_model_name = local_match.group("model")
+    raw_base_url = local_match.group("url")
+    parsed = urlparse(raw_base_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(
+            f"Invalid local model URL '{raw_base_url}'. Expected http(s)://host[:port]/..."
+        )
+
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    api_key_env_values = [
+        value for key, value in query_pairs if key == _API_KEY_ENV_QUERY_PARAM
+    ]
+    if len(api_key_env_values) > 1:
+        raise ValueError(
+            "Local model URL may only specify one 'api_key_env' query parameter."
+        )
+
+    api_key_env_name = None
+    if api_key_env_values:
+        api_key_env_name = api_key_env_values[0].strip()
+        if not api_key_env_name:
+            raise ValueError("Local model URL 'api_key_env' must not be empty.")
+        if not _ENV_VAR_NAME_PATTERN.match(api_key_env_name):
+            raise ValueError(
+                f"Invalid api_key_env '{api_key_env_name}'. "
+                "Expected an environment variable name like CUSTOM_API_KEY."
+            )
+
+    sanitized_query_pairs = [
+        (key, value) for key, value in query_pairs if key != _API_KEY_ENV_QUERY_PARAM
+    ]
+    base_url = urlunparse(
+        parsed._replace(query=urlencode(sanitized_query_pairs, doseq=True))
+    )
+
+    return ResolvedLocalOpenAIModel(
+        original_model_name=model_name,
+        api_model_name=api_model_name,
+        base_url=base_url,
+        api_key_env_name=api_key_env_name,
+    )
+
+
+def resolve_local_openai_api_key(api_key_env_name: Optional[str] = None) -> str:
+    """Resolve the API key for a local OpenAI-compatible backend."""
+    if api_key_env_name:
+        api_key = os.getenv(api_key_env_name, "").strip()
+        if not api_key:
+            raise ValueError(
+                f"Local model api_key_env references '{api_key_env_name}', "
+                f"but '{api_key_env_name}' is not set."
+            )
+        return api_key
+
+    return os.getenv("LOCAL_OPENAI_API_KEY", "local")

--- a/tests/test_embedding_client_backends.py
+++ b/tests/test_embedding_client_backends.py
@@ -2,6 +2,7 @@ import asyncio
 from types import SimpleNamespace
 
 import openai
+import pytest
 
 from shinka.embed.client import get_async_client_embed, get_client_embed
 from shinka.embed.embedding import AsyncEmbeddingClient, EmbeddingClient
@@ -155,3 +156,32 @@ def test_async_local_embedding_unknown_price_defaults_to_zero(monkeypatch):
 
     assert embedding == [0.1, 0.2, 0.3]
     assert cost == 0.0
+
+
+def test_get_client_embed_local_openai_uses_api_key_env_query_param(monkeypatch):
+    captured_kwargs = {}
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self.base_url = kwargs["base_url"]
+
+    monkeypatch.setenv("CUSTOM_API_KEY", "test-custom-key")
+    monkeypatch.setattr("shinka.embed.client.openai.OpenAI", _FakeOpenAI)
+
+    client, model_name = get_client_embed(
+        "local/dummy-embed@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+    )
+
+    assert model_name == "dummy-embed"
+    assert str(client.base_url).startswith("https://api.example.test/v1")
+    assert captured_kwargs["api_key"] == "test-custom-key"
+
+
+def test_get_async_client_embed_local_openai_missing_api_key_env_raises(monkeypatch):
+    monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="CUSTOM_API_KEY"):
+        get_async_client_embed(
+            "local/dummy-embed@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+        )

--- a/tests/test_embedding_model_resolver.py
+++ b/tests/test_embedding_model_resolver.py
@@ -27,6 +27,18 @@ def test_resolve_local_embedding_model_with_inline_url():
     assert resolved.provider == "local_openai"
     assert resolved.api_model_name == "BAAI/bge-small-en-v1.5"
     assert resolved.base_url == "http://localhost:8080/v1"
+    assert resolved.api_key_env_name is None
+
+
+def test_resolve_local_embedding_model_with_api_key_env_query_param():
+    resolved = resolve_embedding_backend(
+        "local/dummy-embed@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+    )
+
+    assert resolved.provider == "local_openai"
+    assert resolved.api_model_name == "dummy-embed"
+    assert resolved.base_url == "https://api.example.test/v1"
+    assert resolved.api_key_env_name == "CUSTOM_API_KEY"
 
 
 def test_invalid_local_embedding_model_format_raises():

--- a/tests/test_llm_client_backends.py
+++ b/tests/test_llm_client_backends.py
@@ -1,3 +1,5 @@
+import pytest
+
 import shinka.llm.client as llm_client_module
 from shinka.llm.client import get_async_client_llm, get_client_llm
 
@@ -47,3 +49,33 @@ def test_get_async_client_llm_openai_sets_timeout(monkeypatch):
     assert provider == "openai"
     assert model_name == "gpt-5.4-mini"
     assert captured_kwargs["timeout"] == llm_client_module.TIMEOUT
+
+
+def test_get_client_llm_local_openai_uses_api_key_env_query_param(monkeypatch):
+    captured_kwargs = {}
+
+    class _FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            self.base_url = kwargs["base_url"]
+
+    monkeypatch.setenv("CUSTOM_API_KEY", "test-custom-key")
+    monkeypatch.setattr(llm_client_module.openai, "OpenAI", _FakeOpenAI)
+
+    client, model_name, provider = get_client_llm(
+        "local/dummy-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+    )
+
+    assert provider == "local_openai"
+    assert model_name == "dummy-model"
+    assert str(client.base_url).startswith("https://api.example.test/v1")
+    assert captured_kwargs["api_key"] == "test-custom-key"
+
+
+def test_get_async_client_llm_local_openai_missing_api_key_env_raises(monkeypatch):
+    monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="CUSTOM_API_KEY"):
+        get_async_client_llm(
+            "local/dummy-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+        )

--- a/tests/test_local_openai_config.py
+++ b/tests/test_local_openai_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+from shinka.local_openai_config import resolve_local_openai_api_key
+
+
+def test_resolve_local_openai_api_key_from_custom_env(monkeypatch):
+    monkeypatch.setenv("CUSTOM_API_KEY", "test-custom-key")
+
+    assert (
+        resolve_local_openai_api_key(api_key_env_name="CUSTOM_API_KEY")
+        == "test-custom-key"
+    )
+
+
+def test_resolve_local_openai_api_key_uses_local_fallback(monkeypatch):
+    monkeypatch.setenv("LOCAL_OPENAI_API_KEY", "test-local-key")
+
+    assert resolve_local_openai_api_key(api_key_env_name=None) == "test-local-key"
+
+
+def test_resolve_local_openai_api_key_defaults_to_local(monkeypatch):
+    monkeypatch.delenv("LOCAL_OPENAI_API_KEY", raising=False)
+
+    assert resolve_local_openai_api_key(api_key_env_name=None) == "local"
+
+
+def test_resolve_local_openai_api_key_missing_custom_env_raises(monkeypatch):
+    monkeypatch.delenv("CUSTOM_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="CUSTOM_API_KEY"):
+        resolve_local_openai_api_key(api_key_env_name="CUSTOM_API_KEY")

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -33,6 +33,17 @@ def test_resolve_local_model_with_inline_url():
     assert resolved.provider == "local_openai"
     assert resolved.api_model_name == "qwen2.5-coder"
     assert resolved.base_url == "http://localhost:11434/v1"
+    assert resolved.api_key_env_name is None
+
+
+def test_resolve_local_model_with_api_key_env_query_param():
+    resolved = resolve_model_backend(
+        "local/dummy-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+    )
+    assert resolved.provider == "local_openai"
+    assert resolved.api_model_name == "dummy-model"
+    assert resolved.base_url == "https://api.example.test/v1"
+    assert resolved.api_key_env_name == "CUSTOM_API_KEY"
 
 
 def test_resolve_azure_prefixed_model():


### PR DESCRIPTION
## Summary

- Added support for per-model `api_key_env` selection on local OpenAI-compatible model URLs such as `local/dummy-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY`.
- Centralized local backend URL parsing and API-key resolution in a shared helper used by both LLM and embedding clients.
- Added resolver/client regression coverage for inline `api_key_env` handling and missing-env failures.
- Updated docs and the changelog to describe the new local backend configuration.

## Why

- A single global `LOCAL_OPENAI_API_KEY` is too limiting when different OpenAI-compatible endpoints need different credentials in the same run.
- Inline per-model selection keeps the runtime change small and avoids threading extra auth mappings through the broader Hydra config and client-construction path.

## Linked issue or context

- User request to support custom API-key env vars for local OpenAI-compatible backends.

## Testing

- Commands run:
  - `uv run ruff check tests --exclude tests/file.py`
  - `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
  - `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`
  - `uv run ruff check shinka/local_openai_config.py shinka/llm/client.py shinka/llm/providers/model_resolver.py shinka/embed/client.py tests/test_local_openai_config.py tests/test_model_resolver.py tests/test_embedding_model_resolver.py tests/test_llm_client_backends.py tests/test_embedding_client_backends.py`
- Optional secret-backed tests:
  - Not run
- Results:
  - `ruff check tests --exclude tests/file.py`: pass
  - `mypy`: pass
  - `pytest -q -m "not requires_secrets" --cov=shinka ...`: 279 passed
  - targeted `ruff` on changed runtime/test files: pass
  - full-repo `uv run ruff check shinka tests --exclude tests/file.py` is currently blocked by pre-existing unrelated issues in `shinka/database/prompt_dbase.py`, `shinka/llm/providers/deepseek.py`, and plotting modules

## Risks and compatibility

- Backward compatible: existing `LOCAL_OPENAI_API_KEY` behavior remains unchanged when `api_key_env` is not present.
- `api_key_env` is consumed as a reserved query parameter and removed from the runtime `base_url` before client construction.
- Invalid or missing referenced env vars now fail fast with a clear `ValueError`.

## Core evolution pipeline evidence

- Not applicable; this change only affects local backend configuration and client setup.

## Docs and UI

- Docs updated if needed
- No UI changes
