### PR TITLE
feat: add Go language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Added Wolfram Language as a first-class evolution target: registry entries (`wolfram`, `wl`, `wls`, `mathematica`), code-fence and EVOLVE-BLOCK marker support, and end-to-end coverage in `apply_diff` / `apply_full`.
 - Added EVOLVE-BLOCK marker validation in `shinka.edit.marker_validation`, catching the LLM failure mode where a block-comment-language marker is emitted without its closing delimiter (Wolfram, Markdown), which would silently trap the candidate body inside a comment.
 - Added the `examples/wolfram_gcd_sum` task: deoptimized seed for `S(N) = sum_{i,j in 1..N} GCD(i,j)`. The evaluator calibrates the baseline on every run by timing the seed through the same `RepeatedTiming` harness as the candidate, and the Wolfram-side timeout is configurable via `WOLFRAM_GCD_MAX_SECONDS`.
+- Added Go as a first-class evolution target with `go`/`golang` language registration, `.go` task detection, WebUI failure-artifact support, regression coverage, and the `examples/go_collatz_steps` task.
 
 ### Fixed
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -58,6 +58,24 @@ harness in Python.
 
 ---
 
+## Go Collatz Steps
+
+| | |
+|-|-|
+| **Path** | [`examples/go_collatz_steps`](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/go_collatz_steps) |
+| **Language** | Go candidate + Python evaluator |
+| **Focus** | Cross-language evolution, strict correctness scoring |
+
+```bash
+cd examples/go_collatz_steps
+python evaluate.py --program_path initial.go --results_dir results/manual_eval
+```
+
+Use this for a compact compiled-language task where Go candidates compute
+Collatz stopping times and `evaluate.py` owns `go run` validation and scoring.
+
+---
+
 ## Fortran Heat Diffusion
 
 | | |

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -339,6 +339,7 @@ internal analysis and debugging only.
 | [Circle Packing](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/circle_packing) | 26 circles in unit square; maximize sum of radii | Geometric optimization |
 | [2048](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/game_2048) | Evolve a policy to play 2048 | Game-playing / heuristic optimization |
 | [Julia Prime Counting](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/julia_prime_counting) | Optimize Julia prime-count queries | Algorithmic optimization |
+| [Go Collatz Steps](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/go_collatz_steps) | Optimize Go Collatz stopping-time queries | Algorithmic optimization |
 | [Fortran Heat Diffusion](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/fortran_heat_diffusion) | Optimize a compiled Fortran stencil solver | Numerical computing |
 | [Wolfram GCD Sum](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/wolfram_gcd_sum) | Optimize a Wolfram Language GCD-sum solver | Symbolic / numerical optimization |
 | [Novelty Generator](https://github.com/SakanaAI/ShinkaEvolve/tree/main/examples/novelty_generator) | Diverse outputs scored by LLM-as-a-judge | Open-ended exploration |

--- a/examples/go_collatz_steps/README.md
+++ b/examples/go_collatz_steps/README.md
@@ -1,0 +1,30 @@
+# Go Collatz Steps Example
+
+Algorithmic optimization task in Go: compute the Collatz stopping time for each
+input integer.
+
+Files:
+
+- `initial.go`: seed Go implementation with EVOLVE markers.
+- `evaluate.py`: Python evaluator that runs `go run`, validates outputs, writes `metrics.json` and `correct.json`.
+- `run_evo.py`: async Shinka run config with `language="go"`.
+
+Prerequisites:
+
+- Go installed and available on `PATH` as `go`.
+- ShinkaEvolve installed in the active Python environment.
+
+Run a manual evaluation:
+
+```bash
+python evaluate.py --program_path initial.go --results_dir results/manual_eval
+```
+
+Run evolution:
+
+```bash
+python run_evo.py
+```
+
+The evaluator sends fixed positive integers to the Go program and expects one
+integer stopping time per line.

--- a/examples/go_collatz_steps/evaluate.py
+++ b/examples/go_collatz_steps/evaluate.py
@@ -1,0 +1,205 @@
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+QUERIES_PUBLIC = [1, 7, 27, 97, 871, 6_171]
+QUERIES_PRIVATE = [77_031, 106_239, 216_367, 410_011, 837_799]
+TIMEOUT_SECONDS = 20
+
+
+def _collatz_steps(n: int) -> int:
+    steps = 0
+    value = n
+    while value != 1:
+        if value % 2 == 0:
+            value //= 2
+        else:
+            value = 3 * value + 1
+        steps += 1
+    return steps
+
+
+def _expected_steps(queries: list[int]) -> list[int]:
+    return [_collatz_steps(query) for query in queries]
+
+
+def _parse_output(output_path: Path) -> list[int]:
+    text = output_path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    answers: list[int] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            answers.append(int(stripped))
+    return answers
+
+
+def _run_program(program_path: str, queries: list[int]) -> tuple[list[int], float]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        input_path = tmpdir_path / "queries.txt"
+        output_path = tmpdir_path / "answers.txt"
+        input_path.write_text("\n".join(str(q) for q in queries), encoding="utf-8")
+
+        cmd = ["go", "run", program_path, str(input_path), str(output_path)]
+        start = time.perf_counter()
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+        elapsed = time.perf_counter() - start
+
+        if completed.returncode != 0:
+            stderr = completed.stderr.strip()
+            stdout = completed.stdout.strip()
+            error_parts = ["Go program failed"]
+            if stderr:
+                error_parts.append(f"stderr: {stderr}")
+            if stdout:
+                error_parts.append(f"stdout: {stdout}")
+            raise RuntimeError(" | ".join(error_parts))
+
+        if not output_path.exists():
+            raise RuntimeError("Go program did not produce output file")
+
+        answers = _parse_output(output_path)
+        return answers, elapsed
+
+
+def _build_metrics(
+    queries: list[int],
+    expected: list[int],
+    predicted: list[int],
+    runtime_seconds: float,
+) -> tuple[dict[str, Any], bool, str]:
+    if len(predicted) != len(expected):
+        msg = (
+            f"Output length mismatch. Expected {len(expected)} answers, "
+            f"got {len(predicted)}."
+        )
+        metrics = {
+            "combined_score": 0.0,
+            "public": {
+                "runtime_seconds": runtime_seconds,
+                "num_queries": len(queries),
+                "num_answers": len(predicted),
+                "accuracy": 0.0,
+            },
+            "private": {},
+        }
+        return metrics, False, msg
+
+    mismatches: list[dict[str, int]] = []
+    for idx, (query, exp, pred) in enumerate(zip(queries, expected, predicted)):
+        if exp != pred:
+            mismatches.append(
+                {
+                    "index": idx,
+                    "query": query,
+                    "expected": exp,
+                    "predicted": pred,
+                }
+            )
+
+    num_correct = len(queries) - len(mismatches)
+    accuracy = num_correct / len(queries)
+    all_correct = len(mismatches) == 0
+    combined_score = max(0.0, accuracy * 100.0 - runtime_seconds)
+
+    metrics = {
+        "combined_score": combined_score,
+        "public": {
+            "runtime_seconds": runtime_seconds,
+            "num_queries": len(queries),
+            "num_correct": num_correct,
+            "accuracy": accuracy,
+        },
+        "private": {
+            "mismatch_count": len(mismatches),
+            "first_mismatch": mismatches[0] if mismatches else None,
+        },
+    }
+
+    if all_correct:
+        return metrics, True, ""
+    msg = f"{len(mismatches)} mismatches found. First mismatch: {mismatches[0]}"
+    return metrics, False, msg
+
+
+def _failure_metrics(runtime_seconds: float = 0.0) -> dict[str, Any]:
+    return {
+        "combined_score": 0.0,
+        "public": {"runtime_seconds": runtime_seconds, "accuracy": 0.0},
+        "private": {},
+    }
+
+
+def main(program_path: str, results_dir: str):
+    os.makedirs(results_dir, exist_ok=True)
+    all_queries = QUERIES_PUBLIC + QUERIES_PRIVATE
+    expected = _expected_steps(all_queries)
+
+    try:
+        predicted, runtime_seconds = _run_program(program_path, all_queries)
+        metrics, correct, error = _build_metrics(
+            queries=all_queries,
+            expected=expected,
+            predicted=predicted,
+            runtime_seconds=runtime_seconds,
+        )
+    except FileNotFoundError:
+        metrics = _failure_metrics()
+        correct = False
+        error = "Go executable not found. Install Go and make `go` available in PATH."
+    except subprocess.TimeoutExpired:
+        metrics = _failure_metrics(TIMEOUT_SECONDS)
+        correct = False
+        error = f"Go program timed out after {TIMEOUT_SECONDS} seconds."
+    except Exception as exc:
+        metrics = _failure_metrics()
+        correct = False
+        error = str(exc)
+
+    correct_path = Path(results_dir) / "correct.json"
+    metrics_path = Path(results_dir) / "metrics.json"
+    correct_path.write_text(
+        json.dumps({"correct": correct, "error": error}, indent=4), encoding="utf-8"
+    )
+    metrics_path.write_text(json.dumps(metrics, indent=4), encoding="utf-8")
+
+    print(f"Evaluated program: {program_path}")
+    print(f"Results saved to: {results_dir}")
+    print(f"Correct: {correct}")
+    if error:
+        print(f"Error: {error}")
+    print(f"Combined score: {metrics.get('combined_score', 0.0):.6f}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Evaluate Go Collatz stopping-time program"
+    )
+    parser.add_argument(
+        "--program_path",
+        type=str,
+        default="initial.go",
+        help="Path to candidate Go program",
+    )
+    parser.add_argument(
+        "--results_dir",
+        type=str,
+        default="results",
+        help="Directory where metrics.json and correct.json are written",
+    )
+    args = parser.parse_args()
+    main(args.program_path, args.results_dir)

--- a/examples/go_collatz_steps/initial.go
+++ b/examples/go_collatz_steps/initial.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// EVOLVE-BLOCK-START
+func collatzSteps(n int64) int {
+	steps := 0
+	value := n
+	for value != 1 {
+		if value%2 == 0 {
+			value /= 2
+		} else {
+			value = 3*value + 1
+		}
+		steps++
+	}
+	return steps
+}
+
+func solveStoppingTimes(queries []int64) []int {
+	answers := make([]int, len(queries))
+	for i, q := range queries {
+		answers[i] = collatzSteps(q)
+	}
+	return answers
+}
+
+// EVOLVE-BLOCK-END
+
+func readQueries(inputPath string) ([]int64, error) {
+	file, err := os.Open(inputPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var queries []int64
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		value, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		if value < 1 {
+			return nil, fmt.Errorf("query must be >= 1: %d", value)
+		}
+		queries = append(queries, value)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return queries, nil
+}
+
+func writeAnswers(outputPath string, answers []int) error {
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	for i, value := range answers {
+		if i > 0 {
+			if _, err := writer.WriteString("\n"); err != nil {
+				return err
+			}
+		}
+		if _, err := writer.WriteString(strconv.Itoa(value)); err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "Usage: go run initial.go <input_path> <output_path>")
+		os.Exit(1)
+	}
+
+	inputPath := os.Args[1]
+	outputPath := os.Args[2]
+	queries, err := readQueries(inputPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	answers := solveStoppingTimes(queries)
+	if len(answers) != len(queries) {
+		fmt.Fprintf(
+			os.Stderr,
+			"Length mismatch: got %d answers for %d queries\n",
+			len(answers),
+			len(queries),
+		)
+		os.Exit(1)
+	}
+
+	if err := writeAnswers(outputPath, answers); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/examples/go_collatz_steps/run_evo.py
+++ b/examples/go_collatz_steps/run_evo.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from shinka.core import ShinkaEvolveRunner, EvolutionConfig
+from shinka.database import DatabaseConfig
+from shinka.launch import LocalJobConfig
+
+
+job_config = LocalJobConfig(
+    eval_program_path="evaluate.py",
+    time="00:03:00",
+)
+
+db_config = DatabaseConfig(
+    db_path="evolution_db.sqlite",
+    num_islands=1,
+    archive_size=40,
+    elite_selection_ratio=0.3,
+    num_archive_inspirations=4,
+    num_top_k_inspirations=2,
+)
+
+task_sys_msg = """
+You are optimizing a Go program for a Collatz stopping-time task.
+
+Task:
+- Input is a list of positive integers n.
+- Output must be the exact number of Collatz steps needed for each n to reach 1.
+
+Rules:
+- Keep all immutable code outside EVOLVE-BLOCK markers unchanged.
+- Only modify code inside EVOLVE-BLOCK regions.
+- Preserve function signatures.
+- Focus on algorithmic speedups while keeping outputs exact.
+
+Hints:
+- Caching intermediate stopping times can help repeated trajectories.
+- Avoid redundant sequence walks across related inputs.
+"""
+
+evo_config = EvolutionConfig(
+    task_sys_msg=task_sys_msg,
+    patch_types=["diff", "full"],
+    patch_type_probs=[0.7, 0.3],
+    num_generations=24,
+    max_patch_resamples=2,
+    max_patch_attempts=3,
+    job_type="local",
+    language="go",
+    llm_models=["gpt-5-mini"],
+    llm_kwargs=dict(
+        temperatures=[0.2, 0.6, 0.9],
+        reasoning_efforts=["medium"],
+        max_tokens=16384,
+    ),
+    embedding_model="text-embedding-3-small",
+    code_embed_sim_threshold=0.995,
+    init_program_path="initial.go",
+    results_dir="results_go_collatz_steps_async_small",
+    max_novelty_attempts=1,
+)
+
+
+SMALL_MAX_EVAL_JOBS = 1
+SMALL_MAX_PROPOSAL_JOBS = 2
+SMALL_MAX_DB_WORKERS = 1
+
+
+def main():
+    runner = ShinkaEvolveRunner(
+        evo_config=evo_config,
+        job_config=job_config,
+        db_config=db_config,
+        max_evaluation_jobs=SMALL_MAX_EVAL_JOBS,
+        max_proposal_jobs=SMALL_MAX_PROPOSAL_JOBS,
+        max_db_workers=SMALL_MAX_DB_WORKERS,
+        verbose=True,
+    )
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/shinka/cli/run.py
+++ b/shinka/cli/run.py
@@ -17,6 +17,7 @@ from shinka.cli.run_config import load_optional_yaml_config
 SUPPORTED_INITIAL_EXTENSIONS: dict[str, str] = {
     ".py": "python",
     ".jl": "julia",
+    ".go": "go",
     ".rs": "rust",
     ".swift": "swift",
     ".cpp": "cpp",
@@ -32,6 +33,7 @@ SUPPORTED_INITIAL_EXTENSIONS: dict[str, str] = {
 
 INITIAL_EXTENSION_PRIORITY: list[str] = [
     ".py",
+    ".go",
     ".jl",
     ".rs",
     ".cpp",

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -3148,6 +3148,7 @@ class ShinkaEvolveRunner:
             "cc": "cpp",
             "cxx": "cpp",
             "cu": "cuda",
+            "go": "go",
             "f90": "fortran",
             "f95": "fortran",
             "f03": "fortran",

--- a/shinka/database/complexity.py
+++ b/shinka/database/complexity.py
@@ -259,8 +259,8 @@ def analyze_code_metrics(code_string, language="python"):
             # If Python parsing fails, fall back to C++ analysis
             return analyze_cpp_complexity(code_string)
 
-    # For C/C++/CUDA/Rust and other languages, use regex-based analysis
-    elif language in ["cpp", "c", "cuda", "c++", "rust"]:
+    # For C/C++/CUDA/Go/Rust and other languages, use regex-based analysis
+    elif language in ["cpp", "c", "cuda", "c++", "go", "golang", "rust"]:
         return analyze_cpp_complexity(code_string)
 
     # For unknown languages, use simple line-based complexity

--- a/shinka/utils/languages.py
+++ b/shinka/utils/languages.py
@@ -8,6 +8,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "cxx": "cpp",
     "cc": "cpp",
     "cu": "cuda",
+    "golang": "go",
     "md": "markdown",
     "f90": "fortran",
     "f95": "fortran",
@@ -21,6 +22,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
 _LANGUAGE_EXTENSIONS: dict[str, str] = {
     "cuda": "cu",
     "cpp": "cpp",
+    "go": "go",
     "python": "py",
     "rust": "rs",
     "swift": "swift",
@@ -35,6 +37,7 @@ _LANGUAGE_EXTENSIONS: dict[str, str] = {
 _EVOLVE_COMMENT_PREFIXES: dict[str, str] = {
     "cuda": "//",
     "cpp": "//",
+    "go": "//",
     "python": "#",
     "rust": "//",
     "swift": "//",
@@ -49,6 +52,7 @@ _EVOLVE_COMMENT_PREFIXES: dict[str, str] = {
 _LANGUAGE_FENCE_TAGS: dict[str, tuple[str, ...]] = {
     "cuda": ("cuda", "cu"),
     "cpp": ("cpp", "c++", "cc", "cxx"),
+    "go": ("go", "golang"),
     "python": ("python", "py"),
     "rust": ("rust", "rs"),
     "swift": ("swift",),
@@ -124,6 +128,10 @@ _EVOLVE_MARKER_PATTERNS: dict[str, tuple[re.Pattern, re.Pattern]] = {
         re.compile(r"^\s*//\s*EVOLVE-BLOCK-START\s*$"),
         re.compile(r"^\s*//\s*EVOLVE-BLOCK-END\s*$"),
     ),
+    "go": (
+        re.compile(r"^\s*//\s*EVOLVE-BLOCK-START\s*$"),
+        re.compile(r"^\s*//\s*EVOLVE-BLOCK-END\s*$"),
+    ),
     "cuda": (
         re.compile(r"^\s*//\s*EVOLVE-BLOCK-START\s*$"),
         re.compile(r"^\s*//\s*EVOLVE-BLOCK-END\s*$"),
@@ -162,6 +170,7 @@ _EVOLVE_MARKER_EXAMPLES: dict[str, tuple[str, str]] = {
     "python": ("# EVOLVE-BLOCK-START", "# EVOLVE-BLOCK-END"),
     "julia": ("# EVOLVE-BLOCK-START", "# EVOLVE-BLOCK-END"),
     "cpp": ("// EVOLVE-BLOCK-START", "// EVOLVE-BLOCK-END"),
+    "go": ("// EVOLVE-BLOCK-START", "// EVOLVE-BLOCK-END"),
     "cuda": ("// EVOLVE-BLOCK-START", "// EVOLVE-BLOCK-END"),
     "rust": ("// EVOLVE-BLOCK-START", "// EVOLVE-BLOCK-END"),
     "swift": ("// EVOLVE-BLOCK-START", "// EVOLVE-BLOCK-END"),

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -89,6 +89,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             "cc": "cpp",
             "cxx": "cpp",
             "cu": "cuda",
+            "go": "go",
             "f90": "fortran",
             "f95": "fortran",
             "f03": "fortran",
@@ -145,6 +146,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             "typescript": ".ts",
             "cpp": ".cpp",
             "cuda": ".cu",
+            "go": ".go",
             "fortran": ".f90",
         }.get(language)
         if preferred_suffix:

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -211,6 +211,25 @@ def test_validate_code_async_json_delegates_to_helper(
     assert recorded["timeout"] == 13
 
 
+def test_validate_code_async_go_uses_read_only_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def fail_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        raise AssertionError(f"unexpected compiler validation: {args}")
+
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fail_helper)
+    candidate = tmp_path / "candidate.go"
+    candidate.write_text("package main\nfunc main() {}\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="go", timeout=19)
+    )
+
+    assert is_valid is True
+    assert error is None
+
+
 def test_validate_code_async_wolfram_uses_wolframscript_helpers(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -251,6 +251,12 @@ def test_get_failure_language_infers_fortran_from_generated_filename():
     assert runner._get_failure_language(Path("main.f08")) == "fortran"
 
 
+def test_get_failure_language_infers_go_from_generated_filename():
+    runner = _build_runner(evo_config=SimpleNamespace(language=None))
+
+    assert runner._get_failure_language(Path("main.go")) == "go"
+
+
 def test_job_monitor_stops_when_target_reached_with_no_running_jobs():
     async def _run():
         runner = _build_runner(

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,0 +1,22 @@
+from shinka.database.complexity import analyze_code_metrics
+
+
+def test_go_uses_regex_complexity_analysis():
+    metrics = analyze_code_metrics(
+        """
+package main
+
+func score(xs []int) int {
+    total := 0
+    for _, x := range xs {
+        if x > 0 {
+            total += x
+        }
+    }
+    return total
+}
+""",
+        language="go",
+    )
+
+    assert metrics["cyclomatic_complexity"] > 1

--- a/tests/test_edit_go.py
+++ b/tests/test_edit_go.py
@@ -1,0 +1,99 @@
+from shinka.edit import apply_diff_patch, apply_full_patch
+from shinka.utils.languages import (
+    get_code_fence_languages,
+    get_evolve_comment_prefix,
+    get_language_extension,
+    normalize_language,
+)
+
+
+def test_apply_diff_patch_supports_go(tmp_path):
+    original_content = """// EVOLVE-BLOCK-START
+func score(x int) int {
+    return x + 1
+}
+// EVOLVE-BLOCK-END"""
+
+    patch_content = """// EVOLVE-BLOCK-START
+<<<<<<< SEARCH
+    return x + 1
+=======
+    return x + 2
+>>>>>>> REPLACE
+// EVOLVE-BLOCK-END"""
+
+    patch_dir = tmp_path / "go_diff_patch"
+    result = apply_diff_patch(
+        patch_str=patch_content,
+        original_str=original_content,
+        patch_dir=patch_dir,
+        language="go",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert error is None
+    assert num_applied == 1
+    assert "return x + 2" in updated_content
+    assert output_path == patch_dir / "main.go"
+    assert output_path is not None and output_path.exists()
+    assert (patch_dir / "original.go").exists()
+    assert diff_path == patch_dir / "edit.diff"
+    assert diff_path is not None and diff_path.exists()
+    assert patch_txt is not None and "return x + 2" in patch_txt
+
+    search_replace_txt = (patch_dir / "search_replace.txt").read_text("utf-8")
+    assert "EVOLVE-BLOCK-START" not in search_replace_txt
+    assert "EVOLVE-BLOCK-END" not in search_replace_txt
+
+
+def test_apply_full_patch_supports_go_and_golang_fence(tmp_path):
+    original_content = """// EVOLVE-BLOCK-START
+func score(x int) int {
+    return x + 1
+}
+// EVOLVE-BLOCK-END
+"""
+
+    patch_content = """```golang
+// EVOLVE-BLOCK-START
+func score(x int) int {
+    return x + 10
+}
+// EVOLVE-BLOCK-END
+```"""
+
+    patch_dir = tmp_path / "go_full_patch"
+    result = apply_full_patch(
+        patch_str=patch_content,
+        original_str=original_content,
+        patch_dir=patch_dir,
+        language="go",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert error is None
+    assert num_applied == 1
+    assert "return x + 10" in updated_content
+    assert output_path == patch_dir / "main.go"
+    assert output_path is not None and output_path.exists()
+    assert (patch_dir / "rewrite.txt").exists()
+    assert (patch_dir / "original.go").exists()
+    assert diff_path == patch_dir / "edit.diff"
+    assert diff_path is not None and diff_path.exists()
+    assert patch_txt is not None and "return x + 10" in patch_txt
+
+
+def test_language_helpers_support_go_aliases():
+    assert normalize_language("go") == "go"
+    assert normalize_language("golang") == "go"
+    assert normalize_language("Go") == "go"
+    assert get_language_extension("go") == "go"
+    assert get_language_extension("golang") == "go"
+    assert get_evolve_comment_prefix("go") == "//"
+    assert get_evolve_comment_prefix("golang") == "//"
+
+    fences = get_code_fence_languages("golang")
+    assert fences[0] == "golang"
+    assert "go" in fences

--- a/tests/test_go_collatz_steps_example.py
+++ b/tests/test_go_collatz_steps_example.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+
+def _load_evaluator():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "examples" / "go_collatz_steps" / "evaluate.py"
+    spec = importlib.util.spec_from_file_location("go_collatz_eval", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_go_evaluator_runs_candidate_and_parses_output(monkeypatch, tmp_path):
+    evaluator = _load_evaluator()
+    run_calls = []
+
+    def fake_run(args, **kwargs):
+        run_calls.append((args, kwargs))
+        output_path = Path(args[-1])
+        output_path.write_text("0\n16\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
+
+    answers, _ = evaluator._run_program(str(tmp_path / "candidate.go"), [1, 7])
+
+    assert answers == [0, 16]
+    assert run_calls
+    assert run_calls[0][0][:2] == ["go", "run"]
+    assert run_calls[0][0][2] == str(tmp_path / "candidate.go")
+
+
+def test_go_evaluator_scores_correct_candidate(monkeypatch, tmp_path):
+    evaluator = _load_evaluator()
+
+    def fake_run(args, **kwargs):
+        output_path = Path(args[-1])
+        queries = [int(line) for line in Path(args[-2]).read_text().splitlines()]
+        answers = evaluator._expected_steps(queries)
+        output_path.write_text(
+            "\n".join(str(answer) for answer in answers),
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
+
+    results_dir = tmp_path / "results"
+    evaluator.main(str(tmp_path / "candidate.go"), str(results_dir))
+
+    metrics = json.loads((results_dir / "metrics.json").read_text(encoding="utf-8"))
+    correct = json.loads((results_dir / "correct.json").read_text(encoding="utf-8"))
+    assert correct["correct"] is True
+    assert metrics["public"]["accuracy"] == 1.0
+    assert metrics["combined_score"] > 0.0
+
+
+def test_go_evaluator_reports_nonzero_exit(monkeypatch, tmp_path):
+    evaluator = _load_evaluator()
+
+    def fake_run(args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=1,
+            stdout="",
+            stderr="compile failed",
+        )
+
+    monkeypatch.setattr(evaluator.subprocess, "run", fake_run)
+
+    results_dir = tmp_path / "results"
+    evaluator.main(str(tmp_path / "candidate.go"), str(results_dir))
+
+    correct = json.loads((results_dir / "correct.json").read_text(encoding="utf-8"))
+    metrics = json.loads((results_dir / "metrics.json").read_text(encoding="utf-8"))
+    assert correct["correct"] is False
+    assert "Go program failed" in correct["error"]
+    assert metrics["combined_score"] == 0.0

--- a/tests/test_marker_validation.py
+++ b/tests/test_marker_validation.py
@@ -18,6 +18,7 @@ WELL_FORMED = {
     "swift": "// EVOLVE-BLOCK-START\nfunc f() {}\n// EVOLVE-BLOCK-END",
     "json": '// EVOLVE-BLOCK-START\n{"a": 1}\n// EVOLVE-BLOCK-END',
     "json5": "// EVOLVE-BLOCK-START\n{a: 1}\n// EVOLVE-BLOCK-END",
+    "go": "// EVOLVE-BLOCK-START\nfunc f() {}\n// EVOLVE-BLOCK-END",
     "fortran": "! EVOLVE-BLOCK-START\ninteger :: x\n! EVOLVE-BLOCK-END",
     "markdown": "<!-- EVOLVE-BLOCK-START -->\nhello\n<!-- EVOLVE-BLOCK-END -->",
     "wolfram": "(* EVOLVE-BLOCK-START *)\nf[n_] := n\n(* EVOLVE-BLOCK-END *)",
@@ -43,6 +44,10 @@ def test_wolfram_aliases(alias):
 @pytest.mark.parametrize("alias", ["c++", "cxx", "cc"])
 def test_cpp_aliases(alias):
     assert validate_evolve_markers(WELL_FORMED["cpp"], alias) is None
+
+
+def test_go_aliases():
+    assert validate_evolve_markers(WELL_FORMED["go"], "golang") is None
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +166,11 @@ def test_python_trailing_marker_is_ok():
 def test_cpp_trailing_marker_is_ok():
     code = "// EVOLVE-BLOCK-START\n" "int x = 1;// EVOLVE-BLOCK-END\n"
     assert validate_evolve_markers(code, "cpp") is None
+
+
+def test_go_trailing_marker_is_ok():
+    code = "// EVOLVE-BLOCK-START\n" "var x = 1 // EVOLVE-BLOCK-END\n"
+    assert validate_evolve_markers(code, "go") is None
 
 
 def test_fortran_trailing_marker_is_ok():

--- a/tests/test_shinka_run_cli.py
+++ b/tests/test_shinka_run_cli.py
@@ -158,6 +158,36 @@ def test_shinka_run_infers_fortran_initial_extensions(
     assert evo_config.init_program_path.endswith(f"initial{extension}")
 
 
+def test_shinka_run_infers_go_initial_extension(tmp_path, monkeypatch):
+    _reset_dummy_runner()
+    task_dir = _make_task_dir(tmp_path)
+    (task_dir / "initial.py").unlink()
+    (task_dir / "initial.go").write_text(
+        "// EVOLVE-BLOCK-START\n"
+        "func run() int { return 0 }\n"
+        "// EVOLVE-BLOCK-END\n",
+        encoding="utf-8",
+    )
+    results_dir = tmp_path / "results_go"
+    monkeypatch.setattr(cli_run, "ShinkaEvolveRunner", _DummyRunner)
+
+    exit_code = cli_run.main(
+        [
+            "--task-dir",
+            str(task_dir),
+            "--results_dir",
+            str(results_dir),
+            "--num_generations",
+            "2",
+        ]
+    )
+
+    assert exit_code == 0
+    evo_config = _DummyRunner.last_kwargs["evo_config"]
+    assert evo_config.language == "go"
+    assert evo_config.init_program_path.endswith("initial.go")
+
+
 def test_shinka_run_prefers_python_over_fortran_initial(tmp_path):
     task_dir = _make_task_dir(tmp_path)
     (task_dir / "initial.f90").write_text(
@@ -166,6 +196,18 @@ def test_shinka_run_prefers_python_over_fortran_initial(tmp_path):
         "    run = 0\n"
         "end function run\n"
         "! EVOLVE-BLOCK-END\n",
+        encoding="utf-8",
+    )
+
+    assert cli_run._detect_initial_program(task_dir) == task_dir / "initial.py"
+
+
+def test_shinka_run_prefers_python_over_go_initial(tmp_path):
+    task_dir = _make_task_dir(tmp_path)
+    (task_dir / "initial.go").write_text(
+        "// EVOLVE-BLOCK-START\n"
+        "func run() int { return 0 }\n"
+        "// EVOLVE-BLOCK-END\n",
         encoding="utf-8",
     )
 

--- a/tests/test_visualization_meta.py
+++ b/tests/test_visualization_meta.py
@@ -411,6 +411,85 @@ def test_handle_get_program_details_infers_failed_fortran_node_from_suffix(
     assert sent["data"]["code"] == "program main\nend program main\n"
 
 
+def test_handle_get_program_details_infers_failed_go_node_from_suffix(
+    tmp_path,
+):
+    results_dir = tmp_path / "results"
+    results_dir.mkdir(parents=True)
+    db_path = results_dir / "programs.sqlite"
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE programs (
+            id TEXT PRIMARY KEY,
+            code TEXT,
+            generation INTEGER,
+            correct INTEGER,
+            combined_score REAL,
+            timestamp REAL,
+            metadata TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE metadata_store (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE attempt_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            generation INTEGER NOT NULL,
+            stage TEXT NOT NULL,
+            status TEXT NOT NULL,
+            details TEXT,
+            created_at REAL NOT NULL
+        )
+        """
+    )
+    gen_dir = results_dir / "gen_10"
+    gen_dir.mkdir(parents=True)
+    (gen_dir / "main.go").write_text(
+        "package main\nfunc main() {}\n",
+        encoding="utf-8",
+    )
+    (gen_dir / "failure.json").write_text(
+        '{"artifacts":{"generated_code_path":"results/gen_10/main.go"}}',
+        encoding="utf-8",
+    )
+    conn.execute(
+        "INSERT INTO attempt_log (generation, stage, status, details, created_at) VALUES (?, ?, ?, ?, ?)",
+        (
+            10,
+            "proposal",
+            "failed",
+            '{"node_kind":"failed_proposal","failure_stage":"proposal","failure_class":"llm_output_invalid","failure_reason":"proposal failed","failure_json_path":"results/gen_10/failure.json"}',
+            150.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    handler = _make_handler(tmp_path)
+    sent = {}
+    handler.send_json_response = lambda data: sent.setdefault("data", data)
+    handler.send_error = lambda code, msg: sent.setdefault("error", (code, msg))
+
+    handler.handle_get_program_details(
+        "results/programs.sqlite", "failed:proposal:10"
+    )
+
+    assert "error" not in sent
+    assert sent["data"]["id"] == "failed:proposal:10"
+    assert sent["data"]["language"] == "go"
+    assert sent["data"]["code"] == "package main\nfunc main() {}\n"
+
+
 def test_handle_get_database_stats_uses_best_correct_program(tmp_path):
     results_dir = tmp_path / "results"
     results_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Add Go/`golang` as a first-class language target with `.go` file output, `//` EVOLVE markers, code fences, CLI task detection, failure artifact inference, WebUI failed-node lookup, and regex complexity analysis.
- Add a unique Go example task, `examples/go_collatz_steps`, with a Go seed program and Python evaluator using `go run`.
- Update docs and `CHANGELOG.md`, and add regression coverage for Go patching, validation fallback, CLI detection, failed-node display, complexity, and the example evaluator.

## Why
Closes #135 by making Go usable without local language-registry workarounds and by documenting a runnable, non-Python candidate example distinct from the Julia prime-counting task.

## Testing
- `uv run pytest tests/test_edit_go.py tests/test_marker_validation.py tests/test_async_apply.py tests/test_shinka_run_cli.py tests/test_async_runner_recovery.py::test_get_failure_language_infers_go_from_generated_filename tests/test_visualization_meta.py::test_handle_get_program_details_infers_failed_go_node_from_suffix tests/test_complexity.py tests/test_go_collatz_steps_example.py -q`
- `uv run python examples/go_collatz_steps/evaluate.py --program_path examples/go_collatz_steps/initial.go --results_dir /tmp/shinka_go_collatz_eval`
- `uv run ruff check tests --exclude tests/file.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
- `uv run --group docs mkdocs build --strict`
- `uv run pytest -q`
- `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`

## Notes
- Shinka's generic Go syntax validation intentionally uses the existing read-only fallback; evaluator-level `go run` owns build/run validation for Go tasks.
- Existing bandit persistence runtime warnings still appear during pytest.
