### PR TITLE
Fix failed proposal persistence and polish WebUI summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Fixed the local WebUI to render failed proposal nodes from `attempt_log` plus `failure.json` so failure lineage remains visible without storing synthetic failed programs in the main results database.
 - Fixed failed terminal proposal and prompt-evolution cost accounting so the runtime API budget counter now reflects those spend buckets, and added runtime-timeline metadata for failed proposal nodes rendered from `attempt_log`.
 - Fixed bandit summary tables to preserve readable `local/<model>` and `openrouter/<model>` labels while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
+- Fixed the LLM bandit sampling summary to use the same 120-column table width as the program, patch, and other Rich summaries.
 - Fixed the compare view so negative best scores remain visible instead of being clamped away by the WebUI summary logic.
 - Fixed documentation links and metadata URLs to use the deployed GitHub Pages path capitalization (`/ShinkaEvolve/`).
 - Fixed oversubscription regression coverage and docs so adaptive proposal backlog behavior is now clearly opt-in instead of implied by defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Fixed failed terminal proposal and prompt-evolution cost accounting so the runtime API budget counter now reflects those spend buckets, and added runtime-timeline metadata for failed proposal nodes rendered from `attempt_log`.
 - Fixed bandit summary tables to preserve readable `local/<model>` and `openrouter/<model>` labels while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
 - Fixed the LLM bandit sampling summary to use the same 120-column table width as the program, patch, and other Rich summaries.
+- Fixed the default `AsymmetricUCB` bandit summary to omit the `div` and `log mean` columns for a more compact Rich table.
 - Fixed the compare view so negative best scores remain visible instead of being clamped away by the WebUI summary logic.
 - Fixed documentation links and metadata URLs to use the deployed GitHub Pages path capitalization (`/ShinkaEvolve/`).
 - Fixed oversubscription regression coverage and docs so adaptive proposal backlog behavior is now clearly opt-in instead of implied by defaults.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed async run-time regressions from proposal-failure persistence by keeping terminal failed proposals in `attempt_log` plus `failure.json` artifacts instead of inserting them into the main `programs` table during evolution runs.
 - Fixed bandit summary tables to preserve readable `local/<model>` and `openrouter/<model>` labels while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
 - Fixed the compare view so negative best scores remain visible instead of being clamped away by the WebUI summary logic.
 - Fixed documentation links and metadata URLs to use the deployed GitHub Pages path capitalization (`/ShinkaEvolve/`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 ### Fixed
 
 - Fixed async run-time regressions from proposal-failure persistence by keeping terminal failed proposals in `attempt_log` plus `failure.json` artifacts instead of inserting them into the main `programs` table during evolution runs.
+- Fixed the local WebUI to render failed proposal nodes from `attempt_log` plus `failure.json` so failure lineage remains visible without storing synthetic failed programs in the main results database.
 - Fixed bandit summary tables to preserve readable `local/<model>` and `openrouter/<model>` labels while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
 - Fixed the compare view so negative best scores remain visible instead of being clamped away by the WebUI summary logic.
 - Fixed documentation links and metadata URLs to use the deployed GitHub Pages path capitalization (`/ShinkaEvolve/`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 - Fixed async run-time regressions from proposal-failure persistence by keeping terminal failed proposals in `attempt_log` plus `failure.json` artifacts instead of inserting them into the main `programs` table during evolution runs.
 - Fixed the local WebUI to render failed proposal nodes from `attempt_log` plus `failure.json` so failure lineage remains visible without storing synthetic failed programs in the main results database.
+- Fixed failed terminal proposal and prompt-evolution cost accounting so the runtime API budget counter now reflects those spend buckets, and added runtime-timeline metadata for failed proposal nodes rendered from `attempt_log`.
 - Fixed bandit summary tables to preserve readable `local/<model>` and `openrouter/<model>` labels while stripping endpoint and API-key query details from local OpenAI-compatible model labels.
 - Fixed the compare view so negative best scores remain visible instead of being clamped away by the WebUI summary logic.
 - Fixed documentation links and metadata URLs to use the deployed GitHub Pages path capitalization (`/ShinkaEvolve/`).

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -1024,6 +1024,8 @@ class ShinkaEvolveRunner:
                                 ),
                                 timeout=600.0,  # 10 minute timeout for final meta summary
                             )
+                            if success and final_meta_cost > 0:
+                                self.total_api_cost += final_meta_cost
                             if self.verbose:
                                 if success and final_meta_cost > 0:
                                     logger.info(
@@ -1435,6 +1437,7 @@ class ShinkaEvolveRunner:
             )
 
             self.prompt_api_cost += cost
+            self.total_api_cost += cost
 
             if new_prompt:
                 self.prompt_db.add(new_prompt, verbose=self.verbose)
@@ -3156,6 +3159,10 @@ class ShinkaEvolveRunner:
         failure_reason: str,
     ) -> None:
         """Record one terminal pre-eval failure via attempt_log plus failure.json."""
+        terminal_failure_cost = float(api_costs) + float(embed_cost) + float(
+            novelty_cost
+        )
+        self.total_api_cost += terminal_failure_cost
         failure_class = self._classify_failed_proposal(
             failure_stage=failure_stage,
             failure_reason=failure_reason,
@@ -3179,6 +3186,7 @@ class ShinkaEvolveRunner:
             sampling_worker_id=sampling_worker_id,
             active_proposals_at_start=active_proposals_at_start,
         )
+        terminal_failure_at = time.time()
         await self._record_attempt_event(
             generation=generation,
             stage=failure_stage,
@@ -3207,6 +3215,20 @@ class ShinkaEvolveRunner:
                 "patch_attempt": (meta_patch_data or {}).get("patch_attempt"),
                 "max_similarity": (meta_patch_data or {}).get("max_similarity"),
                 "failure_json_path": failure_json_path,
+                "pipeline_started_at": proposal_started_at,
+                "sampling_started_at": proposal_started_at,
+                "sampling_finished_at": terminal_failure_at,
+                "evaluation_started_at": terminal_failure_at,
+                "evaluation_finished_at": terminal_failure_at,
+                "postprocess_started_at": terminal_failure_at,
+                "postprocess_finished_at": terminal_failure_at,
+                "timeline_lane_mode": "pool_slots",
+                "sampling_worker_id": sampling_worker_id,
+                "evaluation_worker_id": None,
+                "postprocess_worker_id": None,
+                "sampling_worker_capacity": self.max_proposal_jobs,
+                "evaluation_worker_capacity": self.max_evaluation_jobs,
+                "postprocess_worker_capacity": self.max_db_workers,
                 "generated_code_available": failure_payload.get(
                     "generated_code_available", False
                 ),

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -3063,6 +3063,23 @@ class ShinkaEvolveRunner:
 
         return artifacts
 
+    def _get_failure_language(self, exec_path: Path) -> str:
+        """Infer the failed proposal language from config or the generated filename."""
+        configured_language = getattr(self.evo_config, "language", None)
+        if configured_language:
+            return configured_language
+
+        ext = exec_path.suffix.lstrip(".").lower()
+        return {
+            "py": "python",
+            "js": "javascript",
+            "ts": "typescript",
+            "cpp": "cpp",
+            "cc": "cpp",
+            "cxx": "cpp",
+            "cu": "cuda",
+        }.get(ext, ext or "python")
+
     async def _write_failure_artifact_async(
         self,
         *,
@@ -3094,6 +3111,7 @@ class ShinkaEvolveRunner:
         payload = {
             "generation": generation,
             "node_kind": "failed_proposal",
+            "language": self._get_failure_language(exec_path),
             "failure_stage": failure_stage,
             "failure_class": failure_class,
             "failure_reason": failure_reason,
@@ -3163,6 +3181,8 @@ class ShinkaEvolveRunner:
             novelty_cost
         )
         self.total_api_cost += terminal_failure_cost
+        if terminal_failure_cost > 0.0:
+            self._update_avg_proposal_cost(terminal_failure_cost)
         failure_class = self._classify_failed_proposal(
             failure_stage=failure_stage,
             failure_reason=failure_reason,
@@ -3193,6 +3213,7 @@ class ShinkaEvolveRunner:
             status="failed",
             details={
                 "node_kind": "failed_proposal",
+                "language": failure_payload.get("language"),
                 "failure_stage": failure_stage,
                 "failure_class": failure_class,
                 "failure_reason": failure_reason,

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -2101,10 +2101,7 @@ class ShinkaEvolveRunner:
                                         f"{self.completed_generations}"
                                     )
 
-                    # Record progress when jobs complete
                     self._record_progress()
-
-                    # Signal that slots are available
                     self.slot_available.set()
 
                 # Retry any failed DB jobs
@@ -2593,6 +2590,8 @@ class ShinkaEvolveRunner:
         novelty_checks_performed = 0
         novelty_total_cost = 0.0
         novelty_explanation = ""
+        last_failure_stage = "proposal"
+        last_failure_reason = "LLM failed to generate a valid proposal after all attempts"
         proposal_accepted = False
         parent_program: Optional[Program] = None
         archive_programs: List[Program] = []
@@ -2604,7 +2603,7 @@ class ShinkaEvolveRunner:
         # Select LLM once per program generation (before all loops)
         model_sample_probs = None
         model_posterior = None
-        if self.llm_selection is not None:
+        if getattr(self, "llm_selection", None) is not None:
             model_sample_probs, model_posterior = self.llm_selection.select_llm()
 
         for attempt in range(self.evo_config.max_novelty_attempts):
@@ -2668,12 +2667,20 @@ class ShinkaEvolveRunner:
                         )
 
                     if not patch_result:
+                        last_failure_stage = "proposal"
+                        last_failure_reason = "Patch generation returned no result"
                         continue
 
                     code_diff, meta_patch_data, success = patch_result
                     api_costs += meta_patch_data.get("api_costs", 0.0)
 
                     if not success:
+                        last_failure_stage = "proposal"
+                        last_failure_reason = (
+                            meta_patch_data.get("last_error_msg")
+                            or meta_patch_data.get("error_attempt")
+                            or "Patch generation failed before evaluation"
+                        )
                         continue
 
                     # We have a successful patch, break from resample loop
@@ -2683,6 +2690,8 @@ class ShinkaEvolveRunner:
                     logger.warning(
                         f"Error in patch generation attempt {resample + 1}: {e}"
                     )
+                    last_failure_stage = "proposal"
+                    last_failure_reason = str(e)
                     continue
             else:
                 # No successful patch in all resamples, continue to next novelty attempt
@@ -2731,11 +2740,27 @@ class ShinkaEvolveRunner:
                     novelty_explanation = novelty_metadata.get(
                         "novelty_explanation", ""
                     )
+                    meta_patch_data["novelty_checks_performed"] = (
+                        novelty_checks_performed
+                    )
+                    meta_patch_data["novelty_cost"] = novelty_total_cost
+                    meta_patch_data["novelty_explanation"] = novelty_explanation
+                    meta_patch_data["max_similarity"] = novelty_metadata.get(
+                        "max_similarity"
+                    )
+                    meta_patch_data["similarity_scores"] = novelty_metadata.get(
+                        "similarity_scores", []
+                    )
 
                     if should_accept:
                         proposal_accepted = True
                         break
                     # If not accepted, continue to next attempt (rejection sampling)
+                    last_failure_stage = "novelty"
+                    last_failure_reason = (
+                        novelty_explanation
+                        or "Proposal rejected by novelty check before downstream evaluation"
+                    )
                 else:
                     proposal_accepted = True
                     if not self.db.island_manager or not hasattr(
@@ -2849,24 +2874,46 @@ class ShinkaEvolveRunner:
 
             except Exception as e:
                 logger.error(f"Error submitting job: {e}")
-                await self._record_attempt_event(
+                await self._record_terminal_failed_proposal(
                     generation=generation,
-                    stage="evaluation_submit",
-                    status="failed",
-                    details={"error": str(e)},
+                    exec_fname=exec_fname,
+                    proposal_started_at=proposal_started_at,
+                    sampling_worker_id=sampling_worker_id,
+                    active_proposals_at_start=active_proposals_at_start,
+                    parent_program=parent_program,
+                    archive_programs=archive_programs,
+                    top_k_programs=top_k_programs,
+                    code_diff=code_diff,
+                    meta_patch_data=meta_patch_data,
+                    code_embedding=code_embedding,
+                    embed_cost=embed_cost,
+                    novelty_cost=novelty_total_cost,
+                    api_costs=api_costs,
+                    failure_stage="evaluation_submit",
+                    failure_reason=str(e),
                 )
                 return None
 
         logger.warning(
             f"Failed to generate proposal for generation {generation} after all attempts"
         )
-        await self._record_attempt_event(
+        await self._record_terminal_failed_proposal(
             generation=generation,
-            stage="proposal",
-            status="failed",
-            details={
-                "reason": "LLM failed to generate a valid proposal after all attempts"
-            },
+            exec_fname=exec_fname,
+            proposal_started_at=proposal_started_at,
+            sampling_worker_id=sampling_worker_id,
+            active_proposals_at_start=active_proposals_at_start,
+            parent_program=parent_program,
+            archive_programs=archive_programs,
+            top_k_programs=top_k_programs,
+            code_diff=code_diff,
+            meta_patch_data=meta_patch_data,
+            code_embedding=code_embedding,
+            embed_cost=embed_cost,
+            novelty_cost=novelty_total_cost,
+            api_costs=api_costs,
+            failure_stage=last_failure_stage,
+            failure_reason=last_failure_reason,
         )
         return None
 
@@ -2931,6 +2978,241 @@ class ShinkaEvolveRunner:
 
         metadata_file = attempt_dir / "metadata.json"
         await write_file_async(str(metadata_file), json.dumps(metadata, indent=2))
+
+    def _classify_failed_proposal(
+        self,
+        *,
+        failure_stage: str,
+        failure_reason: str,
+        meta_patch_data: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Normalize pre-evaluation failures into stable classes for UI/analytics."""
+        if failure_stage == "novelty":
+            return "novelty_rejected"
+        if failure_stage == "evaluation_submit":
+            return "evaluation_submit_failed"
+
+        reason = (failure_reason or "").lower()
+        error_attempt = str((meta_patch_data or {}).get("error_attempt") or "").lower()
+        last_error_msg = str((meta_patch_data or {}).get("last_error_msg") or "").lower()
+        combined = " ".join(
+            part for part in [reason, error_attempt, last_error_msg] if part
+        )
+
+        if (
+            "could not extract code" in combined
+            or "llm response content was none" in combined
+            or "no evolve-block regions found" in combined
+        ):
+            return "llm_output_invalid"
+        if (
+            "search text not found" in combined
+            or "no changes applied" in combined
+            or "editable regions" in combined
+        ):
+            return "patch_apply_failed"
+
+        return "proposal_generation_failed"
+
+    def _collect_failure_artifacts(
+        self,
+        *,
+        exec_fname: str,
+        meta_patch_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Collect the well-known artifact paths for a failed generation."""
+        exec_path = Path(exec_fname)
+        gen_dir = exec_path.parent
+        artifacts: Dict[str, Any] = {
+            "generation_dir": str(gen_dir),
+            "generated_code_path": str(exec_path),
+            "results_dir": str(gen_dir / "results"),
+        }
+
+        def add_if_exists(key: str, path: Path) -> None:
+            if path.exists():
+                artifacts[key] = str(path)
+
+        add_if_exists("generation_diff_path", gen_dir / "edit.diff")
+        add_if_exists("generation_search_replace_path", gen_dir / "search_replace.txt")
+        add_if_exists("generation_rewrite_path", gen_dir / "rewrite.txt")
+        add_if_exists("generation_original_path", gen_dir / f"original.{self.lang_ext}")
+
+        if meta_patch_data:
+            novelty_attempt = meta_patch_data.get("novelty_attempt")
+            resample_attempt = meta_patch_data.get("resample_attempt")
+            patch_attempt = meta_patch_data.get("patch_attempt")
+            if all(
+                value is not None
+                for value in [novelty_attempt, resample_attempt, patch_attempt]
+            ):
+                attempt_dir = (
+                    gen_dir
+                    / "attempts"
+                    / f"novelty_{novelty_attempt}"
+                    / f"resample_{resample_attempt}"
+                    / f"patch_{patch_attempt}"
+                )
+                artifacts["attempt_dir"] = str(attempt_dir)
+                add_if_exists("attempt_metadata_path", attempt_dir / "metadata.json")
+                add_if_exists("llm_response_path", attempt_dir / "llm_response.txt")
+                add_if_exists("attempt_patch_path", attempt_dir / "patch.txt")
+
+        return artifacts
+
+    async def _write_failure_artifact_async(
+        self,
+        *,
+        generation: int,
+        exec_fname: str,
+        parent_program: Optional[Program],
+        archive_programs: List[Program],
+        top_k_programs: List[Program],
+        meta_patch_data: Optional[Dict[str, Any]],
+        embed_cost: float,
+        novelty_cost: float,
+        api_costs: float,
+        failure_stage: str,
+        failure_class: str,
+        failure_reason: str,
+        code_embedding: Optional[List[float]],
+        proposal_started_at: float,
+        sampling_worker_id: Optional[int],
+        active_proposals_at_start: int,
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Write the durable `failure.json` payload for a failed generation."""
+        exec_path = Path(exec_fname)
+        failure_path = exec_path.parent / "failure.json"
+        artifacts = self._collect_failure_artifacts(
+            exec_fname=exec_fname,
+            meta_patch_data=meta_patch_data,
+        )
+
+        payload = {
+            "generation": generation,
+            "node_kind": "failed_proposal",
+            "failure_stage": failure_stage,
+            "failure_class": failure_class,
+            "failure_reason": failure_reason,
+            "timestamp": datetime.now().isoformat(),
+            "proposal_started_at": proposal_started_at,
+            "sampling_worker_id": sampling_worker_id,
+            "active_proposals_at_start": active_proposals_at_start,
+            "downstream_eval_submitted": False,
+            "generated_code_available": exec_path.exists(),
+            "code_embedding_available": bool(code_embedding),
+            "parent_id": parent_program.id if parent_program else None,
+            "archive_inspiration_ids": [p.id for p in archive_programs],
+            "top_k_inspiration_ids": [p.id for p in top_k_programs],
+            "patch_type": (meta_patch_data or {}).get("patch_type"),
+            "patch_name": (meta_patch_data or {}).get("patch_name"),
+            "patch_description": (meta_patch_data or {}).get("patch_description"),
+            "system_prompt_id": (meta_patch_data or {}).get("system_prompt_id"),
+            "api_costs": api_costs,
+            "embed_cost": embed_cost,
+            "novelty_cost": novelty_cost,
+            "novelty_checks_performed": (meta_patch_data or {}).get(
+                "novelty_checks_performed", 0
+            ),
+            "novelty_explanation": (meta_patch_data or {}).get(
+                "novelty_explanation", ""
+            ),
+            "max_similarity": (meta_patch_data or {}).get("max_similarity"),
+            "attempts": {
+                "novelty_attempt": (meta_patch_data or {}).get("novelty_attempt"),
+                "resample_attempt": (meta_patch_data or {}).get("resample_attempt"),
+                "patch_attempt": (meta_patch_data or {}).get("patch_attempt"),
+            },
+            "error_attempt": (meta_patch_data or {}).get("error_attempt"),
+            "last_error_msg": (meta_patch_data or {}).get("last_error_msg"),
+            "artifacts": artifacts,
+            "failure_json_path": str(failure_path),
+        }
+
+        await write_file_async(
+            str(failure_path),
+            json.dumps(payload, indent=2, sort_keys=True),
+        )
+        return str(failure_path), payload
+
+    async def _record_terminal_failed_proposal(
+        self,
+        *,
+        generation: int,
+        exec_fname: str,
+        proposal_started_at: float,
+        sampling_worker_id: Optional[int],
+        active_proposals_at_start: int,
+        parent_program: Optional[Program],
+        archive_programs: List[Program],
+        top_k_programs: List[Program],
+        code_diff: Optional[str],
+        meta_patch_data: Optional[Dict[str, Any]],
+        code_embedding: Optional[List[float]],
+        embed_cost: float,
+        novelty_cost: float,
+        api_costs: float,
+        failure_stage: str,
+        failure_reason: str,
+    ) -> None:
+        """Record one terminal pre-eval failure via attempt_log plus failure.json."""
+        failure_class = self._classify_failed_proposal(
+            failure_stage=failure_stage,
+            failure_reason=failure_reason,
+            meta_patch_data=meta_patch_data,
+        )
+        failure_json_path, failure_payload = await self._write_failure_artifact_async(
+            generation=generation,
+            exec_fname=exec_fname,
+            parent_program=parent_program,
+            archive_programs=archive_programs,
+            top_k_programs=top_k_programs,
+            meta_patch_data=meta_patch_data,
+            embed_cost=embed_cost,
+            novelty_cost=novelty_cost,
+            api_costs=api_costs,
+            failure_stage=failure_stage,
+            failure_class=failure_class,
+            failure_reason=failure_reason,
+            code_embedding=code_embedding,
+            proposal_started_at=proposal_started_at,
+            sampling_worker_id=sampling_worker_id,
+            active_proposals_at_start=active_proposals_at_start,
+        )
+        await self._record_attempt_event(
+            generation=generation,
+            stage=failure_stage,
+            status="failed",
+            details={
+                "node_kind": "failed_proposal",
+                "failure_stage": failure_stage,
+                "failure_class": failure_class,
+                "failure_reason": failure_reason,
+                "parent_id": parent_program.id if parent_program else None,
+                "archive_inspiration_ids": [p.id for p in archive_programs],
+                "top_k_inspiration_ids": [p.id for p in top_k_programs],
+                "code_diff_available": bool(code_diff),
+                "patch_type": (meta_patch_data or {}).get("patch_type"),
+                "patch_name": (meta_patch_data or {}).get("patch_name"),
+                "patch_description": (meta_patch_data or {}).get(
+                    "patch_description"
+                ),
+                "system_prompt_id": (meta_patch_data or {}).get("system_prompt_id"),
+                "model_name": (meta_patch_data or {}).get("model_name"),
+                "api_costs": api_costs,
+                "embed_cost": embed_cost,
+                "novelty_cost": novelty_cost,
+                "novelty_attempt": (meta_patch_data or {}).get("novelty_attempt"),
+                "resample_attempt": (meta_patch_data or {}).get("resample_attempt"),
+                "patch_attempt": (meta_patch_data or {}).get("patch_attempt"),
+                "max_similarity": (meta_patch_data or {}).get("max_similarity"),
+                "failure_json_path": failure_json_path,
+                "generated_code_available": failure_payload.get(
+                    "generated_code_available", False
+                ),
+                "downstream_eval_submitted": False,
+            },
+        )
 
     async def _run_fix_patch_async(
         self,
@@ -3132,6 +3414,7 @@ class ShinkaEvolveRunner:
                 "patch_description": patch_description,
                 "num_applied": 0,
                 "error_attempt": "Max fix attempts reached without success.",
+                "last_error_msg": error_str if "error_str" in locals() else None,
                 "novelty_attempt": novelty_attempt,
                 "resample_attempt": resample_attempt,
                 "patch_attempt": self.evo_config.max_patch_attempts,
@@ -3362,10 +3645,13 @@ class ShinkaEvolveRunner:
                 if "patch_description" in locals()
                 else None,
                 "error_attempt": "Max attempts reached without successful patch",
+                "last_error_msg": error_str if "error_str" in locals() else None,
                 "novelty_attempt": novelty_attempt,
                 "resample_attempt": resample_attempt,
                 "patch_attempt": self.evo_config.max_patch_attempts,
                 "system_prompt_id": current_prompt_id,  # Track evolved prompt
+                **llm_kwargs,
+                "llm_result": response.to_dict() if "response" in locals() and response else None,
             }
 
             return None, meta_patch_data, False
@@ -3472,31 +3758,62 @@ class ShinkaEvolveRunner:
         failure_reason: str,
     ) -> Optional[Program]:
         """Persist a pre-evaluation failure as an incorrect program row."""
-        postprocess_worker_id = None
         sampling_finished_at = time.time()
         postprocess_started_at = sampling_finished_at
+        postprocess_finished_at = postprocess_started_at
         source_job_id = f"failed:{failure_stage}:{generation}"
         try:
-            code = await self._read_file_async(exec_fname) or ""
-            postprocess_worker_id = await self.postprocess_slot_pool.acquire()
+            exec_path = Path(exec_fname)
+            code = ""
+            if exec_path.exists():
+                code = await self._read_file_async(exec_fname) or ""
+            failure_class = self._classify_failed_proposal(
+                failure_stage=failure_stage,
+                failure_reason=failure_reason,
+                meta_patch_data=meta_patch_data,
+            )
+            failure_json_path, failure_payload = await self._write_failure_artifact_async(
+                generation=generation,
+                exec_fname=exec_fname,
+                parent_program=parent_program,
+                archive_programs=archive_programs,
+                top_k_programs=top_k_programs,
+                meta_patch_data=meta_patch_data,
+                embed_cost=embed_cost,
+                novelty_cost=novelty_cost,
+                api_costs=api_costs,
+                failure_stage=failure_stage,
+                failure_class=failure_class,
+                failure_reason=failure_reason,
+                code_embedding=code_embedding,
+                proposal_started_at=proposal_started_at,
+                sampling_worker_id=sampling_worker_id,
+                active_proposals_at_start=active_proposals_at_start,
+            )
             metadata = with_pipeline_timing(
                 {
                     **(meta_patch_data or {}),
+                    "node_kind": "failed_proposal",
                     "api_costs": api_costs,
                     "embed_cost": embed_cost,
                     "novelty_cost": novelty_cost,
                     "failure_stage": failure_stage,
+                    "failure_class": failure_class,
                     "failure_reason": failure_reason,
                     "failure_persisted": True,
                     "results_missing": True,
                     "safe_processing": False,
+                    "downstream_eval_submitted": False,
+                    "failure_json_path": failure_json_path,
+                    "generated_code_available": bool(code.strip()),
+                    "failure_artifacts": failure_payload.get("artifacts", {}),
                     "source_job_id": source_job_id,
                     "source_generation": generation,
                     "stdout_log": "",
                     "stderr_log": failure_reason,
                     "sampling_worker_id": sampling_worker_id,
                     "evaluation_worker_id": None,
-                    "postprocess_worker_id": postprocess_worker_id,
+                    "postprocess_worker_id": None,
                     "active_proposals_at_start": active_proposals_at_start,
                     "running_eval_jobs_at_submit": 0,
                     "timeline_lane_mode": "pool_slots",
@@ -3510,7 +3827,7 @@ class ShinkaEvolveRunner:
                 evaluation_started_at=sampling_finished_at,
                 evaluation_finished_at=sampling_finished_at,
                 postprocess_started_at=postprocess_started_at,
-                postprocess_finished_at=postprocess_started_at,
+                postprocess_finished_at=postprocess_finished_at,
             )
             program = Program(
                 id=str(uuid.uuid4()),
@@ -3531,53 +3848,18 @@ class ShinkaEvolveRunner:
                 metadata=metadata,
             )
 
-            await asyncio.wait_for(
-                self.async_db.add_program_async(
-                    program,
-                    parent_id=program.parent_id,
-                    archive_insp_ids=program.archive_inspiration_ids,
-                    top_k_insp_ids=program.top_k_inspiration_ids,
-                    code_diff=program.code_diff,
-                    meta_patch_data=meta_patch_data,
-                    code_embedding=program.embedding,
-                    embed_cost=embed_cost,
-                    verbose=self.verbose,
-                    defer_maintenance=True,
-                ),
-                timeout=90.0,
+            await self.async_db.add_program_async(
+                program,
+                parent_id=program.parent_id,
+                archive_insp_ids=program.archive_inspiration_ids,
+                top_k_insp_ids=program.top_k_inspiration_ids,
+                code_diff=program.code_diff,
+                meta_patch_data=meta_patch_data,
+                code_embedding=program.embedding,
+                embed_cost=embed_cost,
+                verbose=self.verbose,
+                defer_maintenance=True,
             )
-
-            postprocess_finished_at = time.time()
-            program.metadata = with_pipeline_timing(
-                program.metadata,
-                pipeline_started_at=proposal_started_at,
-                sampling_started_at=proposal_started_at,
-                sampling_finished_at=sampling_finished_at,
-                evaluation_started_at=sampling_finished_at,
-                evaluation_finished_at=sampling_finished_at,
-                postprocess_started_at=postprocess_started_at,
-                postprocess_finished_at=postprocess_finished_at,
-            )
-            try:
-                await self._persist_program_metadata_async(program)
-            except Exception as e:
-                logger.warning(
-                    "Metadata persistence error for failed generation %s: %s",
-                    generation,
-                    e,
-                )
-            if hasattr(self.async_db, "run_program_maintenance_async"):
-                try:
-                    await self.async_db.run_program_maintenance_async(
-                        program,
-                        verbose=self.verbose,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Deferred maintenance error for failed generation %s: %s",
-                        generation,
-                        e,
-                    )
 
             await self._update_completed_generations()
             self._record_progress()
@@ -3591,14 +3873,12 @@ class ShinkaEvolveRunner:
             return program
         except Exception as e:
             logger.error(
-                "Failed to persist failed generation %s (%s): %s",
+                "Failed to persist failed generation %s (%s): %r",
                 generation,
                 failure_stage,
                 e,
             )
             return None
-        finally:
-            await self.postprocess_slot_pool.release(postprocess_worker_id)
 
     async def _persist_completed_job(
         self, job: AsyncRunningJob
@@ -4181,13 +4461,18 @@ class ShinkaEvolveRunner:
         old_completed = self.completed_generations
         try:
             async with self.processing_lock:
+                self._mark_surplus_completed_jobs_for_discard(completed_jobs)
                 await self._process_completed_jobs_safely(completed_jobs)
+                await self._update_completed_generations()
+                self.slot_available.set()
         finally:
             self._completed_jobs_pending = max(
                 0,
                 int(getattr(self, "_completed_jobs_pending", 0))
                 - len(completed_jobs),
             )
+
+        self._record_progress()
 
         if not self.verbose:
             return
@@ -5239,8 +5524,9 @@ class ShinkaEvolveRunner:
                 """
                 SELECT DISTINCT attempt_log.generation
                 FROM attempt_log
-                WHERE attempt_log.stage = 'proposal'
-                  AND attempt_log.status = 'failed'
+                WHERE attempt_log.status = 'failed'
+                  AND json_valid(attempt_log.details)
+                  AND json_extract(attempt_log.details, '$.node_kind') = 'failed_proposal'
                   AND attempt_log.generation < ?
                   AND attempt_log.generation NOT IN (
                       SELECT DISTINCT generation FROM programs

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -1687,6 +1687,7 @@ class ProgramDatabase:
                 p.embedding_pca_3d,
                 p.embedding_cluster_id,
                 p.language,
+                p.text_feedback,
                 p.top_k_inspiration_ids,
                 p.archive_inspiration_ids,
                 p.migration_history,

--- a/shinka/llm/prioritization.py
+++ b/shinka/llm/prioritization.py
@@ -681,13 +681,6 @@ class AsymmetricUCB(BanditBase):
         names = self._arm_names or [str(i) for i in range(self._n_arms)]
         post = self.posterior()
         n = self.n.astype(int)
-        mean = self._mean()
-        if self.use_exponential_scaling:
-            mean_disp = mean  # keep in log space
-            mean_label = "log mean"
-        else:
-            mean_disp = mean
-            mean_label = "mean"
         idx = np.arange(self._n_arms)
 
         # exploitation and exploration components
@@ -777,19 +770,17 @@ class AsymmetricUCB(BanditBase):
         )
 
         # Add columns
-        table.add_column("arm", style="white", width=19)
-        table.add_column("n", justify="right", style="green", width=3)
-        table.add_column("n_cost", justify="right", style="green", width=6)
-        table.add_column("div", justify="right", style="yellow", width=6)
-        table.add_column(mean_label, justify="right", style="blue", width=7)
-        table.add_column("tot_cost", justify="right", style="yellow", width=7)
-        table.add_column("mean_cost", justify="right", style="yellow", width=7)
-        table.add_column("exploit", justify="right", style="magenta", width=7)
-        table.add_column("explore", justify="right", style="cyan", width=7)
-        table.add_column("score_raw", justify="right", style="white", width=7)
-        table.add_column("score_cost", justify="right", style="white", width=5)
-        table.add_column("score", justify="right", style="bold white", width=7)
-        table.add_column("post", justify="right", style="bright_green", width=5)
+        table.add_column("arm", style="white", width=24)
+        table.add_column("n", justify="right", style="green", width=4)
+        table.add_column("n_cost", justify="right", style="green", width=7)
+        table.add_column("tot_cost", justify="right", style="yellow", width=8)
+        table.add_column("mean_cost", justify="right", style="yellow", width=8)
+        table.add_column("exploit", justify="right", style="magenta", width=8)
+        table.add_column("explore", justify="right", style="cyan", width=8)
+        table.add_column("score_raw", justify="right", style="white", width=8)
+        table.add_column("score_cost", justify="right", style="white", width=6)
+        table.add_column("score", justify="right", style="bold white", width=8)
+        table.add_column("post", justify="right", style="bright_green", width=6)
 
         # Add rows
         for i, name in enumerate(names):
@@ -809,8 +800,6 @@ class AsymmetricUCB(BanditBase):
                 display_name,
                 f"{n[i]:d}",
                 f"{n_costs[i]:d}",
-                f"{self.divs[i]:.3f}",
-                f"{mean_disp[i]:.4f}",
                 f"{tot_cost[i]:.4f}",
                 mean_cost_str,
                 f"{exploitation[i]:.4f}",

--- a/shinka/llm/prioritization.py
+++ b/shinka/llm/prioritization.py
@@ -773,23 +773,23 @@ class AsymmetricUCB(BanditBase):
             box=rich.box.ROUNDED,
             show_header=True,
             header_style="bold cyan",
-            width=150,
+            width=120,
         )
 
         # Add columns
-        table.add_column("arm", style="white", width=16)
-        table.add_column("n", justify="right", style="green")
-        table.add_column("n_cost", justify="right", style="green")
-        table.add_column("div", justify="right", style="yellow")
-        table.add_column(mean_label, justify="right", style="blue")
-        table.add_column("tot_cost", justify="right", style="yellow")
-        table.add_column("mean_cost", justify="right", style="yellow")
-        table.add_column("exploit", justify="right", style="magenta")
-        table.add_column("explore", justify="right", style="cyan")
-        table.add_column("score_raw", justify="right", style="white")
-        table.add_column("score_cost", justify="right", style="white")
-        table.add_column("score", justify="right", style="bold white")
-        table.add_column("post", justify="right", style="bright_green")
+        table.add_column("arm", style="white", width=19)
+        table.add_column("n", justify="right", style="green", width=3)
+        table.add_column("n_cost", justify="right", style="green", width=6)
+        table.add_column("div", justify="right", style="yellow", width=6)
+        table.add_column(mean_label, justify="right", style="blue", width=7)
+        table.add_column("tot_cost", justify="right", style="yellow", width=7)
+        table.add_column("mean_cost", justify="right", style="yellow", width=7)
+        table.add_column("exploit", justify="right", style="magenta", width=7)
+        table.add_column("explore", justify="right", style="cyan", width=7)
+        table.add_column("score_raw", justify="right", style="white", width=7)
+        table.add_column("score_cost", justify="right", style="white", width=5)
+        table.add_column("score", justify="right", style="bold white", width=7)
+        table.add_column("post", justify="right", style="bright_green", width=5)
 
         # Add rows
         for i, name in enumerate(names):

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -79,6 +79,77 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         except Exception:
             return None
 
+    def _language_from_suffix(self, suffix: str) -> str:
+        ext = suffix.lstrip(".").lower()
+        return {
+            "py": "python",
+            "js": "javascript",
+            "ts": "typescript",
+            "cpp": "cpp",
+            "cc": "cpp",
+            "cxx": "cpp",
+            "cu": "cuda",
+        }.get(ext, ext or "python")
+
+    def _resolve_failed_node_language(
+        self,
+        details: Dict[str, Any],
+        failure_payload: Optional[Dict[str, Any]],
+    ) -> str:
+        for source in (failure_payload or {}, details):
+            language = source.get("language")
+            if language:
+                return str(language)
+
+        generated_code_path = ((failure_payload or {}).get("artifacts", {}) or {}).get(
+            "generated_code_path"
+        )
+        if generated_code_path:
+            return self._language_from_suffix(Path(generated_code_path).suffix)
+
+        failure_json_path = details.get("failure_json_path")
+        if failure_json_path:
+            failure_path = Path(self.search_root) / failure_json_path
+            candidates = sorted(failure_path.parent.glob("main.*"))
+            if candidates:
+                return self._language_from_suffix(candidates[0].suffix)
+
+        return "python"
+
+    def _resolve_failed_node_code_path(
+        self,
+        details: Dict[str, Any],
+        failure_payload: Optional[Dict[str, Any]],
+    ) -> Optional[Path]:
+        generated_code_path = ((failure_payload or {}).get("artifacts", {}) or {}).get(
+            "generated_code_path"
+        )
+        if generated_code_path:
+            code_path = Path(self.search_root) / generated_code_path
+            if code_path.exists():
+                return code_path
+
+        failure_json_path = details.get("failure_json_path")
+        if not failure_json_path:
+            return None
+
+        failure_path = Path(self.search_root) / failure_json_path
+        language = self._resolve_failed_node_language(details, failure_payload)
+        preferred_suffix = {
+            "python": ".py",
+            "javascript": ".js",
+            "typescript": ".ts",
+            "cpp": ".cpp",
+            "cuda": ".cu",
+        }.get(language)
+        if preferred_suffix:
+            preferred_path = failure_path.parent / f"main{preferred_suffix}"
+            if preferred_path.exists():
+                return preferred_path
+
+        candidates = sorted(failure_path.parent.glob("main.*"))
+        return candidates[0] if candidates else None
+
     def _build_failed_node_dict(
         self,
         *,
@@ -93,6 +164,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         if failure_payload:
             for key in [
                 "failure_json_path",
+                "language",
                 "generated_code_available",
                 "downstream_eval_submitted",
                 "artifacts",
@@ -106,31 +178,20 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 if key in failure_payload:
                     metadata[key] = failure_payload[key]
 
+        language = self._resolve_failed_node_language(details, failure_payload)
         code = None
         if include_code and failure_payload:
-            generated_code_path = (
-                failure_payload.get("artifacts", {}) or {}
-            ).get("generated_code_path")
-            if generated_code_path:
-                code_path = Path(self.search_root) / generated_code_path
-                if code_path.exists():
-                    try:
-                        code = code_path.read_text(encoding="utf-8")
-                    except Exception:
-                        code = None
-            if code is None and failure_json_path:
-                failure_path = Path(self.search_root) / failure_json_path
-                fallback_code_path = failure_path.parent / "main.py"
-                if fallback_code_path.exists():
-                    try:
-                        code = fallback_code_path.read_text(encoding="utf-8")
-                    except Exception:
-                        code = None
+            code_path = self._resolve_failed_node_code_path(details, failure_payload)
+            if code_path is not None:
+                try:
+                    code = code_path.read_text(encoding="utf-8")
+                except Exception:
+                    code = None
 
         return {
             "id": self._make_failed_node_id(generation),
             "code": code,
-            "language": "python",
+            "language": language,
             "parent_id": details.get("parent_id"),
             "archive_inspiration_ids": details.get("archive_inspiration_ids") or [],
             "top_k_inspiration_ids": details.get("top_k_inspiration_ids") or [],
@@ -152,7 +213,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             "migration_history": [],
             "metadata": metadata,
             "in_archive": False,
-            "system_prompt_id": details.get("system_prompt_id"),
+            "system_prompt_id": metadata.get("system_prompt_id"),
         }
 
     def _load_failed_proposal_nodes(

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 import webbrowser
+from pathlib import Path
 from typing import Optional, Dict, Any, Tuple
 
 from shinka.database import DatabaseConfig, ProgramDatabase
@@ -52,6 +53,153 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
     def log_message(self, format, *args):
         """Override to provide more detailed logging."""
         print(f"\n[SERVER] {format % args}")
+
+    def _make_failed_node_id(self, generation: int) -> str:
+        return f"failed:proposal:{generation}"
+
+    def _parse_failed_node_generation(self, node_id: str) -> Optional[int]:
+        prefix = "failed:proposal:"
+        if not node_id.startswith(prefix):
+            return None
+        try:
+            return int(node_id[len(prefix) :])
+        except ValueError:
+            return None
+
+    def _read_failure_json(
+        self, failure_json_path: Optional[str]
+    ) -> Optional[Dict[str, Any]]:
+        if not failure_json_path:
+            return None
+        try:
+            failure_path = Path(self.search_root) / failure_json_path
+            if not failure_path.exists():
+                return None
+            return json.loads(failure_path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+    def _build_failed_node_dict(
+        self,
+        *,
+        generation: int,
+        created_at: float,
+        details: Dict[str, Any],
+        include_code: bool = False,
+    ) -> Dict[str, Any]:
+        failure_json_path = details.get("failure_json_path")
+        failure_payload = self._read_failure_json(failure_json_path)
+        metadata = dict(details)
+        if failure_payload:
+            for key in [
+                "failure_json_path",
+                "generated_code_available",
+                "downstream_eval_submitted",
+                "artifacts",
+                "attempts",
+                "api_costs",
+                "embed_cost",
+                "novelty_cost",
+                "novelty_explanation",
+                "max_similarity",
+            ]:
+                if key in failure_payload:
+                    metadata[key] = failure_payload[key]
+
+        code = None
+        if include_code and failure_payload:
+            generated_code_path = (
+                failure_payload.get("artifacts", {}) or {}
+            ).get("generated_code_path")
+            if generated_code_path:
+                code_path = Path(self.search_root) / generated_code_path
+                if code_path.exists():
+                    try:
+                        code = code_path.read_text(encoding="utf-8")
+                    except Exception:
+                        code = None
+            if code is None and failure_json_path:
+                failure_path = Path(self.search_root) / failure_json_path
+                fallback_code_path = failure_path.parent / "main.py"
+                if fallback_code_path.exists():
+                    try:
+                        code = fallback_code_path.read_text(encoding="utf-8")
+                    except Exception:
+                        code = None
+
+        return {
+            "id": self._make_failed_node_id(generation),
+            "code": code,
+            "language": "python",
+            "parent_id": details.get("parent_id"),
+            "archive_inspiration_ids": details.get("archive_inspiration_ids") or [],
+            "top_k_inspiration_ids": details.get("top_k_inspiration_ids") or [],
+            "island_idx": None,
+            "generation": generation,
+            "timestamp": created_at,
+            "code_diff": None,
+            "combined_score": 0.0,
+            "public_metrics": {},
+            "private_metrics": {},
+            "text_feedback": details.get("failure_reason", ""),
+            "correct": False,
+            "children_count": 0,
+            "complexity": 0.0,
+            "embedding": [],
+            "embedding_pca_2d": [],
+            "embedding_pca_3d": [],
+            "embedding_cluster_id": None,
+            "migration_history": [],
+            "metadata": metadata,
+            "in_archive": False,
+            "system_prompt_id": details.get("system_prompt_id"),
+        }
+
+    def _load_failed_proposal_nodes(
+        self,
+        abs_db_path: str,
+        *,
+        include_code: bool = False,
+        generation: Optional[int] = None,
+    ) -> list[Dict[str, Any]]:
+        conn = sqlite3.connect(abs_db_path, timeout=5.0, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        try:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA busy_timeout = 5000;")
+            query = """
+                SELECT generation, details, created_at
+                FROM attempt_log
+                WHERE status = 'failed'
+                  AND json_valid(details)
+                  AND json_extract(details, '$.node_kind') = 'failed_proposal'
+            """
+            params: list[Any] = []
+            if generation is not None:
+                query += " AND generation = ?"
+                params.append(generation)
+            query += " ORDER BY generation ASC, created_at DESC, id DESC"
+            cursor.execute(query, params)
+
+            selected: Dict[int, Dict[str, Any]] = {}
+            for row in cursor.fetchall():
+                gen = int(row["generation"])
+                if gen in selected:
+                    continue
+                try:
+                    details = json.loads(row["details"])
+                except json.JSONDecodeError:
+                    continue
+                selected[gen] = self._build_failed_node_dict(
+                    generation=gen,
+                    created_at=float(row["created_at"]),
+                    details=details,
+                    include_code=include_code,
+                )
+
+            return [selected[g] for g in sorted(selected)]
+        finally:
+            conn.close()
 
     def do_GET(self):
         print(f"\n[SERVER] Received GET request for: {self.path}")
@@ -248,15 +396,19 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 # Set WAL mode compatible settings for read-only connections
                 # Longer busy_timeout for concurrent access during evolution
                 if db.cursor:
-                    db.cursor.execute(
-                        "PRAGMA busy_timeout = 30000;"
-                    )  # 30 second timeout
-                    db.cursor.execute("PRAGMA journal_mode = WAL;")  # Ensure WAL mode
+                    db.cursor.execute("PRAGMA busy_timeout = 30000;")
+                    try:
+                        db.cursor.execute("PRAGMA journal_mode = WAL;")
+                    except sqlite3.OperationalError:
+                        pass
 
                 programs = db.get_all_programs()
 
                 # Convert Program objects to dicts for JSON
                 programs_dict = [p.to_dict() for p in programs]
+                programs_dict.extend(
+                    self._load_failed_proposal_nodes(abs_db_path, include_code=False)
+                )
 
                 # Update cache
                 db_cache[db_path] = (time.time(), programs_dict)
@@ -337,9 +489,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
                 if db.cursor:
                     db.cursor.execute("PRAGMA busy_timeout = 30000;")
-                    db.cursor.execute("PRAGMA journal_mode = WAL;")
+                    try:
+                        db.cursor.execute("PRAGMA journal_mode = WAL;")
+                    except sqlite3.OperationalError:
+                        pass
 
                 summaries = db.get_programs_summary()
+                summaries.extend(
+                    self._load_failed_proposal_nodes(abs_db_path, include_code=False)
+                )
                 self.send_json_response(summaries)
                 print(
                     f"[SERVER] Successfully served {len(summaries)} "
@@ -401,8 +559,27 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
                 if db.cursor:
                     db.cursor.execute("PRAGMA busy_timeout = 30000;")
+                    try:
+                        db.cursor.execute("PRAGMA journal_mode = WAL;")
+                    except sqlite3.OperationalError:
+                        pass
 
                 result = db.get_program_count_and_timestamp()
+                failed_nodes = self._load_failed_proposal_nodes(
+                    abs_db_path, include_code=False
+                )
+                if failed_nodes:
+                    result["count"] += len(failed_nodes)
+                    max_failure_timestamp = max(
+                        node["timestamp"]
+                        for node in failed_nodes
+                        if node.get("timestamp") is not None
+                    )
+                    if (
+                        result.get("max_timestamp") is None
+                        or max_failure_timestamp > result["max_timestamp"]
+                    ):
+                        result["max_timestamp"] = max_failure_timestamp
                 self.send_json_response(result)
                 return
 
@@ -450,6 +627,27 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.send_error(404, f"Database file not found: {actual_db_path}")
             return
 
+        failed_generation = self._parse_failed_node_generation(program_id)
+        if failed_generation is not None:
+            try:
+                failed_nodes = self._load_failed_proposal_nodes(
+                    abs_db_path,
+                    include_code=True,
+                    generation=failed_generation,
+                )
+                if not failed_nodes:
+                    self.send_error(404, f"Program not found: {program_id}")
+                    return
+                self.send_json_response(failed_nodes[0])
+                return
+            except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+                self.send_error(500, f"Database error: {str(e)}")
+                return
+            except Exception as e:
+                print(f"[SERVER] Error fetching failed node details: {e}")
+                self.send_error(500, f"Error: {str(e)}")
+                return
+
         max_retries = 8
         delay = 0.2
         for i in range(max_retries):
@@ -460,6 +658,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
                 if db.cursor:
                     db.cursor.execute("PRAGMA busy_timeout = 30000;")
+                    try:
+                        db.cursor.execute("PRAGMA journal_mode = WAL;")
+                    except sqlite3.OperationalError:
+                        pass
 
                 program = db.get(program_id)
                 if program is None:

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -276,6 +276,23 @@
         .analysis-section.full-width {
             grid-column: span 2;
         }
+
+        #throughput-eval-distribution-plot,
+        #throughput-completion-rate-plot {
+            min-width: 0;
+            max-width: 100%;
+        }
+
+        #throughput-eval-distribution-plot .js-plotly-plot,
+        #throughput-eval-distribution-plot .plot-container,
+        #throughput-eval-distribution-plot .svg-container,
+        #throughput-completion-rate-plot .js-plotly-plot,
+        #throughput-completion-rate-plot .plot-container,
+        #throughput-completion-rate-plot .svg-container {
+            width: 100% !important;
+            max-width: 100% !important;
+            overflow: hidden !important;
+        }
         
         /* Highlight Python code tabs */
         #agent-code, #solution-code {
@@ -2026,14 +2043,14 @@
                             <div id="throughput-occupancy-percent-plot" style="width: 100%; height: 320px; overflow: hidden;"></div>
                         </div>
                         <div class="analysis-section full-width">
-                            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px;">
-                                <div>
+                            <div style="display: grid; grid-template-columns: 1fr; gap: 10px; min-width: 0;">
+                                <div style="min-width: 0; overflow: hidden;">
                                     <h3>Evaluation Occupancy Distribution</h3>
-                                    <div id="throughput-eval-distribution-plot" style="width: 100%; height: 320px; overflow: hidden;"></div>
+                                    <div id="throughput-eval-distribution-plot" style="width: 100%; max-width: 100%; height: 240px; overflow: hidden;"></div>
                                 </div>
-                                <div>
+                                <div style="min-width: 0; overflow: hidden;">
                                     <h3>Completed Evaluations per Minute</h3>
-                                    <div id="throughput-completion-rate-plot" style="width: 100%; height: 320px; overflow: hidden;"></div>
+                                    <div id="throughput-completion-rate-plot" style="width: 100%; max-width: 100%; height: 240px; overflow: hidden;"></div>
                                 </div>
                             </div>
                         </div>
@@ -16551,7 +16568,7 @@ console.error("[DEBUG] Error in processData:", error);
                 },
                 height: 320,
                 margin: { l: 60, r: 20, t: 50, b: 50 },
-                legend: { orientation: 'h', x: 0.01, y: 1.12 },
+                legend: { orientation: 'h', x: 0.01, y: 1.12, font: { size: 11 } },
                 hovermode: 'x unified',
             }, { responsive: true, displayModeBar: false });
         }
@@ -16580,10 +16597,19 @@ console.error("[DEBUG] Error in processData:", error);
                     color: x.map(count => count === capacities.evaluation ? '#f59e0b' : '#60a5fa'),
                 },
             }], {
-                xaxis: { title: 'Occupied Evaluation Workers' },
-                yaxis: { title: 'Wall-Clock Share (%)', rangemode: 'tozero' },
-                height: 320,
-                margin: { l: 60, r: 20, t: 50, b: 50 },
+                xaxis: {
+                    title: 'Occupied Evaluation Workers',
+                    tickfont: { size: 10 },
+                    titlefont: { size: 11 },
+                },
+                yaxis: {
+                    title: 'Wall-Clock Share (%)',
+                    rangemode: 'tozero',
+                    tickfont: { size: 10 },
+                    titlefont: { size: 11 },
+                },
+                height: 240,
+                margin: { l: 50, r: 10, t: 30, b: 38 },
             }, { responsive: true, displayModeBar: false });
         }
 
@@ -16611,10 +16637,20 @@ console.error("[DEBUG] Error in processData:", error);
                 marker: { color: '#34d399' },
                 name: 'Evaluations / Minute',
             }], {
-                xaxis: { title: 'Wall Clock Time', type: 'date' },
-                yaxis: { title: 'Completed Evaluations', rangemode: 'tozero' },
-                height: 320,
-                margin: { l: 60, r: 20, t: 50, b: 50 },
+                xaxis: {
+                    title: 'Wall Clock Time',
+                    type: 'date',
+                    tickfont: { size: 10 },
+                    titlefont: { size: 11 },
+                },
+                yaxis: {
+                    title: 'Completed Evaluations',
+                    rangemode: 'tozero',
+                    tickfont: { size: 10 },
+                    titlefont: { size: 11 },
+                },
+                height: 240,
+                margin: { l: 50, r: 10, t: 30, b: 38 },
             }, { responsive: true, displayModeBar: false });
         }
 

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -555,6 +555,8 @@
         
         #tree {
             margin-top: 10px;
+            width: 100%;
+            min-width: 0;
         }
         
         #file-list-container {
@@ -1225,6 +1227,7 @@
         .left-content-section.active {
             display: block;
             height: 100%;
+            min-width: 0;
         }
         
         /* Meta-prompt view uses absolute positioning to fill parent when active */
@@ -3268,13 +3271,13 @@ ${'='.repeat(80)}
                 savePreferences();
                 
                 // Update the tree without complete redraw
-                if (window.currentTreeRoot) {
+                if (window.treeData) {
                     // Use requestAnimationFrame for smoother updates
                     if (window.treeUpdateRAF) {
                         cancelAnimationFrame(window.treeUpdateRAF);
                     }
                     window.treeUpdateRAF = requestAnimationFrame(function() {
-                        renderTree(window.currentTreeRoot, true); // true = reuse existing elements
+                        renderGraph(window.treeData, true);
                     });
                 }
             });
@@ -3286,8 +3289,8 @@ ${'='.repeat(80)}
                     divider.classList.remove('dragging');
                     
                     // Final update with reuse to ensure everything is correctly positioned
-                    if (window.currentTreeRoot) {
-                        renderTree(window.currentTreeRoot, true);
+                    if (window.treeData) {
+                        renderGraph(window.treeData, true);
                     }
                     
                     // Delay resetting the resize flag to prevent immediate refreshes
@@ -7730,11 +7733,21 @@ console.error("[DEBUG] Error in processData:", error);
         // Add specific panel resize handling to redraw the tree when panels are resized
         const observer = new ResizeObserver(() => {
             console.log("[DEBUG] Panel resized");
-            const resultSelect = document.getElementById('result-select');
-            
-            if (resultSelect.value) {
-                loadDatabase(resultSelect.value);
+
+            if (window.isResizing) {
+                return;
             }
+
+            if (window.treeResizeTimeout) {
+                clearTimeout(window.treeResizeTimeout);
+            }
+
+            window.treeResizeTimeout = setTimeout(() => {
+                const treeTab = document.querySelector('.left-tab[data-tab="tree-view"]');
+                if (window.treeData && treeTab && treeTab.classList.contains('active')) {
+                    renderGraph(window.treeData, true);
+                }
+            }, 100);
         });
         
         // Observe the tree panel for size changes

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -1823,14 +1823,14 @@
             <div id="tabs">
                 <div class="tab active" data-tab="agent-info">Meta</div>
                 <div class="tab" data-tab="pareto-front">Pareto</div>
-                <div class="tab" data-tab="meta-analysis">Scratchpad</div>
+                <div class="tab" data-tab="meta-analysis">Scratch</div>
                 <div class="tab" data-tab="node-details">Node</div>
                 <div class="tab" data-tab="agent-code">Code</div>
                 <div class="tab" data-tab="code-diff">Diff</div>
-                <div class="tab" data-tab="log-output">Evaluation</div>
+                <div class="tab" data-tab="log-output">Eval</div>
                 <div class="tab" data-tab="llm-result">LLM</div>
                 <div class="tab" data-tab="analysis">Analysis</div>
-                <div class="tab" data-tab="throughput">Throughput</div>
+                <div class="tab" data-tab="throughput">Usage</div>
             </div>
             <div id="tab-content">
                 <div id="agent-info" class="content-section active">
@@ -16520,7 +16520,7 @@ console.error("[DEBUG] Error in processData:", error);
                 traces.push({
                     x: series.x,
                     y: series.y.map(value => (value / stage.capacity) * 100),
-                    name: `${stage.label} Utilization`,
+                    name: `${stage.label} Util.`,
                     type: 'scatter',
                     mode: 'lines',
                     line: { color: stage.color, width: 2 },
@@ -16535,7 +16535,7 @@ console.error("[DEBUG] Error in processData:", error);
             traces.push({
                 x: [minStart * 1000, maxEnd * 1000],
                 y: [100, 100],
-                name: '100% Capacity',
+                name: '100% Cap.',
                 type: 'scatter',
                 mode: 'lines',
                 line: { color: '#6b7280', width: 1, dash: 'dot' },

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -1589,6 +1589,7 @@
                                     <th class="sortable" data-sort="rank">R<span class="sort-arrow"></span></th>
                                     <th class="sortable" data-sort="generation">G<span class="sort-arrow"></span></th>
                                     <th class="sortable" data-sort="archive">A<span class="sort-arrow"></span></th>
+                                    <th>Status</th>
                                     <th>Patch Name</th>
                                     <th>Type</th>
                                     <th class="sortable" data-sort="island_idx">I<span class="sort-arrow"></span></th>
@@ -4297,11 +4298,15 @@ console.error("[DEBUG] Error in processData:", error);
                     console.log("[DEBUG] Sample correct nodes:", correctValidNodes.slice(0, 3).map(d => ({id: d.id.substring(0, 8), correct: d.correct, score: d.combined_score})));
                 }
                 
-                // Fallback to all valid nodes if no correct nodes exist
+                // Fallback to evaluated incorrect nodes before using failed proposals
                 let scoringNodes = correctValidNodes;
                 if (correctValidNodes.length === 0) {
-                    console.warn("[DEBUG] No correct nodes found for scoring, falling back to all valid nodes");
-                    scoringNodes = allValidNodes;
+                    console.warn("[DEBUG] No correct nodes found for scoring, falling back to non-failed valid nodes");
+                    scoringNodes = allValidNodes.filter(d => !isFailedProposalNode(d));
+                    if (scoringNodes.length === 0) {
+                        console.warn("[DEBUG] No evaluated nodes found for scoring, falling back to all valid nodes");
+                        scoringNodes = allValidNodes;
+                    }
                     if (scoringNodes.length === 0) {
                         console.warn("[DEBUG] No valid nodes found for scoring");
                         window.allBestPaths = [];
@@ -4685,6 +4690,9 @@ console.error("[DEBUG] Error in processData:", error);
                                         return '#ff8c00'; // Always orange for single path
                                     }
                                 }
+                                if (isFailedProposalNode(n.data)) {
+                                    return '#c0392b';
+                                }
                                 return "#000"; // Default stroke
                             })
                             .style("stroke-width", n => {
@@ -4734,6 +4742,14 @@ console.error("[DEBUG] Error in processData:", error);
                                 <em>Common origin for all islands</em>
                             `);
                         } else {
+                            if (isFailedProposalNode(d.data)) {
+                                tooltip.html(`
+                                    <strong style="color: #ffb3b3; font-size: 13px;">${patchName}</strong><br>
+                                    <strong>Status:</strong> Failed Proposal<br>
+                                    <strong>Failure:</strong> ${escapeHtml(d.data.metadata.failure_class || d.data.metadata.failure_stage || 'failed_proposal')}<br>
+                                    <strong>Reason:</strong> ${escapeHtml(d.data.metadata.failure_reason || d.data.text_feedback || 'N/A')}
+                                `);
+                            } else {
                             tooltip.html(`
                                 <strong style="color: #58a6ff; font-size: 13px;">${patchName}</strong><br>
                                 <strong>Score:</strong> ${score}<br>
@@ -4741,6 +4757,7 @@ console.error("[DEBUG] Error in processData:", error);
                                 <strong>Island:</strong> ${islandIdx}<br>
                                 <strong>Model:</strong> ${modelName}
                             `);
+                            }
                         }
                         
                         tooltip.style("left", (event.pageX + 15) + "px")
@@ -4768,6 +4785,7 @@ console.error("[DEBUG] Error in processData:", error);
                     .style("fill", d => {
                         if (d.data.isUnifiedRoot) return '#9b59b6'; // Purple for unified root
                         if (d.data.id === window.bestNodeId) return '#ffd700';
+                        if (isFailedProposalNode(d.data)) return '#ffb3b3';
                         if (!d.data.correct) return '#e74c3c';
                         const score = d.data.combined_score;
                         if (score !== null && !isNaN(score)) {
@@ -4791,6 +4809,7 @@ console.error("[DEBUG] Error in processData:", error);
                                 }
                             }
                         }
+                        if (isFailedProposalNode(d.data)) return '#c0392b';
                         return "#000"; // Default stroke
                     })
                     .style("stroke-width", d => {
@@ -4804,6 +4823,7 @@ console.error("[DEBUG] Error in processData:", error);
                         }
                         return 3; // Default width
                     })
+                    .style("stroke-dasharray", d => isFailedProposalNode(d.data) ? "6,3" : null)
                     .style("filter", d => d.data.id === window.bestNodeId ? "drop-shadow(0px 3px 6px rgba(255, 140, 0, 0.5))" : "drop-shadow(0px 2px 4px rgba(0,0,0,0.2))");
 
                 // Add animated rings for the SINGLE best node
@@ -5743,6 +5763,8 @@ console.error("[DEBUG] Error in processData:", error);
                 analysisMetricsHtml = '<p>No analysis metrics.</p>';
             }
 
+            const failureSummaryHtml = buildFailureSummaryHtml(data);
+
             let gridItemsHtml = `
                     <div class="details-section">
                         <h5>General</h5>
@@ -5753,6 +5775,7 @@ console.error("[DEBUG] Error in processData:", error);
                         <p><strong>Children:</strong> ${data.children_count || 0}</p>
                         <p><strong>Complexity:</strong> ${data.complexity || 'N/A'}</p>
         </div>
+                    ${failureSummaryHtml}
                     <div class="details-section">
                         <h5>Performance Score</h5>
                         <p><strong>Combined Score:</strong> ${formatScore(data.combined_score)}</p>
@@ -6442,6 +6465,43 @@ console.error("[DEBUG] Error in processData:", error);
                 // Return the original value as string if it's not a valid number
                 return String(score);
             }
+        }
+
+        function isFailedProposalNode(program) {
+            return Boolean(
+                program &&
+                program.metadata &&
+                program.metadata.node_kind === 'failed_proposal'
+            );
+        }
+
+        function getFailureStatusLabel(program) {
+            if (isFailedProposalNode(program)) {
+                const failureClass = program.metadata.failure_class || program.metadata.failure_stage || 'failed_proposal';
+                return failureClass.replace(/_/g, ' ');
+            }
+            return program.correct ? 'correct' : 'incorrect';
+        }
+
+        function buildFailureSummaryHtml(data) {
+            if (!isFailedProposalNode(data)) {
+                return '';
+            }
+
+            const failureStage = data.metadata?.failure_stage || 'proposal';
+            const failureClass = data.metadata?.failure_class || 'failed_proposal';
+            const failureReason = data.metadata?.failure_reason || data.text_feedback || 'Failed before downstream evaluation.';
+            const failureJsonPath = data.metadata?.failure_json_path || 'N/A';
+
+            return `
+                <div class="details-section">
+                    <h5>Failure Summary</h5>
+                    <p><strong>Stage:</strong> ${escapeHtml(String(failureStage))}</p>
+                    <p><strong>Class:</strong> ${escapeHtml(String(failureClass))}</p>
+                    <p><strong>Reason:</strong> ${escapeHtml(String(failureReason))}</p>
+                    <p><strong>failure.json:</strong> <span class="metadata-value">${escapeHtml(String(failureJsonPath))}</span></p>
+                </div>
+            `;
         }
         // Create charts for the Meta Info tab
         function createCharts(currentGenId) {
@@ -8041,9 +8101,14 @@ console.error("[DEBUG] Error in processData:", error);
             pageData.forEach(prog => {
                 const row = document.createElement("tr");
                 row.setAttribute("data-node-id", prog.id);
+                const isFailedProposal = isFailedProposalNode(prog);
+                const statusLabel = getFailureStatusLabel(prog);
                 
                 // Style incorrect programs differently
-                if (!prog.correct) {
+                if (isFailedProposal) {
+                    row.style.backgroundColor = '#fff1f0';
+                    row.style.color = '#7a1c1c';
+                } else if (!prog.correct) {
                     row.style.backgroundColor = '#fff5f5';
                     row.style.color = '#721c24';
                 }
@@ -8066,6 +8131,7 @@ console.error("[DEBUG] Error in processData:", error);
                     <td>${prog.original_rank}</td>
                     <td>${prog.generation}</td>
                     <td style="text-align: center; color: ${prog.in_archive ? '#28a745' : '#6c757d'}; font-weight: bold;">${archiveStatus}</td>
+                    <td>${escapeHtml(statusLabel)}</td>
                     <td>${patchName}</td>
                     <td>${prog.metadata?.patch_type || 'N/A'}</td>
                     <td>${islandIdx}</td>
@@ -10211,7 +10277,15 @@ console.error("[DEBUG] Error in processData:", error);
                         
                         // Update node styles
                         node.selectAll('path')
-                            .style("stroke", n => ancestorIds.has(n.data.id) ? '#ff8c00' : "#000")
+                            .style("stroke", n => {
+                                if (ancestorIds.has(n.data.id)) {
+                                    return '#ff8c00';
+                                }
+                                if (isFailedProposalNode(n.data)) {
+                                    return '#c0392b';
+                                }
+                                return "#000";
+                            })
                             .style("stroke-width", n => ancestorIds.has(n.data.id) ? 3 : 2)
                             .style("filter", n => n.data.id === window.bestNodeId ? "drop-shadow(0px 2px 4px rgba(255, 140, 0, 0.3))" : "drop-shadow(0px 1px 2px rgba(0,0,0,0.2))");
                         
@@ -10252,14 +10326,23 @@ console.error("[DEBUG] Error in processData:", error);
                     const patchType = d.data.metadata.patch_type || 'N/A';
                     const islandIdx = d.data.island_idx;
                     
-                    tooltip.html(`
-                        <strong style="color: #58a6ff; font-size: 13px;">${patchName}</strong><br>
-                        <strong>Score:</strong> ${score}<br>
-                        <strong>Type:</strong> ${patchType}<br>
-                        <strong>Island:</strong> ${islandIdx}
-                    `)
-                    .style("left", (event.pageX + 15) + "px")
-                    .style("top", (event.pageY - 10) + "px");
+                    if (isFailedProposalNode(d.data)) {
+                        tooltip.html(`
+                            <strong style="color: #ffb3b3; font-size: 13px;">${patchName}</strong><br>
+                            <strong>Status:</strong> Failed Proposal<br>
+                            <strong>Failure:</strong> ${escapeHtml(d.data.metadata.failure_class || d.data.metadata.failure_stage || 'failed_proposal')}<br>
+                            <strong>Reason:</strong> ${escapeHtml(d.data.metadata.failure_reason || d.data.text_feedback || 'N/A')}
+                        `);
+                    } else {
+                        tooltip.html(`
+                            <strong style="color: #58a6ff; font-size: 13px;">${patchName}</strong><br>
+                            <strong>Score:</strong> ${score}<br>
+                            <strong>Type:</strong> ${patchType}<br>
+                            <strong>Island:</strong> ${islandIdx}
+                        `);
+                    }
+                    tooltip.style("left", (event.pageX + 15) + "px")
+                        .style("top", (event.pageY - 10) + "px");
                 })
                 .on('mousemove', (event) => {
                     d3.select(".node-tooltip")
@@ -10278,6 +10361,7 @@ console.error("[DEBUG] Error in processData:", error);
                     })
                     .style("fill", d => {
                         if (d.data.id === window.bestNodeId) return '#ffd700';
+                        if (isFailedProposalNode(d.data)) return '#ffb3b3';
                         if (!d.data.correct) return '#e74c3c';
                         const score = d.data.combined_score;
                         if (score !== null && !isNaN(score)) {
@@ -10297,9 +10381,11 @@ console.error("[DEBUG] Error in processData:", error);
                                 return "#000";
                             }
                         }
+                        if (isFailedProposalNode(d.data)) return '#c0392b';
                         return "#000";
                     })
                     .style("stroke-width", d => ancestorIds.has(d.data.id) ? 3 : 2)
+                    .style("stroke-dasharray", d => isFailedProposalNode(d.data) ? "6,3" : null)
                     .style("filter", d => d.data.id === window.bestNodeId ? "drop-shadow(0px 2px 4px rgba(255, 140, 0, 0.3))" : "drop-shadow(0px 1px 2px rgba(0,0,0,0.2))");
 
                 // Add animated rings for the SINGLE best node (island view)

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -366,6 +366,7 @@ def test_persist_failed_generation_stores_incorrect_program(tmp_path):
         failure_payload = json.loads((gen_dir / "failure.json").read_text())
         assert failure_payload["generation"] == 3
         assert failure_payload["node_kind"] == "failed_proposal"
+        assert failure_payload["language"] == "python"
         assert failure_payload["failure_stage"] == "proposal_failed"
         assert failure_payload["failure_class"] == "proposal_generation_failed"
         assert failure_payload["failure_reason"] == "LLM failed to generate a valid proposal"
@@ -467,6 +468,7 @@ def test_generate_evolved_proposal_records_failed_node_attempt_after_pre_eval_fa
         assert event["details"]["postprocess_finished_at"] is not None
 
         failure_payload = json.loads((gen_dir / "failure.json").read_text())
+        assert failure_payload["language"] == "python"
         assert failure_payload["failure_stage"] == "proposal"
         assert failure_payload["failure_class"] == "patch_apply_failed"
         assert failure_payload["failure_reason"] == "No changes applied"
@@ -566,6 +568,51 @@ def test_record_terminal_failed_proposal_updates_total_api_cost_once(tmp_path):
 
         assert runner.total_api_cost == 1.34
         assert len(async_db.attempt_events) == 1
+
+    asyncio.run(_run())
+
+
+def test_record_terminal_failed_proposal_updates_avg_proposal_cost(tmp_path):
+    async def _run():
+        async_db = _RecordingAsyncDB()
+        runner = _build_runner(
+            async_db=async_db,
+            total_api_cost=0.5,
+            completed_proposal_costs=[0.3],
+            avg_proposal_cost=0.3,
+        )
+
+        gen_dir = tmp_path / "gen_10"
+        gen_dir.mkdir()
+        exec_path = gen_dir / "main.py"
+
+        await runner._record_terminal_failed_proposal(
+            generation=10,
+            exec_fname=str(exec_path),
+            proposal_started_at=time.time(),
+            sampling_worker_id=None,
+            active_proposals_at_start=1,
+            parent_program=SimpleNamespace(id="parent-10"),
+            archive_programs=[],
+            top_k_programs=[],
+            code_diff=None,
+            meta_patch_data={
+                "api_costs": 0.06,
+                "novelty_attempt": 1,
+                "resample_attempt": 1,
+                "patch_attempt": 1,
+            },
+            code_embedding=None,
+            embed_cost=0.01,
+            novelty_cost=0.02,
+            api_costs=0.06,
+            failure_stage="proposal",
+            failure_reason="Could not extract code from patch string",
+        )
+
+        assert runner.total_api_cost == 0.59
+        assert runner.completed_proposal_costs == [0.3, 0.09]
+        assert runner.avg_proposal_cost == pytest.approx(0.195)
 
     asyncio.run(_run())
 

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -446,6 +446,7 @@ def test_generate_evolved_proposal_records_failed_node_attempt_after_pre_eval_fa
         )
 
         assert result is None
+        assert runner.total_api_cost == 0.1
         assert runner.completed_generations == 0
         assert len(async_db.programs) == 0
         assert len(async_db.attempt_events) == 1
@@ -457,6 +458,13 @@ def test_generate_evolved_proposal_records_failed_node_attempt_after_pre_eval_fa
         assert event["details"]["failure_stage"] == "proposal"
         assert event["details"]["failure_class"] == "patch_apply_failed"
         assert event["details"]["failure_reason"] == "No changes applied"
+        assert event["details"]["pipeline_started_at"] is not None
+        assert event["details"]["sampling_started_at"] is not None
+        assert event["details"]["sampling_finished_at"] is not None
+        assert event["details"]["evaluation_started_at"] is not None
+        assert event["details"]["evaluation_finished_at"] is not None
+        assert event["details"]["postprocess_started_at"] is not None
+        assert event["details"]["postprocess_finished_at"] is not None
 
         failure_payload = json.loads((gen_dir / "failure.json").read_text())
         assert failure_payload["failure_stage"] == "proposal"
@@ -519,6 +527,80 @@ def test_persist_failed_generation_skips_maintenance_and_handles_missing_code(tm
         assert async_db.maintenance_calls == 0
         assert program.metadata["postprocess_worker_id"] is None
         assert program.metadata["failure_json_path"] == str(gen_dir / "failure.json")
+
+    asyncio.run(_run())
+
+
+def test_record_terminal_failed_proposal_updates_total_api_cost_once(tmp_path):
+    async def _run():
+        async_db = _RecordingAsyncDB()
+        runner = _build_runner(async_db=async_db, total_api_cost=1.25)
+
+        gen_dir = tmp_path / "gen_9"
+        gen_dir.mkdir()
+        exec_path = gen_dir / "main.py"
+
+        await runner._record_terminal_failed_proposal(
+            generation=9,
+            exec_fname=str(exec_path),
+            proposal_started_at=time.time(),
+            sampling_worker_id=None,
+            active_proposals_at_start=2,
+            parent_program=SimpleNamespace(id="parent-9"),
+            archive_programs=[],
+            top_k_programs=[],
+            code_diff=None,
+            meta_patch_data={
+                "api_costs": 0.06,
+                "novelty_attempt": 1,
+                "resample_attempt": 1,
+                "patch_attempt": 1,
+            },
+            code_embedding=None,
+            embed_cost=0.01,
+            novelty_cost=0.02,
+            api_costs=0.06,
+            failure_stage="proposal",
+            failure_reason="Could not extract code from patch string",
+        )
+
+        assert runner.total_api_cost == 1.34
+        assert len(async_db.attempt_events) == 1
+
+    asyncio.run(_run())
+
+
+def test_maybe_evolve_prompt_updates_total_api_cost():
+    async def _run():
+        runner = _build_runner(
+            total_api_cost=1.0,
+            evo_config=SimpleNamespace(
+                evolve_prompts=True,
+                prompt_evolution_interval=1,
+                prompt_evo_top_k_programs=3,
+                language="python",
+                use_text_feedback=False,
+            ),
+            prompt_db=SimpleNamespace(last_generation=2, add=lambda *args, **kwargs: None),
+        )
+        runner.prompt_evolution_counter = 0
+        runner.prompt_sampler_evo = SimpleNamespace(
+            sample=lambda: SimpleNamespace(id="prompt-parent")
+        )
+        runner.prompt_evolver = SimpleNamespace(
+            evolve=lambda **kwargs: asyncio.sleep(
+                0, result=(SimpleNamespace(id="prompt-new", generation=3), "diff", 0.25)
+            )
+        )
+        runner.async_db.get_top_programs_async = lambda n: asyncio.sleep(0, result=[])
+        runner.meta_summarizer = None
+        runner.prompt_api_cost = 0.0
+        runner.verbose = False
+
+        await runner._maybe_evolve_prompt()
+
+        assert runner.prompt_api_cost == 0.25
+        assert runner.total_api_cost == 1.25
 
     asyncio.run(_run())
 

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1,10 +1,16 @@
 import asyncio
+import json
 import time
 from types import SimpleNamespace
 
 import pytest
 
-from shinka.core.async_runner import AsyncRunningJob, ShinkaEvolveRunner
+from shinka.core.async_runner import (
+    AsyncRunningJob,
+    CompletedJobPersistResult,
+    PersistedProgramEvent,
+    ShinkaEvolveRunner,
+)
 from shinka.core.runtime_slots import LogicalSlotPool
 
 
@@ -20,10 +26,27 @@ class _RecordingAsyncDB(_FakeAsyncDB):
     def __init__(self):
         super().__init__(total_programs=0)
         self.programs = []
+        self.maintenance_calls = 0
+        self.attempt_events = []
 
     async def add_program_async(self, program, **kwargs):
         self.programs.append((program, kwargs))
         self.total_programs += 1
+
+    async def run_program_maintenance_async(self, program, verbose=False):
+        self.maintenance_calls += 1
+
+    async def record_attempt_event_async(
+        self, generation, stage, status, details=None
+    ):
+        self.attempt_events.append(
+            {
+                "generation": generation,
+                "stage": stage,
+                "status": status,
+                "details": details or {},
+            }
+        )
 
 
 class _FakeSlotPool:
@@ -155,6 +178,10 @@ def _build_runner(**overrides):
     runner._evaluation_seconds_ewma = overrides.get("evaluation_ewma")
     runner.verbose = overrides.get("verbose", False)
     runner.cost_limit_reached = overrides.get("cost_limit_reached", False)
+    runner.lang_ext = overrides.get("lang_ext", "py")
+    runner.llm_selection = overrides.get("llm_selection")
+    runner.meta_summarizer = overrides.get("meta_summarizer")
+    runner.results_dir = overrides.get("results_dir", ".")
     runner.prompt_db = overrides.get("prompt_db")
     runner._prompt_percentile_recompute_task = overrides.get(
         "_prompt_percentile_recompute_task"
@@ -297,7 +324,9 @@ def test_persist_failed_generation_stores_incorrect_program(tmp_path):
         runner._update_completed_generations = _update_completed_generations
         runner._persist_program_metadata_async = _persist_program_metadata_async
 
-        exec_path = tmp_path / "candidate.py"
+        gen_dir = tmp_path / "gen_3"
+        gen_dir.mkdir()
+        exec_path = gen_dir / "main.py"
         exec_path.write_text("print('failed candidate')\n")
 
         program = await runner._persist_failed_generation(
@@ -324,11 +353,214 @@ def test_persist_failed_generation_stores_incorrect_program(tmp_path):
         assert program.combined_score == 0.0
         assert program.text_feedback == "LLM failed to generate a valid proposal"
         assert program.code == "print('failed candidate')\n"
+        assert program.metadata["node_kind"] == "failed_proposal"
         assert program.metadata["failure_stage"] == "proposal_failed"
+        assert program.metadata["failure_class"] == "proposal_generation_failed"
         assert program.metadata["failure_persisted"] is True
+        assert program.metadata["downstream_eval_submitted"] is False
+        assert program.metadata["failure_json_path"] == str(gen_dir / "failure.json")
         assert runner.completed_generations == 1
         assert slot_event.is_set() is True
         assert len(async_db.programs) == 1
+
+        failure_payload = json.loads((gen_dir / "failure.json").read_text())
+        assert failure_payload["generation"] == 3
+        assert failure_payload["node_kind"] == "failed_proposal"
+        assert failure_payload["failure_stage"] == "proposal_failed"
+        assert failure_payload["failure_class"] == "proposal_generation_failed"
+        assert failure_payload["failure_reason"] == "LLM failed to generate a valid proposal"
+        assert failure_payload["artifacts"]["generated_code_path"] == str(exec_path)
+        assert failure_payload["downstream_eval_submitted"] is False
+
+    asyncio.run(_run())
+
+
+def test_generate_evolved_proposal_records_failed_node_attempt_after_pre_eval_failure(
+    tmp_path,
+):
+    async def _run():
+        async_db = _RecordingAsyncDB()
+        runner = _build_runner(
+            async_db=async_db,
+            postprocess_slot_pool=_FakeSlotPool(),
+            evo_config=SimpleNamespace(
+                max_novelty_attempts=1,
+                max_patch_resamples=1,
+                num_generations=5,
+            ),
+        )
+        runner._record_progress = lambda: None
+        runner.novelty_judge = None
+
+        async def _update_completed_generations():
+            runner.completed_generations = await runner._count_completed_generations_from_db()
+
+        async def _persist_program_metadata_async(_program):
+            return None
+
+        async def _sample_with_fix_mode_async(**_kwargs):
+            return (
+                SimpleNamespace(id="parent-1", generation=1, island_idx=None),
+                [SimpleNamespace(id="archive-1")],
+                [SimpleNamespace(id="topk-1")],
+                False,
+            )
+
+        async def _run_patch_async(*_args, **_kwargs):
+            return (
+                None,
+                {
+                    "api_costs": 0.1,
+                    "patch_type": "diff",
+                    "patch_name": "broken_patch",
+                    "patch_description": "fails before evaluation",
+                    "patch_attempt": 1,
+                    "resample_attempt": 1,
+                    "novelty_attempt": 1,
+                    "last_error_msg": "No changes applied",
+                    "error_attempt": "Max attempts reached without successful patch",
+                },
+                False,
+            )
+
+        runner._update_completed_generations = _update_completed_generations
+        runner._persist_program_metadata_async = _persist_program_metadata_async
+        runner.async_db.sample_with_fix_mode_async = _sample_with_fix_mode_async
+        runner._run_patch_async = _run_patch_async
+
+        gen_dir = tmp_path / "gen_4"
+        gen_dir.mkdir()
+        exec_path = gen_dir / "main.py"
+
+        result = await runner._generate_evolved_proposal(
+            generation=4,
+            task_id="proposal-4",
+            exec_fname=str(exec_path),
+            results_dir=str(gen_dir / "results"),
+            meta_recs=None,
+            meta_summary=None,
+            meta_scratch=None,
+            proposal_started_at=time.time(),
+            sampling_worker_id=None,
+            active_proposals_at_start=1,
+        )
+
+        assert result is None
+        assert runner.completed_generations == 0
+        assert len(async_db.programs) == 0
+        assert len(async_db.attempt_events) == 1
+        event = async_db.attempt_events[0]
+        assert event["generation"] == 4
+        assert event["stage"] == "proposal"
+        assert event["status"] == "failed"
+        assert event["details"]["node_kind"] == "failed_proposal"
+        assert event["details"]["failure_stage"] == "proposal"
+        assert event["details"]["failure_class"] == "patch_apply_failed"
+        assert event["details"]["failure_reason"] == "No changes applied"
+
+        failure_payload = json.loads((gen_dir / "failure.json").read_text())
+        assert failure_payload["failure_stage"] == "proposal"
+        assert failure_payload["failure_class"] == "patch_apply_failed"
+        assert failure_payload["failure_reason"] == "No changes applied"
+
+    asyncio.run(_run())
+
+
+def test_persist_failed_generation_skips_maintenance_and_handles_missing_code(tmp_path):
+    async def _run():
+        async_db = _RecordingAsyncDB()
+        runner = _build_runner(
+            async_db=async_db,
+            postprocess_slot_pool=_FakeSlotPool(),
+            evo_config=SimpleNamespace(num_generations=5),
+        )
+        runner._record_progress = lambda: None
+
+        async def _update_completed_generations():
+            runner.completed_generations = await runner._count_completed_generations_from_db()
+
+        async def _persist_program_metadata_async(_program):
+            raise AssertionError("failed proposal persistence should not perform metadata rewrite")
+
+        runner._update_completed_generations = _update_completed_generations
+        runner._persist_program_metadata_async = _persist_program_metadata_async
+
+        gen_dir = tmp_path / "gen_4"
+        gen_dir.mkdir()
+        exec_path = gen_dir / "main.py"
+
+        program = await runner._persist_failed_generation(
+            generation=4,
+            exec_fname=str(exec_path),
+            proposal_started_at=time.time(),
+            sampling_worker_id=None,
+            active_proposals_at_start=1,
+            parent_program=SimpleNamespace(id="parent-1"),
+            archive_programs=[],
+            top_k_programs=[],
+            code_diff=None,
+            meta_patch_data={
+                "api_costs": 0.05,
+                "patch_type": "full",
+                "patch_name": "broken",
+                "error_attempt": "Max attempts reached without successful patch",
+                "last_error_msg": "Could not extract code from patch string",
+            },
+            code_embedding=None,
+            embed_cost=0.0,
+            novelty_cost=0.0,
+            api_costs=0.05,
+            failure_stage="proposal",
+            failure_reason="Could not extract code from patch string",
+        )
+
+        assert program is not None
+        assert program.code == ""
+        assert async_db.maintenance_calls == 0
+        assert program.metadata["postprocess_worker_id"] is None
+        assert program.metadata["failure_json_path"] == str(gen_dir / "failure.json")
+
+    asyncio.run(_run())
+
+
+def test_process_single_job_safely_applies_side_effects_inline():
+    async def _run():
+        runner = _build_runner()
+        job = AsyncRunningJob(
+            job_id="job-side-effects",
+            exec_fname="program.py",
+            results_dir="results",
+            start_time=time.time(),
+            proposal_started_at=time.time(),
+            evaluation_submitted_at=time.time(),
+            generation=9,
+        )
+        event = PersistedProgramEvent(
+            job=job,
+            program=SimpleNamespace(id="program-1"),
+            evaluation_finished_at=1.0,
+            postprocess_started_at=2.0,
+            postprocess_finished_at=3.0,
+        )
+        applied = []
+
+        async def persist_completed_job(_job):
+            return CompletedJobPersistResult(job=_job, success=True, persisted_event=event)
+
+        async def enqueue_background_side_effects(_events):
+            raise AssertionError("side effects should not be queued in inline mode")
+
+        async def apply_persisted_program_side_effects(_persisted_event):
+            applied.append(_persisted_event)
+
+        runner._persist_completed_job = persist_completed_job
+        runner._enqueue_background_side_effects = enqueue_background_side_effects
+        runner._apply_persisted_program_side_effects = apply_persisted_program_side_effects
+
+        success = await runner._process_single_job_safely(job)
+
+        assert success is True
+        assert applied == [event]
 
     asyncio.run(_run())
 

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -194,6 +194,28 @@ def test_asymmetric_ucb_print_summary_preserves_openrouter_prefix():
     assert "openrouter/exampl" in output
 
 
+
+def test_asymmetric_ucb_print_summary_matches_standard_summary_width():
+    bandit = AsymmetricUCB(
+        arm_names=["gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet"],
+        exploration_coef=2.0,
+        epsilon=0.1,
+        auto_decay=0.95,
+    )
+
+    bandit.set_baseline_score(0.5)
+    bandit.update_submitted("gpt-4o")
+    bandit.update("gpt-4o", reward=0.8, baseline=0.5)
+    bandit.update_submitted("gpt-4o-mini")
+    bandit.update("gpt-4o-mini", reward=0.6, baseline=0.5)
+
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    bandit.print_summary(console=console)
+    output_lines = buffer.getvalue().splitlines()
+
+    assert max(len(line) for line in output_lines) == 120
+
 if __name__ == "__main__":
     test_asymmetric_ucb_persistence()
     test_thompson_sampler_persistence()

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -194,7 +194,6 @@ def test_asymmetric_ucb_print_summary_preserves_openrouter_prefix():
     assert "openrouter/exampl" in output
 
 
-
 def test_asymmetric_ucb_print_summary_matches_standard_summary_width():
     bandit = AsymmetricUCB(
         arm_names=["gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet"],
@@ -215,6 +214,24 @@ def test_asymmetric_ucb_print_summary_matches_standard_summary_width():
     output_lines = buffer.getvalue().splitlines()
 
     assert max(len(line) for line in output_lines) == 120
+
+
+def test_asymmetric_ucb_print_summary_omits_div_and_log_mean_columns():
+    bandit = AsymmetricUCB(
+        arm_names=["gpt-4o"],
+        exploration_coef=2.0,
+        epsilon=0.1,
+        auto_decay=0.95,
+    )
+
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=False, width=200)
+    bandit.print_summary(console=console)
+    output = buffer.getvalue()
+
+    assert "│ div " not in output
+    assert "log mean" not in output
+
 
 if __name__ == "__main__":
     test_asymmetric_ucb_persistence()

--- a/tests/test_failure_nodes_webui.py
+++ b/tests/test_failure_nodes_webui.py
@@ -30,3 +30,11 @@ def test_webui_tree_styles_failed_proposal_nodes_distinctly():
     assert "if (isFailedProposalNode(d.data)) return '#ffb3b3';" in html
     assert "if (isFailedProposalNode(d.data)) return '#c0392b';" in html
     assert ".style(\"stroke-dasharray\", d => isFailedProposalNode(d.data) ? \"6,3\" : null)" in html
+
+
+def test_webui_tree_resizer_rerenders_graph_instead_of_reloading_data():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert "renderGraph(window.treeData, true);" in html
+    assert "window.treeResizeTimeout" in html
+    assert "if (window.isResizing) {" in html

--- a/tests/test_failure_nodes_webui.py
+++ b/tests/test_failure_nodes_webui.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VIZ_TREE_HTML = REPO_ROOT / "shinka" / "webui" / "viz_tree.html"
+
+
+def test_webui_defines_failed_proposal_node_helpers_and_details_section():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert "function isFailedProposalNode(program)" in html
+    assert "program.metadata.node_kind === 'failed_proposal'" in html
+    assert "function getFailureStatusLabel(program)" in html
+    assert "function buildFailureSummaryHtml(data)" in html
+    assert "<h5>Failure Summary</h5>" in html
+    assert "failure_json_path" in html
+
+
+def test_webui_program_table_includes_status_column_for_failed_nodes():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert "<th>Status</th>" in html
+    assert "const statusLabel = getFailureStatusLabel(prog);" in html
+    assert "const isFailedProposal = isFailedProposalNode(prog);" in html
+
+
+def test_webui_tree_styles_failed_proposal_nodes_distinctly():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert "if (isFailedProposalNode(d.data)) return '#ffb3b3';" in html
+    assert "if (isFailedProposalNode(d.data)) return '#c0392b';" in html
+    assert ".style(\"stroke-dasharray\", d => isFailedProposalNode(d.data) ? \"6,3\" : null)" in html

--- a/tests/test_program_summary.py
+++ b/tests/test_program_summary.py
@@ -37,3 +37,33 @@ def test_program_summary_excludes_full_embeddings_but_keeps_pca_fields():
             assert summaries[0]["embedding_cluster_id"] == 7
         finally:
             db.close()
+
+
+def test_program_summary_includes_text_feedback_for_lightweight_details():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "summary.db"
+        db = ProgramDatabase(
+            config=DatabaseConfig(db_path=str(db_path), num_islands=1),
+            embedding_model="",
+            read_only=False,
+        )
+        try:
+            db.add(
+                Program(
+                    id="failure-node",
+                    code="",
+                    correct=False,
+                    combined_score=0.0,
+                    generation=3,
+                    text_feedback="proposal failed before evaluation",
+                    metadata={"node_kind": "failed_proposal"},
+                )
+            )
+
+            summaries = db.get_programs_summary()
+
+            assert len(summaries) == 1
+            assert summaries[0]["text_feedback"] == "proposal failed before evaluation"
+            assert summaries[0]["metadata"]["node_kind"] == "failed_proposal"
+        finally:
+            db.close()

--- a/tests/test_runtime_timeline_webui.py
+++ b/tests/test_runtime_timeline_webui.py
@@ -105,6 +105,31 @@ def test_throughput_tab_contains_runtime_and_utilization_sections():
     assert "function renderThroughputOccupancyPercentPlot(rows, capacities)" in html
 
 
+def test_tab_labels_use_shortened_scratch_and_eval_text():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert '<div class="tab" data-tab="meta-analysis">Scratch</div>' in html
+    assert '<div class="tab" data-tab="log-output">Eval</div>' in html
+    assert '<div class="tab" data-tab="meta-analysis">Scratchpad</div>' not in html
+    assert '<div class="tab" data-tab="log-output">Evaluation</div>' not in html
+
+
+def test_throughput_tab_uses_usage_label():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert '<div class="tab" data-tab="throughput">Usage</div>' in html
+    assert '<div class="tab" data-tab="throughput">Throughput</div>' not in html
+
+
+def test_normalized_occupancy_plot_uses_short_util_label():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert "name: `${stage.label} Util.`" in html
+    assert "name: `${stage.label} Utilization`" not in html
+    assert "name: '100% Cap.'" in html
+    assert "name: '100% Capacity'" not in html
+
+
 def test_meta_panel_uses_update_wording_instead_of_generation_wording():
     html = VIZ_TREE_HTML.read_text(encoding="utf-8")
 

--- a/tests/test_runtime_timeline_webui.py
+++ b/tests/test_runtime_timeline_webui.py
@@ -105,6 +105,34 @@ def test_throughput_tab_contains_runtime_and_utilization_sections():
     assert "function renderThroughputOccupancyPercentPlot(rows, capacities)" in html
 
 
+def test_throughput_distribution_and_completion_plots_stack_vertically():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert (
+        '<div style="display: grid; grid-template-columns: 1fr; gap: 10px; min-width: 0;">'
+        in html
+    )
+    assert "<h3>Evaluation Occupancy Distribution</h3>" in html
+    assert "<h3>Completed Evaluations per Minute</h3>" in html
+    assert '<div style="min-width: 0; overflow: hidden;">' in html
+    assert (
+        'id="throughput-eval-distribution-plot" style="width: 100%; max-width: 100%; height: 240px; overflow: hidden;"'
+        in html
+    )
+    assert (
+        'id="throughput-completion-rate-plot" style="width: 100%; max-width: 100%; height: 240px; overflow: hidden;"'
+        in html
+    )
+    assert "#throughput-eval-distribution-plot .svg-container," in html
+    assert "#throughput-completion-rate-plot .svg-container {" in html
+    assert "max-width: 100% !important;" in html
+    assert "overflow: hidden !important;" in html
+    assert "height: 240," in html
+    assert "margin: { l: 50, r: 10, t: 30, b: 38 }" in html
+    assert "tickfont: { size: 10 }" in html
+    assert "titlefont: { size: 11 }" in html
+
+
 def test_tab_labels_use_shortened_scratch_and_eval_text():
     html = VIZ_TREE_HTML.read_text(encoding="utf-8")
 
@@ -128,6 +156,9 @@ def test_normalized_occupancy_plot_uses_short_util_label():
     assert "name: `${stage.label} Utilization`" not in html
     assert "name: '100% Cap.'" in html
     assert "name: '100% Capacity'" not in html
+    assert (
+        "legend: { orientation: 'h', x: 0.01, y: 1.12, font: { size: 11 } }" in html
+    )
 
 
 def test_meta_panel_uses_update_wording_instead_of_generation_wording():

--- a/tests/test_visualization_meta.py
+++ b/tests/test_visualization_meta.py
@@ -155,7 +155,7 @@ def test_handle_get_programs_summary_merges_failed_attempt_nodes(tmp_path):
             7,
             "proposal",
             "failed",
-            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"patch_apply_failed","failure_reason":"proposal failed","parent_id":"parent-1","failure_json_path":"results/gen_7/failure.json"}',
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"patch_apply_failed","failure_reason":"proposal failed","parent_id":"parent-1","failure_json_path":"results/gen_7/failure.json","pipeline_started_at":100.0,"sampling_started_at":100.0,"sampling_finished_at":105.0,"evaluation_started_at":105.0,"evaluation_finished_at":105.0,"postprocess_started_at":105.0,"postprocess_finished_at":105.0}',
             123.0,
         ),
     )
@@ -176,6 +176,8 @@ def test_handle_get_programs_summary_merges_failed_attempt_nodes(tmp_path):
     assert failed_node["parent_id"] == "parent-1"
     assert failed_node["metadata"]["node_kind"] == "failed_proposal"
     assert failed_node["text_feedback"] == "proposal failed"
+    assert failed_node["metadata"]["sampling_started_at"] == 100.0
+    assert failed_node["metadata"]["postprocess_finished_at"] == 105.0
 
 
 def test_handle_get_program_details_returns_failed_attempt_node(tmp_path):
@@ -230,7 +232,7 @@ def test_handle_get_program_details_returns_failed_attempt_node(tmp_path):
             7,
             "proposal",
             "failed",
-            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"llm_output_invalid","failure_reason":"proposal failed","failure_json_path":"results/gen_7/failure.json"}',
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"llm_output_invalid","failure_reason":"proposal failed","failure_json_path":"results/gen_7/failure.json","pipeline_started_at":100.0,"sampling_started_at":100.0,"sampling_finished_at":105.0,"evaluation_started_at":105.0,"evaluation_finished_at":105.0,"postprocess_started_at":105.0,"postprocess_finished_at":105.0}',
             123.0,
         ),
     )
@@ -250,6 +252,8 @@ def test_handle_get_program_details_returns_failed_attempt_node(tmp_path):
     assert sent["data"]["id"] == "failed:proposal:7"
     assert sent["data"]["code"] == "print('candidate')\n"
     assert sent["data"]["metadata"]["failure_class"] == "llm_output_invalid"
+    assert sent["data"]["metadata"]["pipeline_started_at"] == 100.0
+    assert sent["data"]["metadata"]["postprocess_finished_at"] == 105.0
 
 
 def test_handle_get_database_stats_uses_best_correct_program(tmp_path):

--- a/tests/test_visualization_meta.py
+++ b/tests/test_visualization_meta.py
@@ -256,6 +256,82 @@ def test_handle_get_program_details_returns_failed_attempt_node(tmp_path):
     assert sent["data"]["metadata"]["postprocess_finished_at"] == 105.0
 
 
+def test_handle_get_program_details_loads_failed_non_python_node_with_language_fallback(
+    tmp_path,
+):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    db_path = results_dir / "programs.sqlite"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE programs (
+            id TEXT PRIMARY KEY,
+            code TEXT,
+            generation INTEGER,
+            correct INTEGER,
+            combined_score REAL,
+            timestamp REAL,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE metadata_store (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE attempt_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            generation INTEGER NOT NULL,
+            stage TEXT NOT NULL,
+            status TEXT NOT NULL,
+            details TEXT,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    gen_dir = results_dir / "gen_8"
+    gen_dir.mkdir(parents=True)
+    (gen_dir / "main.js").write_text("console.log('candidate');\n", encoding="utf-8")
+    (gen_dir / "failure.json").write_text(
+        '{"language":"javascript","failure_reason":"proposal failed","failure_json_path":"results/gen_8/failure.json"}',
+        encoding="utf-8",
+    )
+    conn.execute(
+        "INSERT INTO attempt_log (generation, stage, status, details, created_at) VALUES (?, ?, ?, ?, ?)",
+        (
+            8,
+            "proposal",
+            "failed",
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"llm_output_invalid","failure_reason":"proposal failed","failure_json_path":"results/gen_8/failure.json"}',
+            130.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    handler = _make_handler(tmp_path)
+    sent = {}
+    handler.send_json_response = lambda data: sent.setdefault("data", data)
+    handler.send_error = lambda code, msg: sent.setdefault("error", (code, msg))
+
+    handler.handle_get_program_details(
+        "results/programs.sqlite", "failed:proposal:8"
+    )
+
+    assert "error" not in sent
+    assert sent["data"]["id"] == "failed:proposal:8"
+    assert sent["data"]["language"] == "javascript"
+    assert sent["data"]["code"] == "console.log('candidate');\n"
+
+
 def test_handle_get_database_stats_uses_best_correct_program(tmp_path):
     results_dir = tmp_path / "results"
     results_dir.mkdir(parents=True)

--- a/tests/test_visualization_meta.py
+++ b/tests/test_visualization_meta.py
@@ -84,6 +84,174 @@ def test_handle_get_meta_content_returns_processed_count(tmp_path):
     }
 
 
+def test_handle_get_programs_summary_merges_failed_attempt_nodes(tmp_path):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    db_path = results_dir / "programs.sqlite"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE programs (
+            id TEXT PRIMARY KEY,
+            parent_id TEXT,
+            generation INTEGER,
+            timestamp REAL,
+            combined_score REAL,
+            correct INTEGER,
+            complexity REAL,
+            island_idx INTEGER,
+            children_count INTEGER,
+            public_metrics TEXT,
+            private_metrics TEXT,
+            metadata TEXT,
+            embedding_pca_2d TEXT,
+            embedding_pca_3d TEXT,
+            embedding_cluster_id INTEGER,
+            language TEXT,
+            text_feedback TEXT,
+            top_k_inspiration_ids TEXT,
+            archive_inspiration_ids TEXT,
+            migration_history TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE archive (
+            program_id TEXT PRIMARY KEY
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE metadata_store (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE attempt_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            generation INTEGER NOT NULL,
+            stage TEXT NOT NULL,
+            status TEXT NOT NULL,
+            details TEXT,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    failure_json = results_dir / "gen_7" / "failure.json"
+    failure_json.parent.mkdir(parents=True)
+    failure_json.write_text(
+        '{"failure_reason":"proposal failed","failure_json_path":"results/gen_7/failure.json"}',
+        encoding="utf-8",
+    )
+    conn.execute(
+        "INSERT INTO attempt_log (generation, stage, status, details, created_at) VALUES (?, ?, ?, ?, ?)",
+        (
+            7,
+            "proposal",
+            "failed",
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"patch_apply_failed","failure_reason":"proposal failed","parent_id":"parent-1","failure_json_path":"results/gen_7/failure.json"}',
+            123.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    handler = _make_handler(tmp_path)
+    sent = {}
+    handler.send_json_response = lambda data: sent.setdefault("data", data)
+    handler.send_error = lambda code, msg: sent.setdefault("error", (code, msg))
+
+    handler.handle_get_programs_summary("results/programs.sqlite")
+
+    assert "error" not in sent
+    assert len(sent["data"]) == 1
+    failed_node = sent["data"][0]
+    assert failed_node["id"] == "failed:proposal:7"
+    assert failed_node["parent_id"] == "parent-1"
+    assert failed_node["metadata"]["node_kind"] == "failed_proposal"
+    assert failed_node["text_feedback"] == "proposal failed"
+
+
+def test_handle_get_program_details_returns_failed_attempt_node(tmp_path):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    db_path = results_dir / "programs.sqlite"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE programs (
+            id TEXT PRIMARY KEY,
+            code TEXT,
+            generation INTEGER,
+            correct INTEGER,
+            combined_score REAL,
+            timestamp REAL,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE metadata_store (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE attempt_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            generation INTEGER NOT NULL,
+            stage TEXT NOT NULL,
+            status TEXT NOT NULL,
+            details TEXT,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    gen_dir = results_dir / "gen_7"
+    gen_dir.mkdir(parents=True)
+    (gen_dir / "main.py").write_text("print('candidate')\n", encoding="utf-8")
+    (gen_dir / "failure.json").write_text(
+        '{"artifacts":{"generated_code_path":"results/gen_7/main.py"},"failure_reason":"proposal failed","failure_json_path":"results/gen_7/failure.json"}',
+        encoding="utf-8",
+    )
+    conn.execute(
+        "INSERT INTO attempt_log (generation, stage, status, details, created_at) VALUES (?, ?, ?, ?, ?)",
+        (
+            7,
+            "proposal",
+            "failed",
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"llm_output_invalid","failure_reason":"proposal failed","failure_json_path":"results/gen_7/failure.json"}',
+            123.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    handler = _make_handler(tmp_path)
+    sent = {}
+    handler.send_json_response = lambda data: sent.setdefault("data", data)
+    handler.send_error = lambda code, msg: sent.setdefault("error", (code, msg))
+
+    handler.handle_get_program_details(
+        "results/programs.sqlite", "failed:proposal:7"
+    )
+
+    assert "error" not in sent
+    assert sent["data"]["id"] == "failed:proposal:7"
+    assert sent["data"]["code"] == "print('candidate')\n"
+    assert sent["data"]["metadata"]["failure_class"] == "llm_output_invalid"
+
+
 def test_handle_get_database_stats_uses_best_correct_program(tmp_path):
     results_dir = tmp_path / "results"
     results_dir.mkdir(parents=True)


### PR DESCRIPTION
## What changed
- keep failed proposal artifacts out of the main `programs` table and align runtime budget accounting with failed attempts and prompt costs
- render failed proposal nodes from `attempt_log` / `failure.json` in the WebUI so failure lineage stays visible
- preserve failed-node language metadata in `failure.json` and respect it in the WebUI, including non-Python code fallback
- rerender the tree when the main panel divider moves so widening the tree pane actually expands the visible tree area
- align the LLM bandit summary width with the other Rich summary tables and simplify the default bandit columns
- tighten several WebUI labels and make the small throughput cards fit more reliably in narrow side panels

## Why
- failed proposals should remain observable without polluting the persisted program population
- budget accounting needs to include spend from failed proposal and prompt-evolution paths, including failure-heavy runs
- failed WebUI nodes should reflect the real source language instead of assuming Python
- the tree pane should use newly available horizontal space when the divider is dragged
- the bandit and throughput panels had several readability/layout issues in the right-hand WebUI panel

## How to test
- `uv run pytest -q tests/test_async_runner_recovery.py tests/test_failure_nodes_webui.py tests/test_program_summary.py tests/test_visualization_meta.py tests/test_bandit_persistence.py tests/test_runtime_timeline_webui.py`
- manually drag the main vertical divider in the WebUI and confirm the tree widens instead of being clipped

## Context for reviewers
- the branch includes both runtime persistence fixes and follow-up UI polish commits on the same area of the WebUI
- `CHANGELOG.md` was updated with the new bandit-summary notes
