### PR TITLE
fix: resize bandit state on model changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed bandit sampler resume from legacy or changed `llm_models` state so saved per-arm arrays are resized, name-aligned when possible, and cost-aware UCB range state remains active after loading `bandit_state.pkl` in PR #130, addressing issue #129.
 - Fixed the WebUI embedding similarity heatmap so hydrated programs with empty embeddings no longer leave the tab stuck on `Loading full embedding data...`, and stale cached full-program data is refetched after summary updates.
 
 ## 0.0.5 - 2026-04-22

--- a/shinka/llm/prioritization.py
+++ b/shinka/llm/prioritization.py
@@ -572,6 +572,32 @@ class AsymmetricUCB(BanditBase):
 
         return cost_ref / cost_denom
 
+    def _restore_cost_range(self, state: Dict[str, Any]) -> None:
+        if (
+            self._state_arm_layout_matches(state, "n_costs")
+            and "min_cost_observed" in state
+            and "max_cost_observed" in state
+        ):
+            self.min_cost_observed = float(state["min_cost_observed"])
+            self.max_cost_observed = float(state["max_cost_observed"])
+            return
+
+        have_cost = self.n_costs > 0.0
+        if not np.any(have_cost):
+            self.min_cost_observed = np.inf
+            self.max_cost_observed = -np.inf
+            return
+
+        mean_costs = self.total_costs[have_cost] / self.n_costs[have_cost]
+        finite_costs = mean_costs[np.isfinite(mean_costs)]
+        if finite_costs.size == 0:
+            self.min_cost_observed = np.inf
+            self.max_cost_observed = -np.inf
+            return
+
+        self.min_cost_observed = float(finite_costs.min())
+        self.max_cost_observed = float(finite_costs.max())
+
     def posterior(self, subset=None, samples=None):
         idx = self._resolve_subset(subset)
         if samples is None or int(samples) <= 1:
@@ -898,6 +924,8 @@ class AsymmetricUCB(BanditBase):
             "obs_min": self._obs_min,
             "n_costs": self.n_costs.copy(),
             "total_costs": self.total_costs.copy(),
+            "min_cost_observed": self.min_cost_observed,
+            "max_cost_observed": self.max_cost_observed,
         }
 
     def set_state(self, state: Dict[str, Any]) -> None:
@@ -916,6 +944,7 @@ class AsymmetricUCB(BanditBase):
         self.total_costs = self._align_state_array(
             state, "total_costs", self.total_costs
         )
+        self._restore_cost_range(state)
 
 
 class FixedSampler(BanditBase):

--- a/shinka/llm/prioritization.py
+++ b/shinka/llm/prioritization.py
@@ -220,6 +220,77 @@ class BanditBase(ABC):
             state = pickle.load(f)
         self.set_state(state)
 
+    def _state_arm_names(self) -> Optional[List[str]]:
+        if self._arm_names is None:
+            return None
+        return list(self._arm_names)
+
+    def _align_state_array(
+        self,
+        state: Dict[str, Any],
+        key: str,
+        default: np.ndarray,
+    ) -> np.ndarray:
+        if key not in state:
+            return default.copy()
+
+        saved = np.asarray(state[key], dtype=default.dtype)
+        if saved.ndim != 1:
+            raise ValueError(f"bandit state field '{key}' must be one-dimensional")
+
+        aligned = default.copy()
+        saved_arm_names = state.get("arm_names")
+        if saved_arm_names is not None and self._arm_names is not None:
+            saved_name_to_idx = {
+                name: i for i, name in enumerate(saved_arm_names) if i < saved.size
+            }
+            for i, name in enumerate(self._arm_names):
+                saved_i = saved_name_to_idx.get(name)
+                if saved_i is not None:
+                    aligned[i] = saved[saved_i]
+            return aligned
+
+        n = min(saved.size, aligned.size)
+        if n > 0:
+            aligned[:n] = saved[:n]
+        return aligned
+
+    def _state_arm_layout_matches(self, state: Dict[str, Any], key: str) -> bool:
+        saved_arm_names = state.get("arm_names")
+        if saved_arm_names is not None and self._arm_names is not None:
+            return list(saved_arm_names) == self._arm_names
+        if key not in state:
+            return True
+        return np.asarray(state[key]).size == self.n_arms
+
+    def _restore_observation_range(self, state: Dict[str, Any]) -> None:
+        if self._state_arm_layout_matches(state, "s"):
+            self._obs_max = state["obs_max"]
+            self._obs_min = state["obs_min"]
+            return
+
+        seen = self.divs > 0.0
+        means = self._mean()[seen]
+        finite_means = means[np.isfinite(means)]
+
+        if self.asymmetric_scaling:
+            if self.use_exponential_scaling:
+                self._obs_min = -np.inf
+                self._obs_max = (
+                    float(finite_means.max()) if finite_means.size > 0 else -np.inf
+                )
+            else:
+                self._obs_min = 0.0
+                self._obs_max = (
+                    max(0.0, float(finite_means.max()))
+                    if finite_means.size > 0
+                    else 0.0
+                )
+            return
+
+        self._obs_max = float(finite_means.max()) if finite_means.size > 0 else -np.inf
+        self._obs_min = float(finite_means.min()) if finite_means.size > 0 else np.inf
+
 
 class AsymmetricUCB(BanditBase):
     # asymmetric ucb1 with ε-exploration and adaptive scaling
@@ -817,6 +888,7 @@ class AsymmetricUCB(BanditBase):
     def get_state(self) -> Dict[str, Any]:
         """Get the internal state for serialization."""
         return {
+            "arm_names": self._state_arm_names(),
             "n_submitted": self.n_submitted.copy(),
             "n_completed": self.n_completed.copy(),
             "s": self.s.copy(),
@@ -830,15 +902,20 @@ class AsymmetricUCB(BanditBase):
 
     def set_state(self, state: Dict[str, Any]) -> None:
         """Restore the internal state from serialization."""
-        self.n_submitted = state["n_submitted"].copy()
-        self.n_completed = state["n_completed"].copy()
-        self.s = state["s"].copy()
-        self.divs = state["divs"].copy()
+        self.n_submitted = self._align_state_array(
+            state, "n_submitted", self.n_submitted
+        )
+        self.n_completed = self._align_state_array(
+            state, "n_completed", self.n_completed
+        )
+        self.s = self._align_state_array(state, "s", self.s)
+        self.divs = self._align_state_array(state, "divs", self.divs)
         self._baseline = state["baseline"]
-        self._obs_max = state["obs_max"]
-        self._obs_min = state["obs_min"]
-        self.n_costs = state["n_costs"].copy()
-        self.total_costs = state["total_costs"].copy()
+        self._restore_observation_range(state)
+        self.n_costs = self._align_state_array(state, "n_costs", self.n_costs)
+        self.total_costs = self._align_state_array(
+            state, "total_costs", self.total_costs
+        )
 
 
 class FixedSampler(BanditBase):
@@ -974,6 +1051,7 @@ class FixedSampler(BanditBase):
     def get_state(self) -> Dict[str, Any]:
         """Get the internal state for serialization."""
         return {
+            "arm_names": self._state_arm_names(),
             "baseline": self._baseline,
             "p": self.p.copy(),
             "n_pulls": self.n_pulls.copy(),
@@ -984,13 +1062,16 @@ class FixedSampler(BanditBase):
     def set_state(self, state: Dict[str, Any]) -> None:
         """Restore the internal state from serialization."""
         self._baseline = state["baseline"]
-        self.p = state["p"].copy()
-        if "n_pulls" in state:
-            self.n_pulls = state["n_pulls"].copy()
-        if "n_costs" in state:
-            self.n_costs = state["n_costs"].copy()
-        if "total_costs" in state:
-            self.total_costs = state["total_costs"].copy()
+        self.p = self._align_state_array(state, "p", self.p)
+        p_sum = float(self.p.sum())
+        if p_sum <= 0.0:
+            raise ValueError("loaded fixed sampler probabilities must sum to > 0")
+        self.p = self.p / p_sum
+        self.n_pulls = self._align_state_array(state, "n_pulls", self.n_pulls)
+        self.n_costs = self._align_state_array(state, "n_costs", self.n_costs)
+        self.total_costs = self._align_state_array(
+            state, "total_costs", self.total_costs
+        )
 
 
 class ThompsonSampler(BanditBase):
@@ -1332,6 +1413,7 @@ class ThompsonSampler(BanditBase):
     def get_state(self) -> Dict[str, Any]:
         """Get the internal state for serialization."""
         return {
+            "arm_names": self._state_arm_names(),
             "n_submitted": self.n_submitted.copy(),
             "n_completed": self.n_completed.copy(),
             "s": self.s.copy(),
@@ -1345,12 +1427,15 @@ class ThompsonSampler(BanditBase):
 
     def set_state(self, state: Dict[str, Any]) -> None:
         """Restore the internal state from serialization."""
-        self.n_submitted = state["n_submitted"].copy()
-        self.n_completed = state["n_completed"].copy()
-        self.s = state["s"].copy()
-        self.divs = state["divs"].copy()
-        self.alpha = state["alpha"].copy()
-        self.beta = state["beta"].copy()
+        self.n_submitted = self._align_state_array(
+            state, "n_submitted", self.n_submitted
+        )
+        self.n_completed = self._align_state_array(
+            state, "n_completed", self.n_completed
+        )
+        self.s = self._align_state_array(state, "s", self.s)
+        self.divs = self._align_state_array(state, "divs", self.divs)
+        self.alpha = self._align_state_array(state, "alpha", self.alpha)
+        self.beta = self._align_state_array(state, "beta", self.beta)
         self._baseline = state["baseline"]
-        self._obs_max = state["obs_max"]
-        self._obs_min = state["obs_min"]
+        self._restore_observation_range(state)

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -5,9 +5,28 @@ Test script to verify bandit state persistence works correctly.
 from io import StringIO
 import numpy as np
 from pathlib import Path
+import pickle
 import tempfile
 from rich.console import Console
 from shinka.llm import AsymmetricUCB, ThompsonSampler, FixedSampler
+
+
+def _exercise_sampler_after_resize(bandit):
+    posterior = bandit.posterior()
+    one_hot, selected_posterior = bandit.select_llm()
+
+    assert posterior.shape == (bandit.n_arms,)
+    assert one_hot.shape == (bandit.n_arms,)
+    assert selected_posterior.shape == (bandit.n_arms,)
+    assert np.isclose(posterior.sum(), 1.0)
+
+
+def _save_state_without_arm_names(bandit, path: Path) -> dict:
+    state = bandit.get_state()
+    state.pop("arm_names", None)
+    with open(path, "wb") as f:
+        pickle.dump(state, f)
+    return state
 
 
 def test_asymmetric_ucb_persistence():
@@ -154,6 +173,313 @@ def test_fixed_sampler_persistence():
         assert bandit._baseline == bandit2._baseline, "baseline mismatch!"
 
         print("✅ FixedSampler persistence test passed!")
+
+
+def test_asymmetric_ucb_loads_state_into_more_arms():
+    source = AsymmetricUCB(arm_names=["a", "b", "c"], seed=0)
+    source.update_submitted("a")
+    source.update("a", reward=0.8, baseline=0.0)
+    source.update_submitted("b")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = AsymmetricUCB(arm_names=["a", "b", "c", "d", "e"], seed=1)
+        target.load_state(save_path)
+
+    assert target.n_submitted.shape == (5,)
+    assert np.allclose(target.n_submitted[:3], source.n_submitted)
+    assert np.allclose(target.n_submitted[3:], 0.0)
+    assert np.all(np.isneginf(target.s[3:]))
+    _exercise_sampler_after_resize(target)
+
+
+def test_asymmetric_ucb_loads_state_into_fewer_arms():
+    source = AsymmetricUCB(arm_names=["a", "b", "c", "d", "e"], seed=0)
+    source.update_submitted("a")
+    source.update("a", reward=0.8, baseline=0.0)
+    source.update_submitted("d")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = AsymmetricUCB(arm_names=["a", "b", "c"], seed=1)
+        target.load_state(save_path)
+
+    assert target.n_submitted.shape == (3,)
+    assert np.allclose(target.n_submitted, source.n_submitted[:3])
+    _exercise_sampler_after_resize(target)
+
+
+def test_thompson_sampler_loads_state_into_more_arms():
+    source = ThompsonSampler(arm_names=["a", "b", "c"], seed=0)
+    source.update_submitted("a")
+    source.update("a", reward=0.8, baseline=0.0)
+    source.update_submitted("b")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = ThompsonSampler(
+            arm_names=["a", "b", "c", "d", "e"],
+            seed=1,
+            prior_alpha=2.0,
+            prior_beta=3.0,
+        )
+        target.load_state(save_path)
+
+    assert target.alpha.shape == (5,)
+    assert np.allclose(target.alpha[:3], source.alpha)
+    assert np.allclose(target.beta[:3], source.beta)
+    assert np.allclose(target.alpha[3:], 2.0)
+    assert np.allclose(target.beta[3:], 3.0)
+    _exercise_sampler_after_resize(target)
+
+
+def test_thompson_sampler_loads_state_into_fewer_arms():
+    source = ThompsonSampler(arm_names=["a", "b", "c", "d", "e"], seed=0)
+    source.update_submitted("a")
+    source.update("a", reward=0.8, baseline=0.0)
+    source.update_submitted("d")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = ThompsonSampler(arm_names=["a", "b", "c"], seed=1)
+        target.load_state(save_path)
+
+    assert target.alpha.shape == (3,)
+    assert np.allclose(target.alpha, source.alpha[:3])
+    assert np.allclose(target.beta, source.beta[:3])
+    _exercise_sampler_after_resize(target)
+
+
+def test_fixed_sampler_loads_state_into_more_arms():
+    source = FixedSampler(
+        arm_names=["a", "b", "c"],
+        prior_probs=np.array([0.2, 0.3, 0.5]),
+        seed=0,
+    )
+    source.update("a", reward=1.0)
+    source.update_cost("b", cost=0.4)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = FixedSampler(
+            arm_names=["a", "b", "c", "d", "e"],
+            prior_probs=np.array([0.1, 0.2, 0.3, 0.15, 0.25]),
+            seed=1,
+        )
+        target.load_state(save_path)
+
+    expected_p = np.array([0.2, 0.3, 0.5, 0.15, 0.25])
+    expected_p = expected_p / expected_p.sum()
+    assert target.p.shape == (5,)
+    assert np.allclose(target.p, expected_p)
+    assert np.allclose(target.n_pulls[:3], source.n_pulls)
+    assert np.allclose(target.n_pulls[3:], 0.0)
+    _exercise_sampler_after_resize(target)
+
+
+def test_fixed_sampler_loads_state_into_fewer_arms():
+    source = FixedSampler(
+        arm_names=["a", "b", "c", "d", "e"],
+        prior_probs=np.array([0.1, 0.2, 0.3, 0.15, 0.25]),
+        seed=0,
+    )
+    source.update("a", reward=1.0)
+    source.update_cost("d", cost=0.4)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = FixedSampler(
+            arm_names=["a", "b", "c"],
+            prior_probs=np.array([0.2, 0.3, 0.5]),
+            seed=1,
+        )
+        target.load_state(save_path)
+
+    expected_p = np.array([0.1, 0.2, 0.3])
+    expected_p = expected_p / expected_p.sum()
+    assert target.p.shape == (3,)
+    assert np.allclose(target.p, expected_p)
+    assert np.allclose(target.n_pulls, source.n_pulls[:3])
+    _exercise_sampler_after_resize(target)
+
+
+def test_named_bandit_state_aligns_when_model_order_changes():
+    source = ThompsonSampler(arm_names=["a", "b", "c"], seed=0)
+    source.update_submitted("a")
+    source.update("a", reward=0.8, baseline=0.0)
+    source.update_submitted("c")
+    source.update("c", reward=0.6, baseline=0.0)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = ThompsonSampler(arm_names=["c", "a", "d"], seed=1)
+        target.load_state(save_path)
+
+    assert np.allclose(
+        target.n_submitted,
+        [source.n_submitted[2], source.n_submitted[0], 0.0],
+    )
+    assert np.allclose(
+        target.alpha,
+        [source.alpha[2], source.alpha[0], target.a_prior],
+    )
+    assert np.allclose(target.beta, [source.beta[2], source.beta[0], target.b_prior])
+    _exercise_sampler_after_resize(target)
+
+
+def test_asymmetric_ucb_named_state_aligns_when_model_order_changes():
+    source = AsymmetricUCB(arm_names=["a", "b", "c"], seed=0)
+    source.update_submitted("a")
+    source.update("a", reward=0.8, baseline=0.0)
+    source.update_submitted("c")
+    source.update_cost("c", cost=0.7)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = AsymmetricUCB(arm_names=["c", "a", "d"], seed=1)
+        target.load_state(save_path)
+
+    assert np.allclose(
+        target.n_submitted,
+        [source.n_submitted[2], source.n_submitted[0], 0.0],
+    )
+    assert np.allclose(target.s, [source.s[2], source.s[0], -np.inf])
+    assert np.allclose(target.n_costs, [source.n_costs[2], source.n_costs[0], 0.0])
+    assert np.allclose(
+        target.total_costs,
+        [source.total_costs[2], source.total_costs[0], 0.0],
+    )
+    _exercise_sampler_after_resize(target)
+
+
+def test_fixed_sampler_named_state_aligns_when_model_order_changes():
+    source = FixedSampler(
+        arm_names=["a", "b", "c"],
+        prior_probs=np.array([0.2, 0.3, 0.5]),
+        seed=0,
+    )
+    source.update("a", reward=1.0)
+    source.update_cost("c", cost=0.7)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = FixedSampler(
+            arm_names=["c", "a", "d"],
+            prior_probs=np.array([0.6, 0.3, 0.1]),
+            seed=1,
+        )
+        target.load_state(save_path)
+
+    expected_p = np.array([0.5, 0.2, 0.1])
+    expected_p = expected_p / expected_p.sum()
+    assert np.allclose(target.p, expected_p)
+    assert np.allclose(target.n_pulls, [source.n_pulls[2], source.n_pulls[0], 0.0])
+    assert np.allclose(target.n_costs, [source.n_costs[2], source.n_costs[0], 0.0])
+    assert np.allclose(
+        target.total_costs,
+        [source.total_costs[2], source.total_costs[0], 0.0],
+    )
+    _exercise_sampler_after_resize(target)
+
+
+def test_legacy_bandit_state_without_arm_names_uses_prefix_alignment():
+    source = AsymmetricUCB(arm_names=["old-a", "old-b", "old-c"], seed=0)
+    source.update_submitted("old-a")
+    source.update("old-a", reward=0.8, baseline=0.0)
+    source.update_submitted("old-c")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "legacy_bandit_state.pkl"
+        state = _save_state_without_arm_names(source, save_path)
+
+        target = AsymmetricUCB(
+            arm_names=["new-a", "new-b", "new-c", "new-d"],
+            seed=1,
+        )
+        target.load_state(save_path)
+
+    assert "arm_names" not in state
+    assert np.allclose(target.n_submitted[:3], source.n_submitted)
+    assert np.allclose(target.n_submitted[3], 0.0)
+    _exercise_sampler_after_resize(target)
+
+
+def test_asymmetric_ucb_recomputes_observation_range_when_dropping_arms():
+    source = AsymmetricUCB(
+        arm_names=["a", "b", "c", "d"],
+        auto_decay=None,
+        asymmetric_scaling=False,
+        exponential_base=None,
+        shift_by_baseline=False,
+        shift_by_parent=False,
+    )
+    source.update("a", reward=1.0)
+    source.update("d", reward=100.0)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = AsymmetricUCB(
+            arm_names=["a", "b", "c"],
+            auto_decay=None,
+            asymmetric_scaling=False,
+            exponential_base=None,
+            shift_by_baseline=False,
+            shift_by_parent=False,
+        )
+        target.load_state(save_path)
+
+    assert target._obs_max == 1.0
+    assert target._obs_min == 1.0
+
+
+def test_thompson_sampler_recomputes_observation_range_when_dropping_arms():
+    source = ThompsonSampler(
+        arm_names=["a", "b", "c", "d"],
+        auto_decay=None,
+        asymmetric_scaling=False,
+        exponential_base=None,
+        shift_by_baseline=False,
+        shift_by_parent=False,
+    )
+    source.update("a", reward=1.0)
+    source.update("d", reward=100.0)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = ThompsonSampler(
+            arm_names=["a", "b", "c"],
+            auto_decay=None,
+            asymmetric_scaling=False,
+            exponential_base=None,
+            shift_by_baseline=False,
+            shift_by_parent=False,
+        )
+        target.load_state(save_path)
+
+    assert target._obs_max == 1.0
+    assert target._obs_min == 1.0
 
 
 def test_asymmetric_ucb_print_summary_preserves_local_model_name():

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -315,6 +315,36 @@ def test_fixed_sampler_loads_state_into_fewer_arms():
     _exercise_sampler_after_resize(target)
 
 
+def test_asymmetric_ucb_restores_cost_range_for_cost_aware_resume():
+    source = AsymmetricUCB(
+        arm_names=["cheap", "expensive"],
+        cost_aware_coef=0.5,
+        auto_decay=None,
+        exponential_base=None,
+    )
+    source.update("cheap", reward=1.0, baseline=0.0)
+    source.update("expensive", reward=1.0, baseline=0.0)
+    source.update_cost("cheap", cost=1.0)
+    source.update_cost("expensive", cost=100.0)
+    expected = source.posterior()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "bandit_state.pkl"
+        source.save_state(save_path)
+
+        target = AsymmetricUCB(
+            arm_names=["cheap", "expensive"],
+            cost_aware_coef=0.5,
+            auto_decay=None,
+            exponential_base=None,
+        )
+        target.load_state(save_path)
+
+    assert target.min_cost_observed == source.min_cost_observed
+    assert target.max_cost_observed == source.max_cost_observed
+    assert np.allclose(target.posterior(), expected)
+
+
 def test_named_bandit_state_aligns_when_model_order_changes():
     source = ThompsonSampler(arm_names=["a", "b", "c"], seed=0)
     source.update_submitted("a")

--- a/tests/test_bandit_persistence.py
+++ b/tests/test_bandit_persistence.py
@@ -452,6 +452,63 @@ def test_legacy_bandit_state_without_arm_names_uses_prefix_alignment():
     _exercise_sampler_after_resize(target)
 
 
+def test_legacy_thompson_state_without_arm_names_uses_prefix_alignment():
+    source = ThompsonSampler(arm_names=["old-a", "old-b", "old-c"], seed=0)
+    source.update_submitted("old-a")
+    source.update("old-a", reward=0.8, baseline=0.0)
+    source.update_submitted("old-c")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "legacy_thompson_state.pkl"
+        state = _save_state_without_arm_names(source, save_path)
+
+        target = ThompsonSampler(
+            arm_names=["new-a", "new-b", "new-c", "new-d"],
+            seed=1,
+        )
+        target.load_state(save_path)
+
+    assert "arm_names" not in state
+    assert np.allclose(target.n_submitted[:3], source.n_submitted)
+    assert np.allclose(target.n_submitted[3], 0.0)
+    assert np.allclose(target.alpha[:3], source.alpha)
+    assert np.allclose(target.beta[:3], source.beta)
+    assert target.alpha[3] == target.a_prior
+    assert target.beta[3] == target.b_prior
+    _exercise_sampler_after_resize(target)
+
+
+def test_legacy_fixed_state_without_arm_names_uses_prefix_alignment():
+    source = FixedSampler(
+        arm_names=["old-a", "old-b", "old-c"],
+        prior_probs=np.array([0.2, 0.3, 0.5]),
+        seed=0,
+    )
+    source.update("old-a", reward=1.0)
+    source.update_cost("old-c", cost=0.4)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_path = Path(tmpdir) / "legacy_fixed_state.pkl"
+        state = _save_state_without_arm_names(source, save_path)
+
+        target = FixedSampler(
+            arm_names=["new-a", "new-b", "new-c", "new-d"],
+            prior_probs=np.array([0.1, 0.2, 0.3, 0.4]),
+            seed=1,
+        )
+        target.load_state(save_path)
+
+    expected_p = np.array([0.2, 0.3, 0.5, 0.4])
+    expected_p = expected_p / expected_p.sum()
+    assert "arm_names" not in state
+    assert np.allclose(target.p, expected_p)
+    assert np.allclose(target.n_pulls[:3], source.n_pulls)
+    assert np.allclose(target.n_pulls[3], 0.0)
+    assert np.allclose(target.n_costs[:3], source.n_costs)
+    assert np.allclose(target.total_costs[:3], source.total_costs)
+    _exercise_sampler_after_resize(target)
+
+
 def test_asymmetric_ucb_recomputes_observation_range_when_dropping_arms():
     source = AsymmetricUCB(
         arm_names=["a", "b", "c", "d"],


### PR DESCRIPTION
## Summary
- Persist `arm_names` with bandit sampler state for name-based resume alignment.
- Resize loaded sampler arrays when `llm_models` expands, shrinks, or reorders.
- Keep legacy `bandit_state.pkl` files without `arm_names` loadable via prefix/index alignment.
- Recompute adaptive observation ranges when the saved arm layout changes so removed arms do not keep influencing resumed selection.
- Preserve cost-aware UCB cost range state across resume and document the fix in `CHANGELOG.md`.

## Why
Resuming a run after changing `llm_models` could leave bandit arrays at the old length, causing posterior/select paths to fail or stale stats to be associated with the wrong model.

Fixes #129.

## Tests
- `.venv/bin/python -m pytest tests/test_bandit_persistence.py tests/test_async_runner_recovery.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m ruff check shinka/llm/prioritization.py tests/test_bandit_persistence.py`
- `git diff --check HEAD~2..HEAD`
- `.venv/bin/python -m mkdocs build --strict`

## Notes
The targeted pytest run still emits the existing ThompsonSampler decay `RuntimeWarning`, but all tests pass.
