### PR TITLE
Add Fortran evolution support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Added Vertex AI authentication support for Gemini LLM and embedding clients in PR #125. Thanks @wu375.
 - Added async-runner validation for configured LLM and embedding model environment access before run artifacts are created in PR #127. Thanks @RobertTLange.
 - Added GPT-5.5 and GPT-5.5 Pro entries to the OpenAI LLM pricing catalog.
+- Added Fortran evolution support, including language detection, patch application, validation, visualization metadata, and a compiled heat-diffusion example in PR #131.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For detailed installation instructions and usage examples, see the [Getting Star
 | ⭕ [Circle Packing](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/circle_packing) | Optimize circle packing to maximize radii. | `LocalJobConfig` |
 | 🎮 [Game 2048](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/game_2048) | Optimize a policy for the Game of 2048. | `LocalJobConfig` |
 | ∑ [Julia Prime Counting](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/julia_prime_counting) | Optimize a Julia solver for prime-count queries. | `LocalJobConfig` |
+| 🔥 [Fortran Heat Diffusion](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/fortran_heat_diffusion) | Optimize a compiled Fortran stencil solver. | `LocalJobConfig` |
 | ✨ [Novelty Generator](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/novelty_generator) | Generate creative, surprising outputs (e.g., ASCII art). | `LocalJobConfig` |
 
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -58,6 +58,24 @@ harness in Python.
 
 ---
 
+## Fortran Heat Diffusion
+
+| | |
+|-|-|
+| **Path** | [`examples/fortran_heat_diffusion`](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/fortran_heat_diffusion) |
+| **Language** | Fortran candidate + Python evaluator |
+| **Focus** | Compiled numerical stencil evolution |
+
+```bash
+cd examples/fortran_heat_diffusion
+python evaluate.py --program_path initial.f90 --results_dir results/manual_eval
+```
+
+Use this when candidates should be compiled with `gfortran` before
+floating-point correctness and runtime scoring.
+
+---
+
 ## Novelty Generator
 
 | | |
@@ -84,5 +102,6 @@ before moving into full CLI or API workflows.
 |------|---------|
 | Best default choice | Circle Packing |
 | Cross-language evolution | Julia Prime Counting |
+| Compiled numerical stencil | Fortran Heat Diffusion |
 | Game / control optimization | Game 2048 |
 | Creative / open-ended | Novelty Generator |

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -339,6 +339,7 @@ internal analysis and debugging only.
 | [Circle Packing](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/circle_packing) | 26 circles in unit square; maximize sum of radii | Geometric optimization |
 | [2048](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/game_2048) | Evolve a policy to play 2048 | Game-playing / heuristic optimization |
 | [Julia Prime Counting](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/julia_prime_counting) | Optimize Julia prime-count queries | Algorithmic optimization |
+| [Fortran Heat Diffusion](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/fortran_heat_diffusion) | Optimize a compiled Fortran stencil solver | Numerical computing |
 | [Novelty Generator](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/novelty_generator) | Diverse outputs scored by LLM-as-a-judge | Open-ended exploration |
 | [Tutorial Notebook](https://github.com/SakanaAI/ShinkaEvolve/blob/main/examples/shinka_tutorial.ipynb) | Guided walkthrough of Circle Packing and Novelty Generator | Interactive onboarding |
 

--- a/examples/fortran_heat_diffusion/README.md
+++ b/examples/fortran_heat_diffusion/README.md
@@ -1,0 +1,36 @@
+# Fortran Heat Diffusion
+
+Runnable non-Python candidate example using a Fortran seed program and Python
+evaluator.
+
+## Requirements
+
+- Python 3.10+
+- `gfortran` on `PATH`
+- ShinkaEvolve installed from the repository root
+
+## Files
+
+- `initial.f90`: seed Fortran implementation with `! EVOLVE-BLOCK` markers.
+- `evaluate.py`: compiles candidates with `gfortran`, runs fixed heat-diffusion
+  cases, and writes `metrics.json` plus `correct.json`.
+- `run_evo.py`: small async Shinka run config with `language="fortran"`.
+
+## Manual Evaluation
+
+```bash
+cd examples/fortran_heat_diffusion
+python evaluate.py --program_path initial.f90 --results_dir results/manual_eval
+```
+
+## Run Evolution
+
+```bash
+cd examples/fortran_heat_diffusion
+python run_evo.py
+```
+
+The evaluator checks one-dimensional heat diffusion checksums against a Python
+reference implementation with strict floating-point tolerances. The combined
+score prioritizes correctness, then subtracts runtime so faster correct programs
+rank higher.

--- a/examples/fortran_heat_diffusion/evaluate.py
+++ b/examples/fortran_heat_diffusion/evaluate.py
@@ -110,6 +110,7 @@ def _run_program(
             capture_output=True,
             text=True,
             timeout=TIMEOUT_SECONDS,
+            cwd=tmpdir_path,
         )
         elapsed = time.perf_counter() - start
 

--- a/examples/fortran_heat_diffusion/evaluate.py
+++ b/examples/fortran_heat_diffusion/evaluate.py
@@ -1,0 +1,284 @@
+import argparse
+import json
+import math
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+CASES_PUBLIC = [
+    (96, 120, 0.18),
+    (128, 180, 0.21),
+    (192, 220, 0.16),
+]
+CASES_PRIVATE = [
+    (224, 280, 0.19),
+    (320, 360, 0.17),
+    (384, 440, 0.15),
+]
+TIMEOUT_SECONDS = 20
+REL_TOLERANCE = 1.0e-9
+ABS_TOLERANCE = 1.0e-7
+
+
+def _reference_answer(n: int, steps: int, alpha: float) -> float:
+    state = []
+    for i in range(n):
+        x = i / (n - 1)
+        value = math.exp(-80.0 * (x - 0.35) * (x - 0.35))
+        value += 0.5 * math.exp(-120.0 * (x - 0.72) * (x - 0.72))
+        state.append(value)
+    state[0] = 0.0
+    state[-1] = 0.0
+
+    for _ in range(steps):
+        next_state = [0.0] * n
+        for i in range(1, n - 1):
+            next_state[i] = state[i] + alpha * (
+                state[i - 1] - 2.0 * state[i] + state[i + 1]
+            )
+        state = next_state
+
+    return sum(value * (idx + 1) for idx, value in enumerate(state))
+
+
+def _expected_answers(cases: list[tuple[int, int, float]]) -> list[float]:
+    return [_reference_answer(n, steps, alpha) for n, steps, alpha in cases]
+
+
+def _parse_output(output_path: Path) -> list[float]:
+    text = output_path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    answers: list[float] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            answers.append(float(stripped))
+    return answers
+
+
+def _compile_program(program_path: str, tmpdir_path: Path) -> Path:
+    executable_path = tmpdir_path / "candidate"
+    completed = subprocess.run(
+        [
+            "gfortran",
+            "-O2",
+            str(Path(program_path).resolve()),
+            "-o",
+            str(executable_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+        cwd=tmpdir_path,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        stdout = completed.stdout.strip()
+        error_parts = ["Fortran compilation failed"]
+        if stderr:
+            error_parts.append(f"stderr: {stderr}")
+        if stdout:
+            error_parts.append(f"stdout: {stdout}")
+        raise RuntimeError(" | ".join(error_parts))
+    return executable_path
+
+
+def _run_program(
+    program_path: str,
+    cases: list[tuple[int, int, float]],
+) -> tuple[list[float], float]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        input_path = tmpdir_path / "cases.txt"
+        output_path = tmpdir_path / "answers.txt"
+        input_path.write_text(
+            "\n".join(f"{n} {steps} {alpha:.17g}" for n, steps, alpha in cases),
+            encoding="utf-8",
+        )
+
+        executable_path = _compile_program(program_path, tmpdir_path)
+        start = time.perf_counter()
+        completed = subprocess.run(
+            [str(executable_path), str(input_path), str(output_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+        elapsed = time.perf_counter() - start
+
+        if completed.returncode != 0:
+            stderr = completed.stderr.strip()
+            stdout = completed.stdout.strip()
+            error_parts = ["Fortran program failed"]
+            if stderr:
+                error_parts.append(f"stderr: {stderr}")
+            if stdout:
+                error_parts.append(f"stdout: {stdout}")
+            raise RuntimeError(" | ".join(error_parts))
+
+        if not output_path.exists():
+            raise RuntimeError("Fortran program did not produce output file")
+
+        answers = _parse_output(output_path)
+        return answers, elapsed
+
+
+def _is_close(expected: float, predicted: float) -> bool:
+    return math.isclose(
+        predicted,
+        expected,
+        rel_tol=REL_TOLERANCE,
+        abs_tol=ABS_TOLERANCE,
+    )
+
+
+def _build_metrics(
+    cases: list[tuple[int, int, float]],
+    expected: list[float],
+    predicted: list[float],
+    runtime_seconds: float,
+) -> tuple[dict[str, Any], bool, str]:
+    if len(predicted) != len(expected):
+        msg = (
+            f"Output length mismatch. Expected {len(expected)} answers, "
+            f"got {len(predicted)}."
+        )
+        metrics = {
+            "combined_score": 0.0,
+            "public": {
+                "runtime_seconds": runtime_seconds,
+                "num_cases": len(cases),
+                "num_answers": len(predicted),
+                "accuracy": 0.0,
+            },
+            "private": {},
+        }
+        return metrics, False, msg
+
+    mismatches: list[dict[str, Any]] = []
+    max_abs_error = 0.0
+    for idx, (case, exp, pred) in enumerate(zip(cases, expected, predicted)):
+        abs_error = abs(pred - exp)
+        max_abs_error = max(max_abs_error, abs_error)
+        if not _is_close(exp, pred):
+            mismatches.append(
+                {
+                    "index": idx,
+                    "case": {
+                        "n": case[0],
+                        "steps": case[1],
+                        "alpha": case[2],
+                    },
+                    "expected": exp,
+                    "predicted": pred,
+                    "abs_error": abs_error,
+                }
+            )
+
+    num_correct = len(cases) - len(mismatches)
+    accuracy = num_correct / len(cases)
+    all_correct = len(mismatches) == 0
+    combined_score = max(0.0, accuracy * 100.0 - runtime_seconds)
+
+    metrics = {
+        "combined_score": combined_score,
+        "public": {
+            "runtime_seconds": runtime_seconds,
+            "num_cases": len(cases),
+            "num_correct": num_correct,
+            "accuracy": accuracy,
+            "max_abs_error": max_abs_error,
+        },
+        "private": {
+            "mismatch_count": len(mismatches),
+            "first_mismatch": mismatches[0] if mismatches else None,
+        },
+    }
+
+    if all_correct:
+        return metrics, True, ""
+    msg = f"{len(mismatches)} mismatches found. First mismatch: {mismatches[0]}"
+    return metrics, False, msg
+
+
+def main(program_path: str, results_dir: str):
+    os.makedirs(results_dir, exist_ok=True)
+    all_cases = CASES_PUBLIC + CASES_PRIVATE
+    expected = _expected_answers(all_cases)
+
+    try:
+        predicted, runtime_seconds = _run_program(program_path, all_cases)
+        metrics, correct, error = _build_metrics(
+            cases=all_cases,
+            expected=expected,
+            predicted=predicted,
+            runtime_seconds=runtime_seconds,
+        )
+    except FileNotFoundError:
+        metrics = {
+            "combined_score": 0.0,
+            "public": {"runtime_seconds": 0.0, "accuracy": 0.0},
+            "private": {},
+        }
+        correct = False
+        error = (
+            "gfortran executable not found. Install gfortran and make it available "
+            "in PATH."
+        )
+    except subprocess.TimeoutExpired:
+        metrics = {
+            "combined_score": 0.0,
+            "public": {"runtime_seconds": TIMEOUT_SECONDS, "accuracy": 0.0},
+            "private": {},
+        }
+        correct = False
+        error = f"Fortran evaluation timed out after {TIMEOUT_SECONDS} seconds."
+    except Exception as exc:
+        metrics = {
+            "combined_score": 0.0,
+            "public": {"runtime_seconds": 0.0, "accuracy": 0.0},
+            "private": {},
+        }
+        correct = False
+        error = str(exc)
+
+    correct_path = Path(results_dir) / "correct.json"
+    metrics_path = Path(results_dir) / "metrics.json"
+    correct_path.write_text(
+        json.dumps({"correct": correct, "error": error}, indent=4), encoding="utf-8"
+    )
+    metrics_path.write_text(json.dumps(metrics, indent=4), encoding="utf-8")
+
+    print(f"Evaluated program: {program_path}")
+    print(f"Results saved to: {results_dir}")
+    print(f"Correct: {correct}")
+    if error:
+        print(f"Error: {error}")
+    print(f"Combined score: {metrics.get('combined_score', 0.0):.6f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Evaluate Fortran heat-diffusion stencil program"
+    )
+    parser.add_argument(
+        "--program_path",
+        type=str,
+        default="initial.f90",
+        help="Path to candidate Fortran program",
+    )
+    parser.add_argument(
+        "--results_dir",
+        type=str,
+        default="results",
+        help="Directory where metrics.json and correct.json are written",
+    )
+    args = parser.parse_args()
+    main(args.program_path, args.results_dir)

--- a/examples/fortran_heat_diffusion/initial.f90
+++ b/examples/fortran_heat_diffusion/initial.f90
@@ -1,0 +1,123 @@
+! EVOLVE-BLOCK-START
+module heat_solver
+    implicit none
+contains
+    subroutine initialize_state(n, state)
+        integer, intent(in) :: n
+        real(8), intent(out) :: state(n)
+        integer :: i
+        real(8) :: x
+
+        do i = 1, n
+            x = real(i - 1, 8) / real(n - 1, 8)
+            state(i) = exp(-80.0d0 * (x - 0.35d0) * (x - 0.35d0))
+            state(i) = state(i) + 0.5d0 * exp(-120.0d0 * (x - 0.72d0) * (x - 0.72d0))
+        end do
+        state(1) = 0.0d0
+        state(n) = 0.0d0
+    end subroutine initialize_state
+
+    subroutine evolve_heat(n, steps, alpha, state)
+        integer, intent(in) :: n
+        integer, intent(in) :: steps
+        real(8), intent(in) :: alpha
+        real(8), intent(inout) :: state(n)
+        real(8), allocatable :: next_state(:)
+        integer :: step
+        integer :: i
+
+        allocate (next_state(n))
+        do step = 1, steps
+            next_state(1) = 0.0d0
+            next_state(n) = 0.0d0
+            do i = 2, n - 1
+                next_state(i) = state(i) + alpha * &
+                    (state(i - 1) - 2.0d0 * state(i) + state(i + 1))
+            end do
+            state = next_state
+        end do
+        deallocate (next_state)
+    end subroutine evolve_heat
+
+    real(8) function checksum(n, state)
+        integer, intent(in) :: n
+        real(8), intent(in) :: state(n)
+        integer :: i
+
+        checksum = 0.0d0
+        do i = 1, n
+            checksum = checksum + state(i) * real(i, 8)
+        end do
+    end function checksum
+
+    subroutine solve_case(n, steps, alpha, answer)
+        integer, intent(in) :: n
+        integer, intent(in) :: steps
+        real(8), intent(in) :: alpha
+        real(8), intent(out) :: answer
+        real(8), allocatable :: state(:)
+
+        allocate (state(n))
+        call initialize_state(n, state)
+        call evolve_heat(n, steps, alpha, state)
+        answer = checksum(n, state)
+        deallocate (state)
+    end subroutine solve_case
+end module heat_solver
+! EVOLVE-BLOCK-END
+
+
+program main
+    use heat_solver
+    implicit none
+
+    character(len=1024) :: input_path
+    character(len=1024) :: output_path
+    integer :: argc
+
+    argc = command_argument_count()
+    if (argc /= 2) then
+        write (*, '(A)') "Usage: initial.f90 <input_path> <output_path>"
+        stop 1
+    end if
+
+    call get_command_argument(1, input_path)
+    call get_command_argument(2, output_path)
+    call solve_file(trim(input_path), trim(output_path))
+
+contains
+    subroutine solve_file(input_file, output_file)
+        character(len=*), intent(in) :: input_file
+        character(len=*), intent(in) :: output_file
+        integer :: in_unit
+        integer :: out_unit
+        integer :: status
+        integer :: n
+        integer :: steps
+        real(8) :: alpha
+        real(8) :: answer
+
+        open (newunit=in_unit, file=input_file, status="old", action="read", iostat=status)
+        if (status /= 0) then
+            write (*, '(A)') "Could not open input file"
+            stop 1
+        end if
+
+        open (newunit=out_unit, file=output_file, status="replace", action="write", iostat=status)
+        if (status /= 0) then
+            close (in_unit)
+            write (*, '(A)') "Could not open output file"
+            stop 1
+        end if
+
+        do
+            read (in_unit, *, iostat=status) n, steps, alpha
+            if (status /= 0) exit
+            call solve_case(n, steps, alpha, answer)
+            write (out_unit, '(ES24.16)') answer
+        end do
+
+        close (in_unit)
+        close (out_unit)
+    end subroutine solve_file
+end program main

--- a/examples/fortran_heat_diffusion/run_evo.py
+++ b/examples/fortran_heat_diffusion/run_evo.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from shinka.core import EvolutionConfig, ShinkaEvolveRunner
+from shinka.database import DatabaseConfig
+from shinka.launch import LocalJobConfig
+
+
+job_config = LocalJobConfig(
+    eval_program_path="evaluate.py",
+    time="00:03:00",
+)
+
+db_config = DatabaseConfig(
+    db_path="evolution_db.sqlite",
+    num_islands=1,
+    archive_size=40,
+    elite_selection_ratio=0.3,
+    num_archive_inspirations=4,
+    num_top_k_inspirations=2,
+)
+
+task_sys_msg = """
+You are optimizing a Fortran program for a numerical stencil task.
+
+Task:
+- Simulate one-dimensional heat diffusion with fixed boundary values.
+- Output one floating-point checksum per input case.
+
+Rules:
+- Keep all immutable code outside EVOLVE-BLOCK markers unchanged.
+- Only modify code inside EVOLVE-BLOCK regions.
+- Preserve module/subroutine interfaces used by the immutable CLI.
+- Keep numerical answers within the evaluator tolerance.
+
+Hints:
+- Reuse buffers efficiently.
+- Avoid unnecessary allocations inside repeated time steps.
+- Algebraic rearrangements are useful only if they preserve double precision results.
+"""
+
+evo_config = EvolutionConfig(
+    task_sys_msg=task_sys_msg,
+    patch_types=["diff", "full"],
+    patch_type_probs=[0.7, 0.3],
+    num_generations=24,
+    max_patch_resamples=2,
+    max_patch_attempts=3,
+    job_type="local",
+    language="fortran",
+    llm_models=["gpt-5-mini"],
+    llm_kwargs=dict(
+        temperatures=[0.2, 0.6, 0.9],
+        reasoning_efforts=["medium"],
+        max_tokens=16384,
+    ),
+    embedding_model="text-embedding-3-small",
+    code_embed_sim_threshold=0.995,
+    init_program_path="initial.f90",
+    results_dir="results_fortran_heat_diffusion_async_small",
+    max_novelty_attempts=1,
+)
+
+
+SMALL_MAX_EVAL_JOBS = 1
+SMALL_MAX_PROPOSAL_JOBS = 2
+SMALL_MAX_DB_WORKERS = 1
+
+
+def main():
+    runner = ShinkaEvolveRunner(
+        evo_config=evo_config,
+        job_config=job_config,
+        db_config=db_config,
+        max_evaluation_jobs=SMALL_MAX_EVAL_JOBS,
+        max_proposal_jobs=SMALL_MAX_PROPOSAL_JOBS,
+        max_db_workers=SMALL_MAX_DB_WORKERS,
+        verbose=True,
+    )
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/shinka/cli/run.py
+++ b/shinka/cli/run.py
@@ -24,6 +24,10 @@ SUPPORTED_INITIAL_EXTENSIONS: dict[str, str] = {
     ".cxx": "cpp",
     ".cu": "cuda",
     ".json": "json",
+    ".f90": "fortran",
+    ".f95": "fortran",
+    ".f03": "fortran",
+    ".f08": "fortran",
 }
 
 INITIAL_EXTENSION_PRIORITY: list[str] = [
@@ -36,6 +40,10 @@ INITIAL_EXTENSION_PRIORITY: list[str] = [
     ".cu",
     ".swift",
     ".json",
+    ".f90",
+    ".f95",
+    ".f03",
+    ".f08",
 ]
 
 

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -3114,6 +3114,10 @@ class ShinkaEvolveRunner:
             "cc": "cpp",
             "cxx": "cpp",
             "cu": "cuda",
+            "f90": "fortran",
+            "f95": "fortran",
+            "f03": "fortran",
+            "f08": "fortran",
         }.get(ext, ext or "python")
 
     async def _write_failure_artifact_async(

--- a/shinka/edit/apply_diff.py
+++ b/shinka/edit/apply_diff.py
@@ -14,8 +14,8 @@ PATCH_PATTERN = re.compile(
 )
 
 
-EVOLVE_START = re.compile(r"(?:#|//|)?\s*EVOLVE-BLOCK-START")
-EVOLVE_END = re.compile(r"(?:#|//|)?\s*EVOLVE-BLOCK-END")
+EVOLVE_START = re.compile(r"(?:#|//|!|)?\s*EVOLVE-BLOCK-START")
+EVOLVE_END = re.compile(r"(?:#|//|!|)?\s*EVOLVE-BLOCK-END")
 
 
 def _mutable_ranges(text: str) -> list[tuple[int, int]]:
@@ -140,10 +140,12 @@ def _clean_evolve_markers(text: str) -> str:
     patterns_to_remove = [
         r"^\s*#\s*EVOLVE-BLOCK-START\s*$",  # Python style
         r"^\s*//\s*EVOLVE-BLOCK-START\s*$",  # C/C++/CUDA style
+        r"^\s*!\s*EVOLVE-BLOCK-START\s*$",  # Fortran style
         r"^\s*<!--\s*EVOLVE-BLOCK-START\s*-->\s*$",  # HTML/Markdown style
         r"^\s*EVOLVE-BLOCK-START\s*$",  # Plain text
         r"^\s*#\s*EVOLVE-BLOCK-END\s*$",  # Python style
         r"^\s*//\s*EVOLVE-BLOCK-END\s*$",  # C/C++/CUDA
+        r"^\s*!\s*EVOLVE-BLOCK-END\s*$",  # Fortran style
         r"^\s*<!--\s*EVOLVE-BLOCK-END\s*-->\s*$",  # HTML/Markdown style
         r"^\s*EVOLVE-BLOCK-END\s*$",  # Plain text
     ]

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -9,6 +9,7 @@ from typing import Tuple, Optional
 from pathlib import Path
 from .apply_diff import apply_diff_patch
 from .apply_full import apply_full_patch
+from shinka.utils.languages import normalize_language
 
 try:
     import aiofiles
@@ -117,6 +118,10 @@ async def validate_code_async(
         Tuple of (is_valid, error_message)
     """
     try:
+        try:
+            language = normalize_language(language)
+        except ValueError:
+            language = language.strip().lower()
         if language == "python":
             # Use python -m py_compile for syntax checking
             return await _run_validation_subprocess(
@@ -154,6 +159,14 @@ async def validate_code_async(
             # Use g++ for C++ compilation check
             return await _run_validation_subprocess(
                 "g++",
+                "-fsyntax-only",
+                code_path,
+                timeout=timeout,
+            )
+        elif language == "fortran":
+            # Use gfortran for Fortran syntax checking
+            return await _run_validation_subprocess(
+                "gfortran",
                 "-fsyntax-only",
                 code_path,
                 timeout=timeout,

--- a/shinka/utils/languages.py
+++ b/shinka/utils/languages.py
@@ -7,6 +7,10 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "cc": "cpp",
     "cu": "cuda",
     "md": "markdown",
+    "f90": "fortran",
+    "f95": "fortran",
+    "f03": "fortran",
+    "f08": "fortran",
 }
 
 _LANGUAGE_EXTENSIONS: dict[str, str] = {
@@ -19,6 +23,7 @@ _LANGUAGE_EXTENSIONS: dict[str, str] = {
     "json5": "json",
     "julia": "jl",
     "markdown": "md",
+    "fortran": "f90",
 }
 
 _EVOLVE_COMMENT_PREFIXES: dict[str, str] = {
@@ -31,6 +36,7 @@ _EVOLVE_COMMENT_PREFIXES: dict[str, str] = {
     "json5": "//",
     "julia": "#",
     "markdown": "<!--",
+    "fortran": "!",
 }
 
 _LANGUAGE_FENCE_TAGS: dict[str, tuple[str, ...]] = {
@@ -43,6 +49,7 @@ _LANGUAGE_FENCE_TAGS: dict[str, tuple[str, ...]] = {
     "json5": ("json5", "json"),
     "julia": ("julia", "jl"),
     "markdown": ("markdown", "md"),
+    "fortran": ("fortran", "f90", "f95", "f03", "f08"),
 }
 
 

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -89,6 +89,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             "cc": "cpp",
             "cxx": "cpp",
             "cu": "cuda",
+            "f90": "fortran",
+            "f95": "fortran",
+            "f03": "fortran",
+            "f08": "fortran",
         }.get(ext, ext or "python")
 
     def _resolve_failed_node_language(
@@ -141,6 +145,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             "typescript": ".ts",
             "cpp": ".cpp",
             "cuda": ".cu",
+            "fortran": ".f90",
         }.get(language)
         if preferred_suffix:
             preferred_path = failure_path.parent / f"main{preferred_suffix}"

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -2262,7 +2262,8 @@
                                         'python': 'py',
                                         'cpp': 'cpp',
                                         'javascript': 'js',
-                                        'cuda': 'cu'
+                                        'cuda': 'cu',
+                                        'fortran': 'f90'
                                     }[language] || language;
 
                                     a.download = `${agentName}_gen${gen}.${extension}`;
@@ -12897,7 +12898,8 @@ console.error("[DEBUG] Error in processData:", error);
                     'python': 'py',
                     'cpp': 'cpp',
                     'javascript': 'js',
-                    'cuda': 'cu'
+                    'cuda': 'cu',
+                    'fortran': 'f90'
                 }[language] || language;
                 
                 // Determine comment style based on language
@@ -12909,7 +12911,12 @@ console.error("[DEBUG] Error in processData:", error);
                     'javascript': '//',
                     'js': '//',
                     'cuda': '//',
-                    'cu': '//'
+                    'cu': '//',
+                    'fortran': '!',
+                    'f90': '!',
+                    'f95': '!',
+                    'f03': '!',
+                    'f08': '!'
                 }[language.toLowerCase()] || '//';
                 
                 const filename = `${rank}_gen${gen}_${name.replace(/[^a-zA-Z0-9_-]/g, '_')}.${extension}`;

--- a/skills/shinka-setup/SKILL.md
+++ b/skills/shinka-setup/SKILL.md
@@ -86,6 +86,7 @@ Shinka supports multiple candidate-program languages. Choose one, then keep exte
 |---|---|
 | `python` | `initial.py` |
 | `julia` | `initial.jl` |
+| `fortran` | `initial.f90` |
 | `cpp` | `initial.cpp` |
 | `cuda` | `initial.cu` |
 | `rust` | `initial.rs` |

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -157,6 +157,35 @@ def test_validate_code_async_python_delegates_to_helper(
     assert recorded["timeout"] == 11
 
 
+def test_validate_code_async_fortran_delegates_to_gfortran(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    recorded: dict[str, object] = {}
+
+    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        recorded["args"] = args
+        recorded["timeout"] = timeout
+        return True, None
+
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(
+            str(tmp_path / "candidate.f90"), language="f95", timeout=17
+        )
+    )
+
+    assert is_valid is True
+    assert error is None
+    assert recorded["args"] == (
+        "gfortran",
+        "-fsyntax-only",
+        str(tmp_path / "candidate.f90"),
+    )
+    assert recorded["timeout"] == 17
+
+
 def test_validate_code_async_json_delegates_to_helper(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -239,6 +240,15 @@ def test_get_in_flight_work_count_includes_completed_job_processing_lock():
             runner.processing_lock.release()
 
     asyncio.run(_run())
+
+
+def test_get_failure_language_infers_fortran_from_generated_filename():
+    runner = _build_runner(evo_config=SimpleNamespace(language=None))
+
+    assert runner._get_failure_language(Path("main.f90")) == "fortran"
+    assert runner._get_failure_language(Path("main.f95")) == "fortran"
+    assert runner._get_failure_language(Path("main.f03")) == "fortran"
+    assert runner._get_failure_language(Path("main.f08")) == "fortran"
 
 
 def test_job_monitor_stops_when_target_reached_with_no_running_jobs():

--- a/tests/test_edit_fortran.py
+++ b/tests/test_edit_fortran.py
@@ -15,13 +15,15 @@ integer function score(x)
 end function score
 ! EVOLVE-BLOCK-END"""
 
-    patch_content = """! EVOLVE-BLOCK-START
-<<<<<<< SEARCH
-score = x + 1
-=======
-score = x + 2
->>>>>>> REPLACE
-! EVOLVE-BLOCK-END"""
+    patch_content = (
+        "! EVOLVE-BLOCK-START\n"
+        "<<<<<<< SEARCH\n"
+        "score = x + 1\n"
+        "=======\n"
+        "score = x + 2\n"
+        ">>>>>>> REPLACE\n"
+        "! EVOLVE-BLOCK-END"
+    )
 
     patch_dir = tmp_path / "fortran_diff_patch"
     result = apply_diff_patch(

--- a/tests/test_edit_fortran.py
+++ b/tests/test_edit_fortran.py
@@ -1,0 +1,140 @@
+from shinka.edit import apply_diff_patch, apply_full_patch
+from shinka.utils.languages import (
+    get_code_fence_languages,
+    get_evolve_comment_prefix,
+    get_language_extension,
+    normalize_language,
+)
+
+
+def test_apply_diff_patch_supports_fortran(tmp_path):
+    original_content = """! EVOLVE-BLOCK-START
+integer function score(x)
+    integer, intent(in) :: x
+    score = x + 1
+end function score
+! EVOLVE-BLOCK-END"""
+
+    patch_content = """! EVOLVE-BLOCK-START
+<<<<<<< SEARCH
+score = x + 1
+=======
+score = x + 2
+>>>>>>> REPLACE
+! EVOLVE-BLOCK-END"""
+
+    patch_dir = tmp_path / "fortran_diff_patch"
+    result = apply_diff_patch(
+        patch_str=patch_content,
+        original_str=original_content,
+        patch_dir=patch_dir,
+        language="fortran",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert error is None
+    assert num_applied == 1
+    assert "score = x + 2" in updated_content
+    assert output_path == patch_dir / "main.f90"
+    assert output_path is not None and output_path.exists()
+    assert (patch_dir / "original.f90").exists()
+    assert diff_path == patch_dir / "edit.diff"
+    assert diff_path is not None and diff_path.exists()
+    assert patch_txt is not None and "score = x + 2" in patch_txt
+
+    search_replace_txt = (patch_dir / "search_replace.txt").read_text("utf-8")
+    assert "EVOLVE-BLOCK-START" not in search_replace_txt
+    assert "EVOLVE-BLOCK-END" not in search_replace_txt
+
+
+def test_apply_full_patch_supports_fortran_and_f90_fence(tmp_path):
+    original_content = """! EVOLVE-BLOCK-START
+integer function score(x)
+    integer, intent(in) :: x
+    score = x + 1
+end function score
+! EVOLVE-BLOCK-END
+"""
+
+    patch_content = """```f90
+! EVOLVE-BLOCK-START
+integer function score(x)
+    integer, intent(in) :: x
+    score = x + 10
+end function score
+! EVOLVE-BLOCK-END
+```"""
+
+    patch_dir = tmp_path / "fortran_full_patch"
+    result = apply_full_patch(
+        patch_str=patch_content,
+        original_str=original_content,
+        patch_dir=patch_dir,
+        language="fortran",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert error is None
+    assert num_applied == 1
+    assert "score = x + 10" in updated_content
+    assert output_path == patch_dir / "main.f90"
+    assert output_path is not None and output_path.exists()
+    assert (patch_dir / "rewrite.txt").exists()
+    assert (patch_dir / "original.f90").exists()
+    assert diff_path == patch_dir / "edit.diff"
+    assert diff_path is not None and diff_path.exists()
+    assert patch_txt is not None and "score = x + 10" in patch_txt
+
+
+def test_apply_full_patch_supports_fortran_fence(tmp_path):
+    original_content = """! EVOLVE-BLOCK-START
+integer function score(x)
+    integer, intent(in) :: x
+    score = x + 1
+end function score
+! EVOLVE-BLOCK-END
+"""
+
+    patch_content = """```fortran
+! EVOLVE-BLOCK-START
+integer function score(x)
+    integer, intent(in) :: x
+    score = x + 20
+end function score
+! EVOLVE-BLOCK-END
+```"""
+
+    patch_dir = tmp_path / "fortran_named_fence"
+    result = apply_full_patch(
+        patch_str=patch_content,
+        original_str=original_content,
+        patch_dir=patch_dir,
+        language="f90",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, _ = result
+
+    assert error is None
+    assert num_applied == 1
+    assert "score = x + 20" in updated_content
+    assert output_path == patch_dir / "main.f90"
+    assert patch_txt is not None and "score = x + 20" in patch_txt
+
+
+def test_language_helpers_support_fortran_aliases():
+    for alias in ("f90", "f95", "f03", "f08"):
+        assert normalize_language(alias) == "fortran"
+        assert get_language_extension(alias) == "f90"
+        assert get_evolve_comment_prefix(alias) == "!"
+
+    assert get_language_extension("fortran") == "f90"
+    assert get_evolve_comment_prefix("fortran") == "!"
+
+    fences = get_code_fence_languages("f95")
+    assert fences[0] == "f95"
+    assert "fortran" in fences
+    assert "f90" in fences
+    assert "f03" in fences
+    assert "f08" in fences

--- a/tests/test_fortran_heat_diffusion_example.py
+++ b/tests/test_fortran_heat_diffusion_example.py
@@ -1,0 +1,39 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+def _load_evaluator():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "examples" / "fortran_heat_diffusion" / "evaluate.py"
+    spec = importlib.util.spec_from_file_location("fortran_heat_eval", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fortran_evaluator_runs_candidate_from_tempdir(monkeypatch, tmp_path):
+    evaluator = _load_evaluator()
+    run_calls = []
+
+    def fake_compile_program(program_path, tmpdir_path):
+        executable_path = tmpdir_path / "candidate"
+        executable_path.write_text("", encoding="utf-8")
+        return executable_path
+
+    def fake_run(args, **kwargs):
+        assert kwargs["cwd"] == Path(args[1]).parent
+        run_calls.append((args, kwargs))
+        output_path = Path(args[2])
+        output_path.write_text("1.0\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(evaluator, "_compile_program", fake_compile_program)
+    monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
+
+    answers, _ = evaluator._run_program(str(tmp_path / "candidate.f90"), [(8, 1, 0.1)])
+
+    assert answers == [1.0]
+    assert run_calls

--- a/tests/test_shinka_run_cli.py
+++ b/tests/test_shinka_run_cli.py
@@ -121,6 +121,57 @@ def test_shinka_run_happy_path_with_authoritative_overrides(tmp_path, monkeypatc
     assert "def main" in evaluate_str
 
 
+@pytest.mark.parametrize("extension", [".f90", ".f95", ".f03", ".f08"])
+def test_shinka_run_infers_fortran_initial_extensions(
+    tmp_path,
+    monkeypatch,
+    extension,
+):
+    _reset_dummy_runner()
+    task_dir = _make_task_dir(tmp_path)
+    (task_dir / "initial.py").unlink()
+    (task_dir / f"initial{extension}").write_text(
+        "! EVOLVE-BLOCK-START\n"
+        "integer function run()\n"
+        "    run = 0\n"
+        "end function run\n"
+        "! EVOLVE-BLOCK-END\n",
+        encoding="utf-8",
+    )
+    results_dir = tmp_path / f"results_fortran_{extension[1:]}"
+    monkeypatch.setattr(cli_run, "ShinkaEvolveRunner", _DummyRunner)
+
+    exit_code = cli_run.main(
+        [
+            "--task-dir",
+            str(task_dir),
+            "--results_dir",
+            str(results_dir),
+            "--num_generations",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+    evo_config = _DummyRunner.last_kwargs["evo_config"]
+    assert evo_config.language == "fortran"
+    assert evo_config.init_program_path.endswith(f"initial{extension}")
+
+
+def test_shinka_run_prefers_python_over_fortran_initial(tmp_path):
+    task_dir = _make_task_dir(tmp_path)
+    (task_dir / "initial.f90").write_text(
+        "! EVOLVE-BLOCK-START\n"
+        "integer function run()\n"
+        "    run = 0\n"
+        "end function run\n"
+        "! EVOLVE-BLOCK-END\n",
+        encoding="utf-8",
+    )
+
+    assert cli_run._detect_initial_program(task_dir) == task_dir / "initial.py"
+
+
 def test_shinka_run_parses_json_overrides(tmp_path, monkeypatch):
     _reset_dummy_runner()
     task_dir = _make_task_dir(tmp_path)

--- a/tests/test_visualization_meta.py
+++ b/tests/test_visualization_meta.py
@@ -332,6 +332,85 @@ def test_handle_get_program_details_loads_failed_non_python_node_with_language_f
     assert sent["data"]["code"] == "console.log('candidate');\n"
 
 
+def test_handle_get_program_details_infers_failed_fortran_node_from_suffix(
+    tmp_path,
+):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    db_path = results_dir / "programs.sqlite"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE programs (
+            id TEXT PRIMARY KEY,
+            code TEXT,
+            generation INTEGER,
+            correct INTEGER,
+            combined_score REAL,
+            timestamp REAL,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE metadata_store (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE attempt_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            generation INTEGER NOT NULL,
+            stage TEXT NOT NULL,
+            status TEXT NOT NULL,
+            details TEXT,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    gen_dir = results_dir / "gen_9"
+    gen_dir.mkdir(parents=True)
+    (gen_dir / "main.f90").write_text(
+        "program main\nend program main\n",
+        encoding="utf-8",
+    )
+    (gen_dir / "failure.json").write_text(
+        '{"artifacts":{"generated_code_path":"results/gen_9/main.f90"}}',
+        encoding="utf-8",
+    )
+    conn.execute(
+        "INSERT INTO attempt_log (generation, stage, status, details, created_at) VALUES (?, ?, ?, ?, ?)",
+        (
+            9,
+            "proposal",
+            "failed",
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"llm_output_invalid","failure_reason":"proposal failed","failure_json_path":"results/gen_9/failure.json"}',
+            140.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    handler = _make_handler(tmp_path)
+    sent = {}
+    handler.send_json_response = lambda data: sent.setdefault("data", data)
+    handler.send_error = lambda code, msg: sent.setdefault("error", (code, msg))
+
+    handler.handle_get_program_details(
+        "results/programs.sqlite", "failed:proposal:9"
+    )
+
+    assert "error" not in sent
+    assert sent["data"]["id"] == "failed:proposal:9"
+    assert sent["data"]["language"] == "fortran"
+    assert sent["data"]["code"] == "program main\nend program main\n"
+
+
 def test_handle_get_database_stats_uses_best_correct_program(tmp_path):
     results_dir = tmp_path / "results"
     results_dir.mkdir(parents=True)


### PR DESCRIPTION
## What changed
- Add canonical Fortran language support with f90/f95/f03/f08 aliases, .f90 artifacts, ! EVOLVE markers, and Fortran code fences.
- Teach shinka_run, async validation, failure artifact language inference, and WebUI download/failed-node paths about Fortran.
- Add a distinct Fortran heat-diffusion example with a Python evaluator that compiles candidates with gfortran and scores floating-point stencil checksums.
- Update README, docs, and shinka-setup language tables.

## Why
Fortran is common for numerical/scientific workloads and should be a first-class candidate language rather than an unsupported fallback. The heat-diffusion example demonstrates a compiled numerical stencil workflow rather than duplicating the existing Julia prime-counting task.

## Testing
- uv run pytest tests/test_visualization_meta.py::test_handle_get_program_details_infers_failed_fortran_node_from_suffix tests/test_async_runner_recovery.py::test_get_failure_language_infers_fortran_from_generated_filename tests/test_edit_fortran.py tests/test_async_apply.py::test_validate_code_async_fortran_delegates_to_gfortran -q
- uv run ruff check shinka/core/async_runner.py shinka/webui/visualization.py tests/test_visualization_meta.py tests/test_async_runner_recovery.py tests/test_edit_fortran.py tests/test_async_apply.py
- uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml
- uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py
- uv run --group docs mkdocs build --strict
- git diff --check

Note: local gfortran is not installed, so the example smoke run was limited to verifying the missing-compiler failure path.