### PR TITLE
Refine CLI banners and local model labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Improved local async runtime scaling by launching evaluation subprocesses with the active project interpreter, capping per-process numeric-library thread fan-out, and reducing local monitor polling latency.
 - Moved prompt-fitness percentile recomputation off the prompt side-effect hot path and onto a debounced background task using fresh read-only database connections.
 - Updated the circle-packing scaling presets to run for `100` generations and reduced `max_patch_resamples` to `1` for the small / medium / large benchmark configs.
+- Changed `shinka_run` startup output to use a minimal `Shinka CLI` banner while other launch paths keep the full gradient banner.
 
 ### Fixed
 
 - Fixed adaptive proposal targeting so invalid `proposal_target_hard_cap` values below evaluation capacity no longer silently disable oversubscription.
 - Fixed prompt-percentile background refresh to avoid SQLite thread-affinity failures when recomputing prompt fitness during async runs.
 - Fixed Windows Unicode handling for async candidate-file I/O, diff summaries, and best-path exports by forcing UTF-8 reads and writes on LLM-generated artifacts.
+- Fixed bandit summary tables to preserve readable `local/<model>` names while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
 
 ## 0.0.3 - 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `shinka-evolve` are documented in this file.
 
+## 0.0.5 - Unreleased
+
+### Changed
+
+- Changed `shinka_run` startup output to use a minimal `Shinka CLI` banner while other launch paths keep the full gradient banner.
+
+### Fixed
+
+- Fixed bandit summary tables to preserve readable `local/<model>` and `openrouter/<model>` labels while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
+
 ## 0.0.4 - 2026-04-06
 
 ### Added
@@ -16,14 +26,12 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Improved local async runtime scaling by launching evaluation subprocesses with the active project interpreter, capping per-process numeric-library thread fan-out, and reducing local monitor polling latency.
 - Moved prompt-fitness percentile recomputation off the prompt side-effect hot path and onto a debounced background task using fresh read-only database connections.
 - Updated the circle-packing scaling presets to run for `100` generations and reduced `max_patch_resamples` to `1` for the small / medium / large benchmark configs.
-- Changed `shinka_run` startup output to use a minimal `Shinka CLI` banner while other launch paths keep the full gradient banner.
 
 ### Fixed
 
 - Fixed adaptive proposal targeting so invalid `proposal_target_hard_cap` values below evaluation capacity no longer silently disable oversubscription.
 - Fixed prompt-percentile background refresh to avoid SQLite thread-affinity failures when recomputing prompt fitness during async runs.
 - Fixed Windows Unicode handling for async candidate-file I/O, diff summaries, and best-path exports by forcing UTF-8 reads and writes on LLM-generated artifacts.
-- Fixed bandit summary tables to preserve readable `local/<model>` names while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
 
 ## 0.0.3 - 2026-04-04
 

--- a/shinka/cli/run.py
+++ b/shinka/cli/run.py
@@ -408,6 +408,7 @@ def _build_runner(
         "evo_config": evo_config,
         "job_config": job_config,
         "db_config": db_config,
+        "banner_style": "minimal",
         "verbose": args.verbose,
         "debug": args.debug,
         "init_program_str": init_program_str,

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -60,24 +60,26 @@ from shinka.core.prompt_evolver import (
     AsyncSystemPromptEvolver,
 )
 from shinka.core.runtime_slots import LogicalSlotPool
-from shinka.logo import print_gradient_logo, shinka_ascii
+from shinka.logo import BannerStyle, get_logo_ascii, print_gradient_logo
 from shinka.utils import get_language_extension, parse_time_to_seconds
 from shinka.utils.languages import get_evolve_comment_prefix
 
 logger = logging.getLogger(__name__)
 
 
-def _print_gradient_logo_and_mirror(log_path: Optional[Path] = None) -> None:
+def _print_gradient_logo_and_mirror(
+    log_path: Optional[Path] = None,
+    banner_style: BannerStyle = "full",
+) -> None:
     """Print gradient logo to terminal and mirror plain ASCII to log."""
-    print_gradient_logo((255, 0, 0), (255, 255, 255))
+    logo_ascii = get_logo_ascii(banner_style)
+    print_gradient_logo((255, 0, 0), (255, 255, 255), logo_ascii=logo_ascii)
     if log_path is None:
         return
 
     try:
         with log_path.open("a", encoding="utf-8") as handle:
-            handle.write(
-                shinka_ascii if shinka_ascii.endswith("\n") else f"{shinka_ascii}\n"
-            )
+            handle.write(logo_ascii if logo_ascii.endswith("\n") else f"{logo_ascii}\n")
     except Exception:
         # Never break startup output if log write fails.
         pass
@@ -181,6 +183,7 @@ class ShinkaEvolveRunner:
         evo_config: EvolutionConfig,
         job_config: JobConfig,
         db_config: DatabaseConfig,
+        banner_style: BannerStyle = "full",
         verbose: bool = True,
         max_evaluation_jobs: int = 2,
         max_proposal_jobs: int = 1,
@@ -218,6 +221,7 @@ class ShinkaEvolveRunner:
         self.evo_config = evo_config
         self.job_config = job_config
         self.db_config = db_config
+        self.banner_style = banner_style
         self.enable_deadlock_debugging = debug
         log_filename = f"{self.results_dir}/evolution_run.log"
 
@@ -246,7 +250,9 @@ class ShinkaEvolveRunner:
             # Ensure results directory exists even when not verbose
             Path(self.results_dir).mkdir(parents=True, exist_ok=True)
 
-        _print_gradient_logo_and_mirror(Path(log_filename))
+        _print_gradient_logo_and_mirror(
+            Path(log_filename), banner_style=self.banner_style
+        )
 
         # Handle init_program_str: write to file and update config path
         if init_program_str is not None:

--- a/shinka/llm/prioritization.py
+++ b/shinka/llm/prioritization.py
@@ -59,6 +59,8 @@ def _format_arm_display_name(name: Arm, max_width: int) -> str:
 
     if local_match is not None:
         text = f"local/{local_match.api_model_name}"
+    elif name.startswith("openrouter/"):
+        text = name
     else:
         text = name.split("/")[-1]
 

--- a/shinka/llm/prioritization.py
+++ b/shinka/llm/prioritization.py
@@ -8,6 +8,8 @@ import rich.box
 import pickle
 from pathlib import Path
 
+from shinka.local_openai_config import parse_local_openai_model
+
 Arm = Union[int, str]
 Subset = Optional[Union[np.ndarray, Sequence[Arm]]]
 
@@ -32,6 +34,35 @@ def _logexpm1(z):
     z = np.asarray(z, dtype=float)
     with np.errstate(divide="ignore", invalid="ignore"):
         return np.where(z > 50.0, z, np.log(np.expm1(z)))
+
+
+def _truncate_middle(text: str, max_width: int) -> str:
+    if len(text) <= max_width:
+        return text
+    if max_width <= 3:
+        return text[:max_width]
+
+    left_width = (max_width - 3) // 2
+    right_width = max_width - 3 - left_width
+    return f"{text[:left_width]}...{text[-right_width:]}"
+
+
+def _format_arm_display_name(name: Arm, max_width: int) -> str:
+    text = str(name)
+    if not isinstance(name, str):
+        return _truncate_middle(text, max_width)
+
+    try:
+        local_match = parse_local_openai_model(name)
+    except ValueError:
+        local_match = None
+
+    if local_match is not None:
+        text = f"local/{local_match.api_model_name}"
+    else:
+        text = name.split("/")[-1]
+
+    return _truncate_middle(text, max_width)
 
 
 class BanditBase(ABC):
@@ -760,11 +791,7 @@ class AsymmetricUCB(BanditBase):
 
         # Add rows
         for i, name in enumerate(names):
-            # Split name by "/" and take last part, then last 25 chars
-            if isinstance(name, str):
-                display_name = name.split("/")[-1][-25:]
-            else:
-                display_name = str(name)
+            display_name = _format_arm_display_name(name, max_width=25)
 
             if n_costs[i] > 0:
                 mean_cost_str = f"{mean_costs[i]:.4f}"
@@ -940,11 +967,7 @@ class FixedSampler(BanditBase):
 
         # Add rows
         for i, name in enumerate(names):
-            # Split name by "/" and take last part, then last 28 chars
-            if isinstance(name, str):
-                display_name = name.split("/")[-1][-28:]
-            else:
-                display_name = str(name)
+            display_name = _format_arm_display_name(name, max_width=28)
             table.add_row(
                 display_name,
                 f"{n[i]:d}",
@@ -1300,10 +1323,7 @@ class ThompsonSampler(BanditBase):
         table.add_column("post", justify="right", style="bright_green")
 
         for i, name in enumerate(names):
-            if isinstance(name, str):
-                display_name = name.split("/")[-1][-25:]
-            else:
-                display_name = str(name)
+            display_name = _format_arm_display_name(name, max_width=25)
             table.add_row(
                 display_name,
                 f"{n[i]:d}",

--- a/shinka/logo.py
+++ b/shinka/logo.py
@@ -1,7 +1,11 @@
 import os
+from typing import Literal, Optional
 
 
-shinka_ascii = """  @@@@@@@@@@@@@@@@@@@@@      ░██████╗██╗░░██╗██╗███╗░░██╗██╗░░██╗░█████╗░
+BannerStyle = Literal["full", "minimal"]
+
+
+full_shinka_ascii = """  @@@@@@@@@@@@@@@@@@@@@      ░██████╗██╗░░██╗██╗███╗░░██╗██╗░░██╗░█████╗░
   @                   @      ██╔════╝██║░░██║██║████╗░██║██║░██╔╝██╔══██╗
   @          @        @      ╚█████╗░███████║██║██╔██╗██║█████═╝░███████║
   @    @@   @@  @@    @      ░╚═══██╗██╔══██║██║██║╚████║██╔═██╗░██╔══██║
@@ -32,6 +36,28 @@ shinka_ascii = """  @@@@@@@@@@@@@@@@@@@@@      ░██████╗██╗
 """
 
 
+minimal_shinka_ascii = """
+░██████╗██╗░░██╗██╗███╗░░██╗██╗░░██╗░█████╗░   ░█████╗░██╗░░░░░██╗
+██╔════╝██║░░██║██║████╗░██║██║░██╔╝██╔══██╗   ██╔══██╗██║░░░░░██║
+╚█████╗░███████║██║██╔██╗██║█████═╝░███████║   ██║░░╚═╝██║░░░░░██║
+░╚═══██╗██╔══██║██║██║╚████║██╔═██╗░██╔══██║   ██║░░██╗██║░░░░░██║
+██████╔╝██║░░██║██║██║░╚███║██║░╚██╗██║░░██║   ╚█████╔╝███████╗██║
+╚═════╝░╚═╝░░╚═╝╚═╝╚═╝░░╚══╝╚═╝░░╚═╝╚═╝░░╚═╝   ░╚════╝░╚══════╝╚═╝
+"""
+
+
+shinka_ascii = full_shinka_ascii
+
+
+def get_logo_ascii(style: BannerStyle = "full") -> str:
+    """Return the configured Shinka banner payload."""
+    if style == "full":
+        return full_shinka_ascii
+    if style == "minimal":
+        return minimal_shinka_ascii
+    raise ValueError(f"Unknown banner style: {style}")
+
+
 def rgb_to_ansi(r, g, b):
     """Convert RGB values to ANSI 256-color code."""
     # Use the 216-color cube (16-231) for better color precision
@@ -53,7 +79,11 @@ def create_gradient_colors(start_color, end_color, steps):
     return colors
 
 
-def print_gradient_logo(start_color=(255, 100, 50), end_color=(100, 200, 255)):
+def print_gradient_logo(
+    start_color=(255, 100, 50),
+    end_color=(100, 200, 255),
+    logo_ascii: Optional[str] = None,
+):
     """
     Print the Shinka logo with a color gradient.
 
@@ -61,14 +91,17 @@ def print_gradient_logo(start_color=(255, 100, 50), end_color=(100, 200, 255)):
         start_color: RGB tuple for the starting color (default: orange-red)
         end_color: RGB tuple for the ending color (default: light blue)
     """
+    if logo_ascii is None:
+        logo_ascii = shinka_ascii
+
     # Check if terminal supports colors
     if os.getenv("NO_COLOR") or not (
         hasattr(os.sys.stdout, "isatty") and os.sys.stdout.isatty()
     ):
-        print(shinka_ascii)
+        print(logo_ascii)
         return
 
-    lines = shinka_ascii.split("\n")
+    lines = logo_ascii.split("\n")
     num_lines = len(lines)
 
     # Create gradient colors for each line
@@ -94,7 +127,10 @@ GRADIENT_PRESETS = {
 }
 
 
-def print_preset_gradient_logo(preset="sunset"):
+def print_preset_gradient_logo(
+    preset="sunset",
+    logo_ascii: Optional[str] = None,
+):
     """
     Print the logo with a preset gradient.
 
@@ -104,13 +140,13 @@ def print_preset_gradient_logo(preset="sunset"):
     """
     if preset in GRADIENT_PRESETS:
         start_color, end_color = GRADIENT_PRESETS[preset]
-        print_gradient_logo(start_color, end_color)
+        print_gradient_logo(start_color, end_color, logo_ascii=logo_ascii)
     else:
         print(
             f"Unknown preset '{preset}'. Available presets: "
             f"{list(GRADIENT_PRESETS.keys())}"
         )
-        print_gradient_logo()  # Use default gradient
+        print_gradient_logo(logo_ascii=logo_ascii)  # Use default gradient
 
 
 # https://fsymbols.com/text-art/

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -2,9 +2,11 @@
 Test script to verify bandit state persistence works correctly.
 """
 
+from io import StringIO
 import numpy as np
 from pathlib import Path
 import tempfile
+from rich.console import Console
 from shinka.llm import AsymmetricUCB, ThompsonSampler, FixedSampler
 
 
@@ -152,6 +154,27 @@ def test_fixed_sampler_persistence():
         assert bandit._baseline == bandit2._baseline, "baseline mismatch!"
 
         print("✅ FixedSampler persistence test passed!")
+
+
+def test_asymmetric_ucb_print_summary_preserves_local_model_name():
+    arm_name = (
+        "local/example-model@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+    )
+    bandit = AsymmetricUCB(
+        arm_names=[arm_name],
+        exploration_coef=2.0,
+        epsilon=0.1,
+        auto_decay=0.95,
+    )
+
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    bandit.print_summary(console=console)
+    output = buffer.getvalue()
+
+    assert "local/example-mod" in output
+    assert "api.example.test" not in output
+    assert "CUSTOM_API_KEY" not in output
 
 
 if __name__ == "__main__":

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -177,6 +177,23 @@ def test_asymmetric_ucb_print_summary_preserves_local_model_name():
     assert "CUSTOM_API_KEY" not in output
 
 
+def test_asymmetric_ucb_print_summary_preserves_openrouter_prefix():
+    arm_name = "openrouter/example-model"
+    bandit = AsymmetricUCB(
+        arm_names=[arm_name],
+        exploration_coef=2.0,
+        epsilon=0.1,
+        auto_decay=0.95,
+    )
+
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    bandit.print_summary(console=console)
+    output = buffer.getvalue()
+
+    assert "openrouter/exampl" in output
+
+
 if __name__ == "__main__":
     test_asymmetric_ucb_persistence()
     test_thompson_sampler_persistence()

--- a/tests/test_launch_hydra_async.py
+++ b/tests/test_launch_hydra_async.py
@@ -41,6 +41,7 @@ def test_launch_hydra_uses_async_runner(monkeypatch):
     assert _DummyRunner.last_kwargs["max_evaluation_jobs"] == 7
     assert _DummyRunner.last_kwargs["max_proposal_jobs"] == 3
     assert _DummyRunner.last_kwargs["max_db_workers"] == 5
+    assert _DummyRunner.last_kwargs.get("banner_style", "full") == "full"
 
 
 def test_default_launch_config_uses_neutral_shared_defaults():

--- a/tests/test_logo.py
+++ b/tests/test_logo.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from shinka.logo import full_shinka_ascii, get_logo_ascii, minimal_shinka_ascii
+
+
+def test_minimal_logo_has_leading_blank_line_and_shinka_cli_wordmark():
+    assert minimal_shinka_ascii.startswith("\n")
+    assert "░██████╗" in minimal_shinka_ascii
+    assert "░█████╗░██╗░░░░░██╗" in minimal_shinka_ascii
+    assert "@" not in minimal_shinka_ascii
+
+
+def test_full_logo_preserves_existing_full_banner_art():
+    assert full_shinka_ascii.startswith("  @@@@@@@@@@@@@@@@@@@@@")
+    assert "@" in full_shinka_ascii
+    assert "░██████╗" in full_shinka_ascii
+
+
+def test_get_logo_ascii_supports_full_and_minimal_styles():
+    assert get_logo_ascii("full") == full_shinka_ascii
+    assert get_logo_ascii("minimal") == minimal_shinka_ascii

--- a/tests/test_shinka_run_cli.py
+++ b/tests/test_shinka_run_cli.py
@@ -190,6 +190,7 @@ def test_shinka_run_defaults_to_verbose_logging(tmp_path, monkeypatch):
 
     assert _DummyRunner.last_kwargs is not None
     assert _DummyRunner.last_kwargs["verbose"] is True
+    assert _DummyRunner.last_kwargs["banner_style"] == "minimal"
 
 
 def test_shinka_run_allows_disabling_verbose_logging(tmp_path, monkeypatch):
@@ -212,6 +213,7 @@ def test_shinka_run_allows_disabling_verbose_logging(tmp_path, monkeypatch):
 
     assert _DummyRunner.last_kwargs is not None
     assert _DummyRunner.last_kwargs["verbose"] is False
+    assert _DummyRunner.last_kwargs["banner_style"] == "minimal"
 
 
 def test_shinka_run_loads_optional_config_yaml_with_precedence(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a dedicated minimal `Shinka CLI` startup banner for `shinka_run` while keeping the full gradient banner for other launch paths
- preserve readable `local/<model>` names in bandit summary tables while stripping endpoint and API-key query details
- record both changes in the changelog

## Why
`shinka_run` needed a lighter-weight banner than the full startup art, but non-agent launch paths should still keep the existing branding.

Bandit summaries for local OpenAI-compatible models were showing noisy endpoint/query-string suffixes, which made runtime summaries harder to scan and risked leaking irrelevant credential env-key names into terminal output.

## How To Test
- `pytest tests/test_bandit_persistence.py tests/test_logo.py tests/test_shinka_run_cli.py tests/test_launch_hydra_async.py -q`

## Context
This PR contains three commits:
- `fix(llm): sanitize local model names in bandit summaries`
- `feat(cli): add dedicated shinka_run banner`
- `docs: update changelog for recent cli and bandit fixes`
