### PR TITLE
Fix: avoid silent retries when missing Gemini credentials

### DIFF
--- a/shinka/llm/providers/gemini.py
+++ b/shinka/llm/providers/gemini.py
@@ -13,6 +13,21 @@ MAX_TRIES = BACKOFF_MAX_TRIES
 MAX_VALUE = BACKOFF_MAX_VALUE
 MAX_TIME = BACKOFF_MAX_TIME
 
+NON_RETRYABLE_GEMINI_ERROR_MARKERS = (
+    "your default credentials were not found",
+    "could not automatically determine credentials",
+    "application default credentials",
+    "google_cloud_project is required",
+    "google_cloud_location is required",
+    "gemini_api_key",
+    "api key not valid",
+    "invalid api key",
+    "api_key_invalid",
+    "unauthenticated",
+    "permission denied",
+    "permission_denied",
+)
+
 
 def build_gemini_thinking_config(thinking_budget: int):
     """Build Gemini ThinkingConfig across SDK versions.
@@ -84,6 +99,18 @@ def backoff_handler(details):
         )
 
 
+def is_non_retryable_gemini_error(exc: Exception) -> bool:
+    """Return True for Gemini auth/config errors that retries cannot fix."""
+    error_text = str(exc).lower()
+    return any(marker in error_text for marker in NON_RETRYABLE_GEMINI_ERROR_MARKERS)
+
+
+def giveup_handler(details):
+    exc = details.get("exception")
+    if exc:
+        logger.error(f"Gemini - Non-retryable error: {exc}")
+
+
 def gemini_build_contents(msg_history, msg):
     """Build structured contents from message history and current message.
 
@@ -148,6 +175,8 @@ def gemini_extract_thoughts_and_content(response):
     max_value=MAX_VALUE,
     max_time=MAX_TIME,
     on_backoff=backoff_handler,
+    on_giveup=giveup_handler,
+    giveup=is_non_retryable_gemini_error,
 )
 def query_gemini(
     client,
@@ -224,6 +253,8 @@ def query_gemini(
     max_value=MAX_VALUE,
     max_time=MAX_TIME,
     on_backoff=backoff_handler,
+    on_giveup=giveup_handler,
+    giveup=is_non_retryable_gemini_error,
 )
 async def query_gemini_async(
     client,

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,3 +1,7 @@
+import asyncio
+
+import pytest
+
 from shinka.llm.providers import gemini
 
 
@@ -57,3 +61,80 @@ def test_build_gemini_afc_config_sets_max_remote_calls_none(monkeypatch):
     gemini.build_gemini_afc_config()
 
     assert captured == {"disable": True, "maximum_remote_calls": None}
+
+
+def test_gemini_adc_error_is_non_retryable():
+    assert gemini.is_non_retryable_gemini_error(
+        Exception("Your default credentials were not found")
+    )
+
+
+def test_gemini_api_key_error_is_non_retryable():
+    assert gemini.is_non_retryable_gemini_error(Exception("API key not valid."))
+
+
+def test_gemini_timeout_error_remains_retryable():
+    assert not gemini.is_non_retryable_gemini_error(Exception("deadline exceeded"))
+
+
+def test_query_gemini_does_not_retry_non_retryable_auth_errors():
+    class FakeModels:
+        def __init__(self):
+            self.calls = 0
+
+        def generate_content(self, **kwargs):
+            self.calls += 1
+            raise RuntimeError("Your default credentials were not found")
+
+    class FakeClient:
+        def __init__(self):
+            self.models = FakeModels()
+
+    client = FakeClient()
+
+    with pytest.raises(RuntimeError, match="default credentials"):
+        gemini.query_gemini(
+            client=client,
+            model="gemini-3-flash-preview",
+            msg="hello",
+            system_msg="",
+            msg_history=[],
+            output_model=None,
+        )
+
+    assert client.models.calls == 1
+
+
+def test_query_gemini_async_does_not_retry_non_retryable_auth_errors():
+    class FakeModels:
+        def __init__(self):
+            self.calls = 0
+
+        async def generate_content(self, **kwargs):
+            self.calls += 1
+            raise RuntimeError("Your default credentials were not found")
+
+    class FakeAio:
+        def __init__(self):
+            self.models = FakeModels()
+
+    class FakeClient:
+        def __init__(self):
+            self.aio = FakeAio()
+
+    async def run_test():
+        client = FakeClient()
+
+        with pytest.raises(RuntimeError, match="default credentials"):
+            await gemini.query_gemini_async(
+                client=client,
+                model="gemini-3-flash-preview",
+                msg="hello",
+                system_msg="",
+                msg_history=[],
+                output_model=None,
+            )
+
+        assert client.aio.models.calls == 1
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary

- Skip retries for Gemini authentication errors.

## Why

- Gemini calls previously retried every Exception, including credential failures that cannot recover through retry. This made **runs appear stuck** for `shinka_launch`, specifically when GCP (Vertex AI) Application Default Credentials were missing.

Before this change:

- For `shinka_launch`: When Vertex AI is selected with `GOOGLE_GENAI_USE_VERTEXAI=true` but ADC was missing, Gemini client could initialize but fail during the API call.
- The failure entered Gemini’s retry loop and could **spend a long time retrying** the credentials error silently.

After this change:

- Gemini provider calls classify common auth/config failures as non-retryable, skipping exponential retries for those errors.
- Transient errors, such as timeouts, still remain retryable.
- `shinka_launch` shows error quickly (but still stays in the evo loop, which could be a separate problem, not covered by this PR)

## Related Context
Related to the previous PR which added Vertex AI support: https://github.com/SakanaAI/ShinkaEvolve/pull/125

## Testing

- Commands run:
  - `uv run ruff check tests --exclude tests/file.py`
  - `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
  - `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`
- Optional secret-backed tests:
  - `uv run pytest -q -m "requires_secrets"`
- Results:
  - All passed