### PR TITLE
Validate model env access before async runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 ### Added
 
 - Added Vertex AI authentication support for Gemini LLM and embedding clients in PR #125. Thanks @wu375.
+- Added async-runner validation for configured LLM and embedding model environment access before run artifacts are created in PR #127. Thanks @RobertTLange.
 
 ### Fixed
 

--- a/shinka/cli/models.py
+++ b/shinka/cli/models.py
@@ -5,33 +5,15 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from typing import Any
 
-from shinka.embed.providers.pricing import (
-    get_all_providers as get_all_embedding_providers,
-)
-from shinka.embed.providers.pricing import (
-    get_models_by_provider as get_embedding_models_by_provider,
-)
 from shinka.env import load_shinka_dotenv
-from shinka.google_genai import google_genai_auth_mode
-from shinka.llm.providers.pricing import get_all_providers, get_models_by_provider
-
-PROVIDER_ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
-    "anthropic": ("ANTHROPIC_API_KEY",),
-    "azure": ("AZURE_OPENAI_API_KEY", "AZURE_API_ENDPOINT", "AZURE_API_VERSION"),
-    "bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION_NAME"),
-    "deepseek": ("DEEPSEEK_API_KEY",),
-    "google": ("GEMINI_API_KEY",),
-    "openai": ("OPENAI_API_KEY",),
-    "openrouter": ("OPENROUTER_API_KEY",),
-    "vertexai": (
-        "GOOGLE_GENAI_USE_VERTEXAI",
-        "GOOGLE_CLOUD_PROJECT",
-        "GOOGLE_CLOUD_LOCATION",
-    ),
-}
+from shinka.model_availability import (
+    build_model_availability_payload,
+    build_provider_availability_entry,
+    env_var_status,
+    provider_env_requirements as get_provider_env_requirements,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -85,64 +67,19 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _env_var_status(env_var_names: tuple[str, ...]) -> dict[str, bool]:
-    return {
-        env_var_name: bool(os.getenv(env_var_name, "").strip())
-        for env_var_name in sorted(env_var_names)
-    }
+    return env_var_status(env_var_names)
 
 
 def provider_env_requirements(provider: str) -> tuple[str, ...] | None:
-    if provider == "google" and google_genai_auth_mode() == "vertexai":
-        return PROVIDER_ENV_REQUIREMENTS["vertexai"]
-    return PROVIDER_ENV_REQUIREMENTS.get(provider)
+    return get_provider_env_requirements(provider)
 
 
 def _build_provider_entry(provider: str) -> dict[str, Any] | None:
-    env_var_names = provider_env_requirements(provider)
-    if env_var_names is None:
-        return None
-
-    env_vars = _env_var_status(env_var_names)
-    if not all(env_vars.values()):
-        return None
-
-    llm_models = sorted(get_models_by_provider(provider))
-    embedding_models = sorted(get_embedding_models_by_provider(provider))
-    if not llm_models and not embedding_models:
-        return None
-
-    return {
-        "provider": provider,
-        "env_vars": env_vars,
-        "llm_models": llm_models,
-        "embedding_models": embedding_models,
-    }
+    return build_provider_availability_entry(provider)
 
 
 def _build_payload() -> dict[str, Any]:
-    all_providers = sorted(
-        set(get_all_providers()) | set(get_all_embedding_providers())
-    )
-    available_providers = [
-        provider_entry
-        for provider in all_providers
-        if (provider_entry := _build_provider_entry(provider)) is not None
-    ]
-    llm_models = sorted(
-        model
-        for provider_entry in available_providers
-        for model in provider_entry["llm_models"]
-    )
-    embedding_models = sorted(
-        model
-        for provider_entry in available_providers
-        for model in provider_entry["embedding_models"]
-    )
-    return {
-        "available_providers": available_providers,
-        "embedding": embedding_models,
-        "llm": llm_models,
-    }
+    return build_model_availability_payload()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -15,7 +15,7 @@ import psutil
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Dict, Any, Set, Tuple, Union
+from typing import List, Optional, Dict, Any, Set, Tuple, Union, Iterable
 from dataclasses import dataclass, field
 from rich.console import Console
 from rich.table import Table
@@ -61,6 +61,7 @@ from shinka.core.prompt_evolver import (
 )
 from shinka.core.runtime_slots import LogicalSlotPool
 from shinka.logo import BannerStyle, get_logo_ascii, print_gradient_logo
+from shinka.model_availability import validate_model_env_access
 from shinka.utils import get_language_extension, parse_time_to_seconds
 from shinka.utils.languages import get_evolve_comment_prefix
 
@@ -175,6 +176,39 @@ class CompletedJobPersistResult:
     persisted_event: Optional[PersistedProgramEvent] = None
 
 
+def _dedupe_model_names(model_names: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for model_name in model_names:
+        if model_name in seen:
+            continue
+        seen.add(model_name)
+        deduped.append(model_name)
+    return deduped
+
+
+def _validate_evo_config_model_env_access(evo_config: EvolutionConfig) -> None:
+    llm_models = list(evo_config.llm_models)
+
+    if evo_config.meta_rec_interval and evo_config.meta_llm_models:
+        llm_models.extend(evo_config.meta_llm_models)
+
+    if evo_config.novelty_llm_models:
+        llm_models.extend(evo_config.novelty_llm_models)
+
+    if evo_config.evolve_prompts and evo_config.prompt_llm_models:
+        llm_models.extend(evo_config.prompt_llm_models)
+
+    embedding_models = (
+        [evo_config.embedding_model] if evo_config.embedding_model else []
+    )
+
+    validate_model_env_access(
+        llm_models=_dedupe_model_names(llm_models),
+        embedding_models=_dedupe_model_names(embedding_models),
+    )
+
+
 class ShinkaEvolveRunner:
     """Fully async evolution runner with concurrent proposal generation."""
 
@@ -210,6 +244,8 @@ class ShinkaEvolveRunner:
             evaluate_str: Optional string content for evaluate script
                 (will be saved to results dir and path updated in job_config)
         """
+        _validate_evo_config_model_env_access(evo_config)
+
         self.verbose = verbose
         # Setup results directory first
         if evo_config.results_dir is None:

--- a/shinka/model_availability.py
+++ b/shinka/model_availability.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from shinka.embed.client import resolve_embedding_backend
+from shinka.embed.providers.pricing import (
+    get_all_providers as get_all_embedding_providers,
+)
+from shinka.embed.providers.pricing import (
+    get_models_by_provider as get_embedding_models_by_provider,
+)
+from shinka.google_genai import google_genai_auth_mode
+from shinka.llm.providers.model_resolver import resolve_model_backend
+from shinka.llm.providers.pricing import get_all_providers, get_models_by_provider
+
+
+PROVIDER_ENV_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "azure": ("AZURE_OPENAI_API_KEY", "AZURE_API_ENDPOINT", "AZURE_API_VERSION"),
+    "bedrock": ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION_NAME"),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "google": ("GEMINI_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "vertexai": (
+        "GOOGLE_GENAI_USE_VERTEXAI",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ModelEnvAccessIssue:
+    model_kind: str
+    model_name: str
+    provider: str
+    missing_env_vars: tuple[str, ...]
+
+
+def env_var_status(env_var_names: tuple[str, ...]) -> dict[str, bool]:
+    return {
+        env_var_name: bool(os.getenv(env_var_name, "").strip())
+        for env_var_name in sorted(env_var_names)
+    }
+
+
+def provider_env_requirements(provider: str) -> tuple[str, ...] | None:
+    normalized_provider = "azure" if provider == "azure_openai" else provider
+    if normalized_provider == "google" and google_genai_auth_mode() == "vertexai":
+        return PROVIDER_ENV_REQUIREMENTS["vertexai"]
+    return PROVIDER_ENV_REQUIREMENTS.get(normalized_provider)
+
+
+def missing_env_vars_for_provider(provider: str) -> tuple[str, ...]:
+    env_var_names = provider_env_requirements(provider)
+    if env_var_names is None:
+        return ()
+    return tuple(
+        env_var_name
+        for env_var_name, is_present in env_var_status(env_var_names).items()
+        if not is_present
+    )
+
+
+def build_provider_availability_entry(provider: str) -> dict[str, Any] | None:
+    env_var_names = provider_env_requirements(provider)
+    if env_var_names is None:
+        return None
+
+    env_vars = env_var_status(env_var_names)
+    if not all(env_vars.values()):
+        return None
+
+    llm_models = sorted(get_models_by_provider(provider))
+    embedding_models = sorted(get_embedding_models_by_provider(provider))
+    if not llm_models and not embedding_models:
+        return None
+
+    return {
+        "provider": provider,
+        "env_vars": env_vars,
+        "llm_models": llm_models,
+        "embedding_models": embedding_models,
+    }
+
+
+def build_model_availability_payload() -> dict[str, Any]:
+    all_providers = sorted(
+        set(get_all_providers()) | set(get_all_embedding_providers())
+    )
+    available_providers = [
+        provider_entry
+        for provider in all_providers
+        if (provider_entry := build_provider_availability_entry(provider)) is not None
+    ]
+    llm_models = sorted(
+        model
+        for provider_entry in available_providers
+        for model in provider_entry["llm_models"]
+    )
+    embedding_models = sorted(
+        model
+        for provider_entry in available_providers
+        for model in provider_entry["embedding_models"]
+    )
+    return {
+        "available_providers": available_providers,
+        "embedding": embedding_models,
+        "llm": llm_models,
+    }
+
+
+def find_model_env_access_issues(
+    *,
+    llm_models: Iterable[str] = (),
+    embedding_models: Iterable[str] = (),
+) -> list[ModelEnvAccessIssue]:
+    issues: list[ModelEnvAccessIssue] = []
+
+    for model_name in llm_models:
+        resolved = resolve_model_backend(model_name)
+        issues.extend(
+            _model_env_access_issues(
+                model_kind="llm",
+                model_name=model_name,
+                provider=resolved.provider,
+                api_key_env_name=resolved.api_key_env_name,
+            )
+        )
+
+    for model_name in embedding_models:
+        resolved = resolve_embedding_backend(model_name)
+        issues.extend(
+            _model_env_access_issues(
+                model_kind="embedding",
+                model_name=model_name,
+                provider=resolved.provider,
+                api_key_env_name=resolved.api_key_env_name,
+            )
+        )
+
+    return issues
+
+
+def validate_model_env_access(
+    *,
+    llm_models: Iterable[str] = (),
+    embedding_models: Iterable[str] = (),
+) -> None:
+    issues = find_model_env_access_issues(
+        llm_models=llm_models,
+        embedding_models=embedding_models,
+    )
+    if not issues:
+        return
+
+    issue_text = "; ".join(
+        (
+            f"{issue.model_kind} model '{issue.model_name}' "
+            f"(provider: {issue.provider}) missing "
+            f"{', '.join(issue.missing_env_vars)}"
+        )
+        for issue in issues
+    )
+    raise ValueError(
+        "Requested model(s) are unavailable because required environment "
+        f"variables are missing: {issue_text}. Run `shinka_models --verbose` "
+        "to inspect provider availability."
+    )
+
+
+def _model_env_access_issues(
+    *,
+    model_kind: str,
+    model_name: str,
+    provider: str,
+    api_key_env_name: str | None,
+) -> list[ModelEnvAccessIssue]:
+    missing_env_vars = missing_env_vars_for_provider(provider)
+
+    if provider == "local_openai" and api_key_env_name:
+        missing_env_vars = (
+            (api_key_env_name,) if not os.getenv(api_key_env_name, "").strip() else ()
+        )
+
+    if not missing_env_vars:
+        return []
+
+    return [
+        ModelEnvAccessIssue(
+            model_kind=model_kind,
+            model_name=model_name,
+            provider=provider,
+            missing_env_vars=missing_env_vars,
+        )
+    ]

--- a/tests/test_model_availability.py
+++ b/tests/test_model_availability.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from shinka.core import EvolutionConfig, ShinkaEvolveRunner
+from shinka.database import DatabaseConfig
+from shinka.launch import LocalJobConfig
+from shinka.model_availability import validate_model_env_access
+
+
+_PROVIDER_ENV_VARS = (
+    "ANTHROPIC_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_API_ENDPOINT",
+    "AZURE_API_VERSION",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_REGION_NAME",
+    "DEEPSEEK_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_GENAI_USE_VERTEXAI",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_LOCATION",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "LOCAL_OPENAI_API_KEY",
+)
+
+
+def _clear_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for env_var_name in _PROVIDER_ENV_VARS:
+        monkeypatch.delenv(env_var_name, raising=False)
+
+
+def test_validate_model_env_access_rejects_missing_llm_provider_key(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_provider_env(monkeypatch)
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_model_env_access(llm_models=["gpt-5-mini"])
+
+    error = str(exc_info.value)
+    assert "gpt-5-mini" in error
+    assert "OPENAI_API_KEY" in error
+
+
+def test_validate_model_env_access_allows_local_models_without_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_provider_env(monkeypatch)
+
+    validate_model_env_access(
+        llm_models=["local/qwen2.5-coder@http://localhost:11434/v1"],
+        embedding_models=["local/BAAI/bge-small-en-v1.5@http://localhost:8080/v1"],
+    )
+
+
+def test_validate_model_env_access_rejects_local_model_with_missing_key_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_provider_env(monkeypatch)
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_model_env_access(
+            llm_models=[
+                "local/qwen2.5-coder@https://api.example.test/v1?api_key_env=CUSTOM_API_KEY"
+            ],
+        )
+
+    error = str(exc_info.value)
+    assert "CUSTOM_API_KEY" in error
+    assert "local/qwen2.5-coder" in error
+
+
+def test_validate_model_env_access_rejects_missing_embedding_provider_key(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_provider_env(monkeypatch)
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_model_env_access(embedding_models=["text-embedding-3-small"])
+
+    error = str(exc_info.value)
+    assert "text-embedding-3-small" in error
+    assert "OPENAI_API_KEY" in error
+
+
+def test_validate_model_env_access_rejects_incomplete_vertex_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "1")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_model_env_access(llm_models=["gemini-3-flash-preview"])
+
+    error = str(exc_info.value)
+    assert "gemini-3-flash-preview" in error
+    assert "GOOGLE_CLOUD_LOCATION" in error
+
+
+def test_async_runner_fails_fast_when_requested_model_env_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    _clear_provider_env(monkeypatch)
+    results_dir = tmp_path / "results"
+
+    with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+        ShinkaEvolveRunner(
+            evo_config=EvolutionConfig(
+                llm_models=["gpt-5-mini"],
+                llm_dynamic_selection=None,
+                meta_rec_interval=None,
+                embedding_model=None,
+                num_generations=1,
+                results_dir=str(results_dir),
+            ),
+            job_config=LocalJobConfig(),
+            db_config=DatabaseConfig(),
+            verbose=False,
+        )
+
+    assert not results_dir.exists()


### PR DESCRIPTION
## What changed
- Centralized provider env/model availability checks in `shinka.model_availability`.
- Refactored `shinka_models` to reuse the shared availability utility.
- Added an async runner startup guard that validates requested mutation, meta, novelty, prompt-evolution, and embedding models before creating run artifacts or clients.
- Added tests for missing provider keys, incomplete Vertex env, local model exceptions, embedding checks, and runner fail-fast behavior.

## Why
Runs with unavailable provider credentials should fail before entering the evolution loop, with an actionable message pointing to the missing env vars and `shinka_models --verbose`.

## Testing
- `uv run pytest -q tests/test_model_availability.py tests/test_shinka_models_cli.py tests/test_launch_hydra_async.py tests/test_shinka_run_cli.py`
- `uv run pytest -q tests/test_llm_client_backends.py tests/test_embedding_client_backends.py tests/test_model_resolver.py tests/test_embedding_model_resolver.py tests/test_google_genai.py`
- `uv run ruff check shinka/model_availability.py shinka/cli/models.py shinka/core/async_runner.py tests/test_model_availability.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports shinka/model_availability.py tests/test_model_availability.py`

Note: mypy on `shinka/core/async_runner.py` still reports existing unrelated typing issues, so I scoped the type check to the new utility and tests.
