### PR TITLE
[WIP] Feat: add Gemini image input (for LLM judge evaluators)

### DIFF
--- a/shinka/llm/__init__.py
+++ b/shinka/llm/__init__.py
@@ -1,4 +1,5 @@
 from .llm import LLMClient, AsyncLLMClient, extract_between
+from .image_input import ImageInput, ImageInputLike, ImageInputs
 from .providers import QueryResult
 from .prioritization import (
     BanditBase,
@@ -11,6 +12,9 @@ __all__ = [
     "LLMClient",
     "AsyncLLMClient",
     "extract_between",
+    "ImageInput",
+    "ImageInputLike",
+    "ImageInputs",
     "QueryResult",
     "EmbeddingClient",
     "AsyncEmbeddingClient",

--- a/shinka/llm/image_input.py
+++ b/shinka/llm/image_input.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import mimetypes
+import os
+from pathlib import Path
+from typing import List, TypeAlias
+
+from pydantic import BaseModel
+
+
+SUPPORTED_IMAGE_MIME_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/heic",
+    "image/heif",
+}
+SUPPORTED_IMAGE_RESOLUTIONS = {
+    "low": "MEDIA_RESOLUTION_LOW",
+    "medium": "MEDIA_RESOLUTION_MEDIUM",
+    "high": "MEDIA_RESOLUTION_HIGH",
+    "ultra_high": "MEDIA_RESOLUTION_ULTRA_HIGH",
+    "MEDIA_RESOLUTION_LOW": "MEDIA_RESOLUTION_LOW",
+    "MEDIA_RESOLUTION_MEDIUM": "MEDIA_RESOLUTION_MEDIUM",
+    "MEDIA_RESOLUTION_HIGH": "MEDIA_RESOLUTION_HIGH",
+    "MEDIA_RESOLUTION_ULTRA_HIGH": "MEDIA_RESOLUTION_ULTRA_HIGH",
+}
+
+# Gemini supported image types: https://ai.google.dev/gemini-api/docs/image-understanding
+_MIME_BY_SUFFIX = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+}
+
+
+def _infer_mime_type(path: Path) -> str:
+    mime_type, _ = mimetypes.guess_type(str(path))
+    mime_type = mime_type or _MIME_BY_SUFFIX.get(path.suffix.lower())
+    if mime_type not in SUPPORTED_IMAGE_MIME_TYPES:
+        supported = ", ".join(sorted(SUPPORTED_IMAGE_MIME_TYPES))
+        raise ValueError(
+            f"Unsupported image file type for {path}. Supported MIME types: {supported}."
+        )
+    return mime_type
+
+
+def _normalize_resolution(resolution: str | None) -> str | None:
+    if resolution is None:
+        return None
+    normalized = SUPPORTED_IMAGE_RESOLUTIONS.get(resolution)
+    if normalized is None:
+        supported = ", ".join(sorted(SUPPORTED_IMAGE_RESOLUTIONS))
+        raise ValueError(
+            f"Unsupported image resolution: {resolution!r}. Supported values: {supported}."
+        )
+    return normalized
+
+
+class ImageInput(BaseModel):
+    """Image input for an LLM call.
+
+    ``mime_type`` is inferred from ``path``. ``resolution`` is optional and maps
+    to Gemini's ``types.MediaResolution`` values when a Gemini request is built.
+    """
+
+    path: Path
+    mime_type: str | None = None
+    resolution: str | None = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        object.__setattr__(self, "mime_type", _infer_mime_type(self.path))
+        object.__setattr__(self, "resolution", _normalize_resolution(self.resolution))
+
+
+ImageInputLike: TypeAlias = ImageInput | str | os.PathLike[str]
+ImageInputs: TypeAlias = List[ImageInputLike] | None
+
+
+def _coerce_image_input(image: ImageInputLike) -> ImageInput:
+    if isinstance(image, ImageInput):
+        return image
+    return ImageInput(path=Path(image))
+
+
+def load_image_inputs(images: ImageInputs) -> List[dict]:
+    """Read image paths into provider-neutral payload dictionaries."""
+    if images is None:
+        return []
+
+    image_payloads = []
+    for image in images:
+        image_input = _coerce_image_input(image)
+        if not image_input.path.exists():
+            raise FileNotFoundError(f"Image not found: {image_input.path}")
+        image_payloads.append(
+            {
+                "data": image_input.path.read_bytes(),
+                "mime_type": image_input.mime_type,
+                "resolution": image_input.resolution,
+            }
+        )
+    return image_payloads

--- a/shinka/llm/providers/gemini.py
+++ b/shinka/llm/providers/gemini.py
@@ -84,10 +84,16 @@ def backoff_handler(details):
         )
 
 
-def gemini_build_contents(msg_history, msg):
+def gemini_build_contents(msg_history, msg, images=None):
     """Build structured contents from message history and current message.
 
-    Based on: https://ai.google.dev/gemini-api/docs/text-generation
+    If ``images`` is a non-empty list of image payload dicts, the images are
+    added before the final user text prompt on the final user message
+    (image bytes are not stored in ``msg_history``; only the text turn is).
+
+    Based on:
+    - https://ai.google.dev/gemini-api/docs/text-generation
+    - https://ai.google.dev/gemini-api/docs/image-understanding#tips-best-practices
     """
     contents = []
     # Add message history in structured format
@@ -99,8 +105,18 @@ def gemini_build_contents(msg_history, msg):
         gemini_role = "model" if role == "assistant" else role
 
         contents.append({"role": gemini_role, "parts": [{"text": content}]})
-    # Add current user message
-    contents.append({"role": "user", "parts": [{"text": msg}]})
+    # Add current user message (optional images first, then text prompt).
+    parts: list = []
+    if images:
+        for img in images:
+            part_kwargs = {"data": img["data"], "mime_type": img["mime_type"]}
+            if img.get("resolution"):
+                part_kwargs["media_resolution"] = getattr(
+                    types.MediaResolution, img["resolution"]
+                )
+            parts.append(types.Part.from_bytes(**part_kwargs))
+    parts.append({"text": msg})
+    contents.append({"role": "user", "parts": parts})
     return contents
 
 
@@ -167,7 +183,8 @@ def query_gemini(
         raise ValueError("Gemini does not support structured output.")
 
     # Build structured contents
-    contents = gemini_build_contents(msg_history, msg)
+    images = kwargs.pop("images", None)
+    contents = gemini_build_contents(msg_history, msg, images=images)
 
     # Extract kwargs for generation config
     temperature = kwargs.get("temperature", 0.8)
@@ -242,8 +259,9 @@ async def query_gemini_async(
     if output_model is not None:
         raise ValueError("Gemini does not support structured output.")
 
-    # Build structured contents
-    contents = gemini_build_contents(msg_history, msg)
+    # Build structured contents (with optional image parts on the final turn)
+    images = kwargs.pop("images", None)
+    contents = gemini_build_contents(msg_history, msg, images=images)
 
     # Extract kwargs for generation config
     temperature = kwargs.get("temperature", 0.8)

--- a/shinka/llm/query.py
+++ b/shinka/llm/query.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Dict
 from pydantic import BaseModel
 from .client import get_client_llm, get_async_client_llm
+from .image_input import ImageInputs, load_image_inputs
 from .providers import (
     query_anthropic,
     query_openai,
@@ -26,12 +27,20 @@ def query(
     msg_history: List = [],
     output_model: Optional[BaseModel] = None,
     model_posteriors: Optional[Dict[str, float]] = None,
+    images: ImageInputs = None,
     **kwargs,
 ) -> QueryResult:
     """Query the LLM."""
     client, model_name, provider = get_client_llm(
         model_name, structured_output=output_model is not None
     )
+    if images and provider != "google":
+        raise ValueError(
+            "Image input is currently only supported for Gemini models."
+        )
+    image_payload = load_image_inputs(images)
+    if image_payload:
+        kwargs["images"] = image_payload
     if provider in ("anthropic", "bedrock"):
         query_fn = query_anthropic
     elif provider in ("openai", "azure_openai", "openrouter"):
@@ -64,12 +73,20 @@ async def query_async(
     msg_history: List = [],
     output_model: Optional[BaseModel] = None,
     model_posteriors: Optional[Dict[str, float]] = None,
+    images: ImageInputs = None,
     **kwargs,
 ) -> QueryResult:
     """Query the LLM asynchronously."""
     client, model_name, provider = get_async_client_llm(
         model_name, structured_output=output_model is not None
     )
+    if images and provider != "google":
+        raise ValueError(
+            "Image input is currently only supported for Gemini models."
+        )
+    image_payload = load_image_inputs(images)
+    if image_payload:
+        kwargs["images"] = image_payload
     if provider in ("anthropic", "bedrock"):
         query_fn = query_anthropic_async
     elif provider in ("openai", "azure_openai", "openrouter"):


### PR DESCRIPTION
## Request for maintainer feedback

- @RobertTLange This PR is intentionally opened as a draft to get feedback on direction 🙏. If this feature is wanted, I’ll finish the implementation, add/commit unit tests and docs before marking ready for review.

## Summary

- Adds optional image input support to the Gemini LLM client path, primarily for visual-based evaluator / LLM-judge.

The intended API is lightweight:
```python
llm_judge.query(
    msg=judge_prompt,
    system_msg=judge_system_prompt,
    llm_kwargs={
        "model_name": "gemini-3-flash-preview",
        "images": [rendered_image_path],
    },
)
```

## Why

- Experiments producing visual artifacts could benefit from this feature.
  - For example: [generating diagrams](https://github.com/wu375/shinka-evolve-apps/tree/main/examples/create_figure)
- Keeps LLM calls inside Shinka’s existing client ecosystem (retry, cost tracking, etc.)


## Compatibility

- Does not change the proposal generation flow: proposal LLMs still operate on text/code-only context.