### PR TITLE
Add Vertex AI for Gemini models

### DIFF
--- a/shinka/cli/models.py
+++ b/shinka/cli/models.py
@@ -15,6 +15,7 @@ from shinka.embed.providers.pricing import (
     get_models_by_provider as get_embedding_models_by_provider,
 )
 from shinka.env import load_shinka_dotenv
+from shinka.google_genai import google_genai_auth_mode
 from shinka.llm.providers.pricing import get_all_providers, get_models_by_provider
 
 PROVIDER_ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
@@ -25,6 +26,11 @@ PROVIDER_ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
     "google": ("GEMINI_API_KEY",),
     "openai": ("OPENAI_API_KEY",),
     "openrouter": ("OPENROUTER_API_KEY",),
+    "vertexai": (
+        "GOOGLE_GENAI_USE_VERTEXAI",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+    ),
 }
 
 
@@ -54,7 +60,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "  azure: AZURE_OPENAI_API_KEY + AZURE_API_ENDPOINT + AZURE_API_VERSION\n"
         "  bedrock: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_REGION_NAME\n"
         "  deepseek: DEEPSEEK_API_KEY\n"
-        "  google: GEMINI_API_KEY\n"
+        "  google: GEMINI_API_KEY or GOOGLE_GENAI_USE_VERTEXAI + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION\n"
         "  openai: OPENAI_API_KEY\n"
         "  openrouter: OPENROUTER_API_KEY\n\n"
         "Security:\n"
@@ -85,8 +91,14 @@ def _env_var_status(env_var_names: tuple[str, ...]) -> dict[str, bool]:
     }
 
 
+def provider_env_requirements(provider: str) -> tuple[str, ...] | None:
+    if provider == "google" and google_genai_auth_mode() == "vertexai":
+        return PROVIDER_ENV_REQUIREMENTS["vertexai"]
+    return PROVIDER_ENV_REQUIREMENTS.get(provider)
+
+
 def _build_provider_entry(provider: str) -> dict[str, Any] | None:
-    env_var_names = PROVIDER_ENV_REQUIREMENTS.get(provider)
+    env_var_names = provider_env_requirements(provider)
     if env_var_names is None:
         return None
 

--- a/shinka/embed/client.py
+++ b/shinka/embed/client.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass
 import os
 from typing import Any, Optional, Tuple
 
-from google import genai
 import openai
 
 from shinka.env import load_shinka_dotenv
+from shinka.google_genai import _google_genai_timeout_ms, build_google_genai_client
 from shinka.local_openai_config import (
     parse_local_openai_model,
     resolve_local_openai_api_key,
@@ -91,7 +91,7 @@ def get_client_embed(model_name: str) -> Tuple[Any, str]:
             timeout=TIMEOUT,
         )
     elif provider == "google":
-        client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
     elif provider == "openrouter":
         client = openai.OpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],
@@ -125,7 +125,7 @@ def get_async_client_embed(model_name: str) -> Tuple[Any, str]:
         )
     elif provider == "google":
         # Gemini doesn't have async client yet, will use thread pool in embedding.py
-        client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
     elif provider == "openrouter":
         client = openai.AsyncOpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],

--- a/shinka/embed/embedding.py
+++ b/shinka/embed/embedding.py
@@ -4,6 +4,7 @@ from typing import Union, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from shinka.google_genai import google_genai_auth_mode
 from .client import (
     get_async_client_embed,
     get_client_embed,
@@ -25,7 +26,9 @@ def _get_google_embeddings_and_cost(
     """Embed texts with Gemini and bill using Gemini token counts when available."""
     embeddings = []
     total_tokens = 0
-    model = f"models/{model_name}"
+    model = (
+        model_name if google_genai_auth_mode() == "vertexai" else f"models/{model_name}"
+    )
     price_per_token = get_model_price(model_name)
 
     for text in texts:

--- a/shinka/google_genai.py
+++ b/shinka/google_genai.py
@@ -1,0 +1,51 @@
+import os
+from typing import Any
+
+from google import genai
+
+
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUE_ENV_VALUES
+
+
+def _google_genai_timeout_ms(timeout_seconds: int) -> int:
+    """Convert a second-based timeout to google-genai milliseconds."""
+    return int(timeout_seconds * 1000)
+
+
+def google_genai_auth_mode() -> str:
+    """Return the configured Google GenAI auth mode."""
+    return "vertexai" if _env_flag("GOOGLE_GENAI_USE_VERTEXAI") else "api_key"
+
+
+def build_google_genai_client(timeout_ms: int | None = None) -> genai.Client:
+    """Build a Google GenAI client for either direct Gemini API or Vertex AI."""
+    kwargs: dict[str, Any] = {}
+    if timeout_ms is not None:
+        kwargs["http_options"] = genai.types.HttpOptions(timeout=timeout_ms)
+
+    if google_genai_auth_mode() == "vertexai":
+        project = os.getenv("GOOGLE_CLOUD_PROJECT", "").strip()
+        location = os.getenv("GOOGLE_CLOUD_LOCATION", "").strip()
+        if not project:
+            raise ValueError(
+                "GOOGLE_CLOUD_PROJECT is required when GOOGLE_GENAI_USE_VERTEXAI is enabled."
+            )
+        if not location:
+            raise ValueError(
+                "GOOGLE_CLOUD_LOCATION is required when GOOGLE_GENAI_USE_VERTEXAI is enabled."
+            )
+        return genai.Client(
+            vertexai=True,
+            project=project,
+            location=location,
+            **kwargs,
+        )
+
+    api_key = os.getenv("GEMINI_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("GEMINI_API_KEY is required for Gemini API mode.")
+    return genai.Client(api_key=api_key, **kwargs)

--- a/shinka/google_genai.py
+++ b/shinka/google_genai.py
@@ -47,5 +47,9 @@ def build_google_genai_client(timeout_ms: int | None = None) -> genai.Client:
 
     api_key = os.getenv("GEMINI_API_KEY", "").strip()
     if not api_key:
-        raise ValueError("GEMINI_API_KEY is required for Gemini API mode.")
+        raise ValueError(
+            "Set GEMINI_API_KEY for Gemini API mode, or set "
+            "GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_CLOUD_PROJECT, and "
+            "GOOGLE_CLOUD_LOCATION for Vertex AI mode."
+        )
     return genai.Client(api_key=api_key, **kwargs)

--- a/shinka/llm/client.py
+++ b/shinka/llm/client.py
@@ -3,8 +3,8 @@ import os
 import anthropic
 import openai
 import instructor
-from google import genai
 from shinka.env import load_shinka_dotenv
+from shinka.google_genai import _google_genai_timeout_ms, build_google_genai_client
 from shinka.local_openai_config import resolve_local_openai_api_key
 from .constants import TIMEOUT
 from .providers.model_resolver import resolve_model_backend
@@ -19,13 +19,6 @@ def _build_azure_endpoint() -> str:
     if not endpoint.endswith("/"):
         endpoint += "/"
     return endpoint + "openai/v1/"
-
-
-def _google_genai_timeout_ms() -> int:
-    """Convert the shared second-based timeout to google-genai milliseconds."""
-    return int(TIMEOUT * 1000)
-
-
 def get_client_llm(
     model_name: str, structured_output: bool = False
 ) -> Tuple[Any, str, str]:
@@ -84,10 +77,7 @@ def get_client_llm(
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
     elif provider == "google":
-        client = genai.Client(
-            api_key=os.environ["GEMINI_API_KEY"],
-            http_options=genai.types.HttpOptions(timeout=_google_genai_timeout_ms()),
-        )
+        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
         if structured_output:
             client = instructor.from_openai(
                 client,
@@ -170,10 +160,7 @@ def get_async_client_llm(
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
     elif provider == "google":
-        client = genai.Client(
-            api_key=os.environ["GEMINI_API_KEY"],
-            http_options=genai.types.HttpOptions(timeout=_google_genai_timeout_ms()),
-        )
+        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
         if structured_output:
             raise ValueError("Gemini does not support structured output.")
     elif provider == "openrouter":

--- a/tests/test_embedding_client_backends.py
+++ b/tests/test_embedding_client_backends.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import openai
 import pytest
 
+import shinka.embed.client as embed_client_module
 from shinka.embed.client import get_async_client_embed, get_client_embed
 from shinka.embed.embedding import AsyncEmbeddingClient, EmbeddingClient
 
@@ -48,6 +49,48 @@ def test_get_async_client_embed_local_openai_inline_url(monkeypatch):
     assert isinstance(client, openai.AsyncOpenAI)
     assert model_name == "BAAI/bge-small-en-v1.5"
     assert str(client.base_url).startswith("http://localhost:8080")
+
+
+def test_get_client_embed_gemini_sets_timeout(monkeypatch):
+    captured_kwargs = {}
+    fake_client = object()
+
+    def _fake_build_google_genai_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(
+        embed_client_module,
+        "build_google_genai_client",
+        _fake_build_google_genai_client,
+    )
+
+    client, model_name = get_client_embed("gemini-embedding-001")
+
+    assert client is fake_client
+    assert model_name == "gemini-embedding-001"
+    assert captured_kwargs == {"timeout_ms": embed_client_module.TIMEOUT * 1000}
+
+
+def test_get_async_client_embed_gemini_sets_timeout(monkeypatch):
+    captured_kwargs = {}
+    fake_client = object()
+
+    def _fake_build_google_genai_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
+
+    monkeypatch.setattr(
+        embed_client_module,
+        "build_google_genai_client",
+        _fake_build_google_genai_client,
+    )
+
+    client, model_name = get_async_client_embed("gemini-embedding-001")
+
+    assert client is fake_client
+    assert model_name == "gemini-embedding-001"
+    assert captured_kwargs == {"timeout_ms": embed_client_module.TIMEOUT * 1000}
 
 
 def test_sync_openrouter_embedding_unknown_price_defaults_to_zero(monkeypatch):

--- a/tests/test_gemini_embedding_integration.py
+++ b/tests/test_gemini_embedding_integration.py
@@ -47,19 +47,23 @@ def test_new_gemini_embedding_model_is_registered():
 
 def test_get_client_embed_resolves_new_model_to_google(monkeypatch):
     captured = {}
+    fake_client = object()
 
-    class FakeGenAIClient:
-        def __init__(self, api_key=None):
-            captured["api_key"] = api_key
+    def _fake_build_google_genai_client(**kwargs):
+        captured.update(kwargs)
+        return fake_client
 
-    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
-    monkeypatch.setattr(embed_client.genai, "Client", FakeGenAIClient)
+    monkeypatch.setattr(
+        embed_client,
+        "build_google_genai_client",
+        _fake_build_google_genai_client,
+    )
 
     client, model_name = embed_client.get_client_embed(MODEL_NAME)
 
-    assert isinstance(client, FakeGenAIClient)
+    assert client is fake_client
     assert model_name == MODEL_NAME
-    assert captured["api_key"] == "test-key"
+    assert captured == {"timeout_ms": embed_client.TIMEOUT * 1000}
 
 
 def test_sync_google_embedding_uses_token_count_for_cost(monkeypatch):

--- a/tests/test_google_genai.py
+++ b/tests/test_google_genai.py
@@ -1,0 +1,112 @@
+import pytest
+
+import shinka.google_genai as google_genai_module
+
+
+def test_google_genai_timeout_is_in_milliseconds():
+    assert google_genai_module._google_genai_timeout_ms(1200) == 1_200_000
+
+
+@pytest.mark.parametrize("flag_value", ["1", "true", "yes", "on", "TRUE"])
+def test_google_genai_auth_mode_uses_vertexai_for_truthy_flag(
+    monkeypatch: pytest.MonkeyPatch, flag_value: str
+):
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", flag_value)
+
+    assert google_genai_module.google_genai_auth_mode() == "vertexai"
+
+
+def test_google_genai_auth_mode_defaults_to_api_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+
+    assert google_genai_module.google_genai_auth_mode() == "api_key"
+
+
+def test_build_google_genai_client_uses_api_key(monkeypatch: pytest.MonkeyPatch):
+    captured_kwargs = {}
+    fake_client = object()
+
+    class _FakeHttpOptions:
+        def __init__(self, **kwargs):
+            self.timeout = kwargs["timeout"]
+
+    def _fake_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
+
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    monkeypatch.setattr(google_genai_module.genai.types, "HttpOptions", _FakeHttpOptions)
+    monkeypatch.setattr(google_genai_module.genai, "Client", _fake_client)
+
+    client = google_genai_module.build_google_genai_client(timeout_ms=1234)
+
+    assert client is fake_client
+    assert captured_kwargs["api_key"] == "test-gemini-key"
+    assert captured_kwargs["http_options"].timeout == 1234
+
+
+def test_build_google_genai_client_uses_vertexai(monkeypatch: pytest.MonkeyPatch):
+    captured_kwargs = {}
+    fake_client = object()
+
+    class _FakeHttpOptions:
+        def __init__(self, **kwargs):
+            self.timeout = kwargs["timeout"]
+
+    def _fake_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
+
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setattr(google_genai_module.genai.types, "HttpOptions", _FakeHttpOptions)
+    monkeypatch.setattr(google_genai_module.genai, "Client", _fake_client)
+
+    client = google_genai_module.build_google_genai_client(timeout_ms=5678)
+
+    assert client is fake_client
+    assert captured_kwargs["vertexai"] is True
+    assert captured_kwargs["project"] == "test-project"
+    assert captured_kwargs["location"] == "us-central1"
+    assert captured_kwargs["http_options"].timeout == 5678
+
+
+def test_build_google_genai_client_requires_gemini_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="GEMINI_API_KEY") as exc_info:
+        google_genai_module.build_google_genai_client()
+
+    error_message = str(exc_info.value)
+    assert "Gemini API mode" in error_message
+    assert "GOOGLE_GENAI_USE_VERTEXAI" in error_message
+    assert "GOOGLE_CLOUD_PROJECT" in error_message
+    assert "GOOGLE_CLOUD_LOCATION" in error_message
+
+
+def test_build_google_genai_client_requires_vertex_project(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    with pytest.raises(ValueError, match="GOOGLE_CLOUD_PROJECT"):
+        google_genai_module.build_google_genai_client()
+
+
+def test_build_google_genai_client_requires_vertex_location(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+
+    with pytest.raises(ValueError, match="GOOGLE_CLOUD_LOCATION"):
+        google_genai_module.build_google_genai_client()

--- a/tests/test_llm_client_backends.py
+++ b/tests/test_llm_client_backends.py
@@ -1,12 +1,13 @@
 import pytest
 
 import shinka.llm.client as llm_client_module
+from shinka.google_genai import _google_genai_timeout_ms
 from shinka.llm.client import get_async_client_llm, get_client_llm
 from shinka.llm.constants import TIMEOUT
 
 
 def test_google_genai_timeout_is_in_milliseconds():
-    assert llm_client_module._google_genai_timeout_ms() == TIMEOUT * 1000
+    assert _google_genai_timeout_ms(TIMEOUT) == TIMEOUT * 1000
 
 
 def test_get_client_llm_dynamic_openrouter(monkeypatch):
@@ -58,38 +59,46 @@ def test_get_async_client_llm_openai_sets_timeout(monkeypatch):
 
 def test_get_client_llm_gemini_sets_timeout(monkeypatch):
     captured_kwargs = {}
+    fake_client = object()
 
-    class _FakeGenAIClient:
-        def __init__(self, **kwargs):
-            captured_kwargs.update(kwargs)
+    def _fake_build_google_genai_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
 
-    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
-    monkeypatch.setattr(llm_client_module.genai, "Client", _FakeGenAIClient)
+    monkeypatch.setattr(
+        llm_client_module,
+        "build_google_genai_client",
+        _fake_build_google_genai_client,
+    )
 
-    _client, model_name, provider = get_client_llm("gemini-2.5-flash")
+    client, model_name, provider = get_client_llm("gemini-2.5-flash")
 
+    assert client is fake_client
     assert provider == "google"
     assert model_name == "gemini-2.5-flash"
-    assert captured_kwargs["api_key"] == "test-gemini-key"
-    assert captured_kwargs["http_options"].timeout == TIMEOUT * 1000
+    assert captured_kwargs == {"timeout_ms": TIMEOUT * 1000}
 
 
 def test_get_async_client_llm_gemini_sets_timeout(monkeypatch):
     captured_kwargs = {}
+    fake_client = object()
 
-    class _FakeGenAIClient:
-        def __init__(self, **kwargs):
-            captured_kwargs.update(kwargs)
+    def _fake_build_google_genai_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
 
-    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
-    monkeypatch.setattr(llm_client_module.genai, "Client", _FakeGenAIClient)
+    monkeypatch.setattr(
+        llm_client_module,
+        "build_google_genai_client",
+        _fake_build_google_genai_client,
+    )
 
-    _client, model_name, provider = get_async_client_llm("gemini-2.5-flash")
+    client, model_name, provider = get_async_client_llm("gemini-2.5-flash")
 
+    assert client is fake_client
     assert provider == "google"
     assert model_name == "gemini-2.5-flash"
-    assert captured_kwargs["api_key"] == "test-gemini-key"
-    assert captured_kwargs["http_options"].timeout == TIMEOUT * 1000
+    assert captured_kwargs == {"timeout_ms": TIMEOUT * 1000}
 
 
 def test_get_client_llm_local_openai_uses_api_key_env_query_param(monkeypatch):

--- a/tests/test_shinka_models_cli.py
+++ b/tests/test_shinka_models_cli.py
@@ -19,6 +19,11 @@ PROVIDER_ENV_VARS = {
     "bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION_NAME"),
     "deepseek": ("DEEPSEEK_API_KEY",),
     "google": ("GEMINI_API_KEY",),
+    "vertexai": (
+        "GOOGLE_GENAI_USE_VERTEXAI",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+    ),
     "openai": ("OPENAI_API_KEY",),
     "openrouter": ("OPENROUTER_API_KEY",),
 }
@@ -120,6 +125,72 @@ def test_shinka_models_verbose_prints_full_payload(
         "embedding": expected_embedding_models,
         "llm": expected_llm_models,
     }
+
+
+def test_shinka_models_lists_google_models_when_vertex_env_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    exit_code, payload = _run_cli(capsys)
+
+    expected_embedding_models = _embedding_models_for_provider("google")
+    expected_llm_models = _llm_models_for_provider("google")
+    assert exit_code == 0
+    assert payload == {
+        "embedding": expected_embedding_models,
+        "llm": expected_llm_models,
+    }
+
+
+def test_shinka_models_verbose_uses_vertex_requirements_in_vertex_mode(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    exit_code, payload = _run_cli(capsys, ["--verbose"])
+
+    expected_llm_models = _llm_models_for_provider("google")
+    expected_embedding_models = _embedding_models_for_provider("google")
+    assert exit_code == 0
+    assert payload == {
+        "available_providers": [
+            {
+                "env_vars": {
+                    "GOOGLE_CLOUD_LOCATION": True,
+                    "GOOGLE_CLOUD_PROJECT": True,
+                    "GOOGLE_GENAI_USE_VERTEXAI": True,
+                },
+                "embedding_models": expected_embedding_models,
+                "llm_models": expected_llm_models,
+                "provider": "google",
+            }
+        ],
+        "embedding": expected_embedding_models,
+        "llm": expected_llm_models,
+    }
+
+
+def test_shinka_models_requires_full_vertex_environment(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(cli_models, "load_shinka_dotenv", lambda: ())
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+    exit_code, payload = _run_cli(capsys)
+
+    assert exit_code == 0
+    assert payload == {"embedding": [], "llm": []}
 
 
 def test_shinka_models_loads_dotenv_before_checking_provider_availability(


### PR DESCRIPTION
## Summary

- add Vertex AI authentication support for Gemini LLM and embedding clients through a shared Google GenAI client helper
- update `shinka_models` provider readiness checks
- add and update related unit tests

## Why

- This PR makes it possible to experiment with Gemini models via Vertex AI auth backend.

## Testing

- Commands run:
  - `uv run shinka_run ...`
- Results:
  - Vertex AI Gemini models working
  - Vertex AI embedding models have caveats (see Risks and compatibility section)

- Commands run:
  - `uv run ruff check tests --exclude tests/file.py`
  - `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
  - `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`
- Optional secret-backed tests:
  - `uv run pytest -q -m "requires_secrets"`
- Results:
  - Passed
  - `uv run pytest -q -m "not requires_secrets"`: had 1 warning from `tests/test_bandit_persistence.py` / `shinka/llm/prioritization.py` and appears unrelated to the Vertex AI change

## Risks and compatibility

- Existing Gemini API key behavior is preserved; this change adds an alternate auth path rather than replacing the current one
- Embedding models via Vertex AI
  - This feature does not separate auth for Gemini LLM and embedding models, meaning that when Vertex AI flag is on, both are used via Vertex AI.
  - Vertex AI API takes the raw embedding model name instead of the prefixed `models/<model_name>` form. Based on observed behavior during manual validation, `gemini-embedding-001` did not work on Vertex AI when the prefix was present.
  - For `gemini-embedding-001` on Vertex AI, `embed_content()` appears to work with the raw model name, but `count_tokens()` still does not. This PR preserves the existing fallback behavior when token counting fails, so embeddings can still succeed and cost falls back to the current estimate path.
  - `gemini-embedding-2-preview` appears problematic in Vertex AI testing regardless of the model-name format, so this PR does not attempt to resolve preview-model compatibility beyond the minimal naming change above.
  - Google also introduced the GA `gemini-embedding-2` model today/yesterday. That release may explain some of the preview-model instability, but this PR does not broaden scope beyond Vertex AI compatibility fix.



Thanks for the great work of the Shinka project! Been having fun playing with it :)