### PR TITLE
fix: handle dynamic island roots in tree view

### DIFF
--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -4230,10 +4230,9 @@ console.error("[DEBUG] Error in processData:", error);
                 const rootNodes = hierarchyData.filter(n => !n.parent_id || !nodeMap.has(n.parent_id));
                 const virtualRootId = '___virtual_root___';
 
-                // Only create virtual root if we have multiple roots AND we don't have a unified root
-                const hasUnifiedRoot = rootNodes.some(n => n.isUnifiedRoot);
-                if (rootNodes.length > 1 && !hasUnifiedRoot) {
-                    hierarchyData.push({ id: virtualRootId, parent_id: '', agent_name: 'VIRTUAL ROOT', isVirtual: true, generation: -1 });
+                // Virtualize any remaining orphan roots, including island-spawned roots.
+                if (rootNodes.length > 1) {
+                    hierarchyData.push({ id: virtualRootId, parent_id: null, agent_name: 'VIRTUAL ROOT', isVirtual: true, generation: -1 });
                     rootNodes.forEach(rn => {
                         rn.parent_id = virtualRootId;
                     });

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -4143,6 +4143,30 @@ console.error("[DEBUG] Error in processData:", error);
             const maxTs = Math.max(...data.map(d => d.timestamp || 0));
             return `${count}-${maxGen}-${maxTs}`;
         }
+
+        function normalizeTreeRoots(nodes) {
+            const hierarchyData = JSON.parse(JSON.stringify(nodes));
+            const nodeMap = new Map(nodes.map(node => [node.id, node]));
+            const rootNodes = hierarchyData.filter(node => !node.parent_id || !nodeMap.has(node.parent_id));
+
+            if (rootNodes.length <= 1) {
+                return hierarchyData;
+            }
+
+            const virtualRootId = '___virtual_root___';
+            hierarchyData.push({
+                id: virtualRootId,
+                parent_id: null,
+                agent_name: 'VIRTUAL ROOT',
+                isVirtual: true,
+                generation: -1,
+            });
+            rootNodes.forEach(rootNode => {
+                rootNode.parent_id = virtualRootId;
+            });
+
+            return hierarchyData;
+        }
         
         function renderGraph(data, forceRender = false) {
             console.log("[DEBUG] Starting graph rendering with D3 tree layout");
@@ -4224,19 +4248,7 @@ console.error("[DEBUG] Error in processData:", error);
                 }
                 
                 const nodes = processedData.map(d => ({...d, agent_name: d.metadata.patch_name || d.agent_name || "unnamed_agent"}));
-                const nodeMap = new Map(nodes.map(node => [node.id, node]));
-
-                let hierarchyData = JSON.parse(JSON.stringify(nodes));
-                const rootNodes = hierarchyData.filter(n => !n.parent_id || !nodeMap.has(n.parent_id));
-                const virtualRootId = '___virtual_root___';
-
-                // Virtualize any remaining orphan roots, including island-spawned roots.
-                if (rootNodes.length > 1) {
-                    hierarchyData.push({ id: virtualRootId, parent_id: null, agent_name: 'VIRTUAL ROOT', isVirtual: true, generation: -1 });
-                    rootNodes.forEach(rn => {
-                        rn.parent_id = virtualRootId;
-                    });
-                }
+                const hierarchyData = normalizeTreeRoots(nodes);
                 
                 const root = d3.stratify()
                     .id(d => d.id)

--- a/tests/test_tree_roots_webui.py
+++ b/tests/test_tree_roots_webui.py
@@ -1,3 +1,6 @@
+import json
+import re
+import subprocess
 from pathlib import Path
 
 
@@ -5,9 +8,111 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 VIZ_TREE_HTML = REPO_ROOT / "shinka" / "webui" / "viz_tree.html"
 
 
-def test_webui_always_virtualizes_remaining_multiple_roots():
+def _extract_js_function_source(function_name: str) -> str:
     html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+    match = re.search(rf"function {function_name}\([^)]*\)\s*\{{", html)
+    assert match, f"Could not find function {function_name} in viz_tree.html"
 
-    assert "const hasUnifiedRoot = rootNodes.some(n => n.isUnifiedRoot);" not in html
-    assert "if (rootNodes.length > 1) {" in html
-    assert "parent_id: null" in html
+    brace_depth = 0
+    start = match.start()
+    body_start = html.find("{", match.start())
+
+    for idx in range(body_start, len(html)):
+        char = html[idx]
+        if char == "{":
+            brace_depth += 1
+        elif char == "}":
+            brace_depth -= 1
+            if brace_depth == 0:
+                return html[start : idx + 1]
+
+    raise AssertionError(f"Could not extract complete function body for {function_name}")
+
+
+def _run_normalize_tree_roots(nodes: list[dict]) -> list[dict]:
+    function_source = _extract_js_function_source("normalizeTreeRoots")
+    script = "\n".join(
+        [
+            function_source,
+            f"const input = {json.dumps(nodes)};",
+            "const result = normalizeTreeRoots(input);",
+            "console.log(JSON.stringify(result));",
+        ]
+    )
+    completed = subprocess.run(
+        ["node", "-e", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_normalize_tree_roots_virtualizes_unified_and_spawned_roots():
+    nodes = [
+        {
+            "id": "___unified_root___",
+            "parent_id": None,
+            "agent_name": "Initial Program",
+            "generation": 0,
+            "isUnifiedRoot": True,
+        },
+        {
+            "id": "gen0_a",
+            "parent_id": "___unified_root___",
+            "agent_name": "seed-a",
+            "generation": 0,
+        },
+        {
+            "id": "gen0_b",
+            "parent_id": "___unified_root___",
+            "agent_name": "seed-b",
+            "generation": 0,
+        },
+        {
+            "id": "spawned_root",
+            "parent_id": None,
+            "agent_name": "spawned-root",
+            "generation": 6,
+        },
+        {
+            "id": "spawned_child",
+            "parent_id": "spawned_root",
+            "agent_name": "spawned-child",
+            "generation": 7,
+        },
+    ]
+
+    normalized = _run_normalize_tree_roots(nodes)
+    normalized_by_id = {node["id"]: node for node in normalized}
+
+    assert nodes[0]["parent_id"] is None
+    assert nodes[3]["parent_id"] is None
+
+    root_ids = [node["id"] for node in normalized if not node.get("parent_id")]
+    assert root_ids == ["___virtual_root___"]
+    assert normalized_by_id["___virtual_root___"]["isVirtual"] is True
+    assert normalized_by_id["___unified_root___"]["parent_id"] == "___virtual_root___"
+    assert normalized_by_id["spawned_root"]["parent_id"] == "___virtual_root___"
+    assert normalized_by_id["spawned_child"]["parent_id"] == "spawned_root"
+
+
+def test_normalize_tree_roots_leaves_single_root_trees_unchanged():
+    nodes = [
+        {
+            "id": "root",
+            "parent_id": None,
+            "agent_name": "root",
+            "generation": 0,
+        },
+        {
+            "id": "child",
+            "parent_id": "root",
+            "agent_name": "child",
+            "generation": 1,
+        },
+    ]
+
+    normalized = _run_normalize_tree_roots(nodes)
+
+    assert normalized == nodes

--- a/tests/test_tree_roots_webui.py
+++ b/tests/test_tree_roots_webui.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VIZ_TREE_HTML = REPO_ROOT / "shinka" / "webui" / "viz_tree.html"
+
+
+def test_webui_always_virtualizes_remaining_multiple_roots():
+    html = VIZ_TREE_HTML.read_text(encoding="utf-8")
+
+    assert "const hasUnifiedRoot = rootNodes.some(n => n.isUnifiedRoot);" not in html
+    assert "if (rootNodes.length > 1) {" in html
+    assert "parent_id: null" in html


### PR DESCRIPTION
## Summary
- fix `viz_tree.html` so remaining orphan roots are always attached to a virtual root
- handle dynamic-island spawned roots without skipping the fallback when a unified gen-0 root exists
- add a WebUI regression test that locks in the root-normalization logic

## Why
Fixes #121. Dynamic island spawning can create later-generation roots with `parent_id = NULL`, which caused the tree view to hit D3 `multiple roots` errors.

## How to test
- `pytest tests/test_tree_roots_webui.py -q`
- `pytest tests/test_failure_nodes_webui.py -q`
- `pytest tests/test_dynamic_islands.py -q`
- `uv run ruff check tests --exclude tests/file.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
- `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`

## Context
The change is UI-local; no database or island-spawning semantics changed.