### PR TITLE
fix: harden provider networking and response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed Google GenAI client setup to detect broken IPv6 connectivity to Google API hosts and prefer IPv4 when needed.
+- Fixed LLM pricing boolean metadata normalization so reasoning-model flags handle whitespace and mixed CSV value types.
+- Fixed OpenAI Responses parsing to find assistant text by content type while ignoring reasoning/tool text when no message output exists.
 - Fixed quiet evaluation mode so `run_shinka_eval(..., verbose=False)` also suppresses result-save framework stdout while preserving the default verbose behavior.
 
 ## 0.0.7 - 2026-06-02

--- a/shinka/google_genai.py
+++ b/shinka/google_genai.py
@@ -1,10 +1,37 @@
+import logging
 import os
+import socket
+import threading
 from typing import Any
 
 from google import genai
 
 
+logger = logging.getLogger(__name__)
+
+GOOGLE_GENAI_IP_FAMILY_ENV = "SHINKA_GOOGLE_GENAI_IP_FAMILY"
+GOOGLE_GENAI_IP_PROBE_TIMEOUT_ENV = "SHINKA_GOOGLE_GENAI_IP_PROBE_TIMEOUT"
+
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+_GOOGLE_GENAI_IP_POLICIES = {"auto", "system", "ipv4", "ipv4_first"}
+_GOOGLE_GENAI_IP_POLICY_ALIASES = {
+    "ipv4-first": "ipv4_first",
+    "prefer_ipv4": "ipv4_first",
+    "prefer-ipv4": "ipv4_first",
+    "v4": "ipv4",
+    "v4_first": "ipv4_first",
+    "v4-first": "ipv4_first",
+}
+_GOOGLE_GENAI_PROBE_HOST = "generativelanguage.googleapis.com"
+_GOOGLE_GENAI_PROBE_PORT = 443
+_GOOGLE_GENAI_PROBE_TIMEOUT_SECONDS = 0.3
+_GOOGLE_GENAI_PROBE_CANDIDATES = 2
+
+_ORIGINAL_GETADDRINFO = socket.getaddrinfo
+_NETWORK_LOCK = threading.Lock()
+_ACTIVE_GETADDRINFO_POLICY: str | None = None
+_DETECTED_IP_POLICY: str | None = None
+_LOGGED_AUTO_FALLBACK = False
 
 
 def _env_flag(name: str) -> bool:
@@ -19,6 +46,175 @@ def _google_genai_timeout_ms(timeout_seconds: int) -> int:
 def google_genai_auth_mode() -> str:
     """Return the configured Google GenAI auth mode."""
     return "vertexai" if _env_flag("GOOGLE_GENAI_USE_VERTEXAI") else "api_key"
+
+
+def configure_google_genai_network() -> str:
+    """Configure Google API address ordering and return the active policy."""
+    requested_policy = _google_genai_ip_policy()
+    active_policy = (
+        _detect_google_genai_ip_policy()
+        if requested_policy == "auto"
+        else requested_policy
+    )
+
+    if requested_policy == "auto" and active_policy == "ipv4_first":
+        _log_auto_fallback_once()
+
+    if active_policy == "system":
+        _restore_google_api_getaddrinfo()
+    else:
+        _install_google_api_getaddrinfo_policy(active_policy)
+    return active_policy
+
+
+def _google_genai_ip_policy() -> str:
+    raw_policy = os.getenv(GOOGLE_GENAI_IP_FAMILY_ENV, "auto").strip().lower()
+    policy = _GOOGLE_GENAI_IP_POLICY_ALIASES.get(raw_policy, raw_policy)
+    if policy not in _GOOGLE_GENAI_IP_POLICIES:
+        valid_policies = ", ".join(sorted(_GOOGLE_GENAI_IP_POLICIES))
+        raise ValueError(
+            f"{GOOGLE_GENAI_IP_FAMILY_ENV} must be one of: {valid_policies}."
+        )
+    return policy
+
+
+def _detect_google_genai_ip_policy() -> str:
+    global _DETECTED_IP_POLICY
+
+    with _NETWORK_LOCK:
+        if _DETECTED_IP_POLICY is None:
+            _DETECTED_IP_POLICY = _probe_google_genai_ip_policy()
+        return _DETECTED_IP_POLICY
+
+
+def _probe_google_genai_ip_policy() -> str:
+    try:
+        addresses = _ORIGINAL_GETADDRINFO(
+            _GOOGLE_GENAI_PROBE_HOST,
+            _GOOGLE_GENAI_PROBE_PORT,
+            type=socket.SOCK_STREAM,
+        )
+    except OSError:
+        return "system"
+
+    has_ipv6 = any(address[0] == socket.AF_INET6 for address in addresses)
+    has_ipv4 = any(address[0] == socket.AF_INET for address in addresses)
+    if not has_ipv6 or not has_ipv4:
+        return "system"
+    if _address_family_connects(addresses, socket.AF_INET6):
+        return "system"
+    if _address_family_connects(addresses, socket.AF_INET):
+        return "ipv4_first"
+    return "system"
+
+
+def _address_family_connects(addresses: list[Any], family: socket.AddressFamily) -> bool:
+    timeout = _google_genai_ip_probe_timeout_seconds()
+    checked = 0
+    for address in addresses:
+        if address[0] != family:
+            continue
+        checked += 1
+        _, socktype, proto, _, sockaddr = address
+        try:
+            with socket.socket(family, socktype, proto) as sock:
+                sock.settimeout(timeout)
+                sock.connect(sockaddr)
+            return True
+        except OSError:
+            if checked >= _GOOGLE_GENAI_PROBE_CANDIDATES:
+                return False
+    return False
+
+
+def _google_genai_ip_probe_timeout_seconds() -> float:
+    raw_timeout = os.getenv(GOOGLE_GENAI_IP_PROBE_TIMEOUT_ENV, "").strip()
+    if not raw_timeout:
+        return _GOOGLE_GENAI_PROBE_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw_timeout)
+    except ValueError as exc:
+        raise ValueError(
+            f"{GOOGLE_GENAI_IP_PROBE_TIMEOUT_ENV} must be a positive number."
+        ) from exc
+    if timeout <= 0:
+        raise ValueError(
+            f"{GOOGLE_GENAI_IP_PROBE_TIMEOUT_ENV} must be a positive number."
+        )
+    return timeout
+
+
+def _install_google_api_getaddrinfo_policy(policy: str) -> None:
+    global _ACTIVE_GETADDRINFO_POLICY
+
+    with _NETWORK_LOCK:
+        _ACTIVE_GETADDRINFO_POLICY = policy
+        if socket.getaddrinfo is not _google_api_getaddrinfo:
+            socket.getaddrinfo = _google_api_getaddrinfo
+
+
+def _restore_google_api_getaddrinfo() -> None:
+    global _ACTIVE_GETADDRINFO_POLICY
+
+    with _NETWORK_LOCK:
+        _ACTIVE_GETADDRINFO_POLICY = None
+        if socket.getaddrinfo is _google_api_getaddrinfo:
+            socket.getaddrinfo = _ORIGINAL_GETADDRINFO
+
+
+def _google_api_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+    addresses = _ORIGINAL_GETADDRINFO(host, port, family, type, proto, flags)
+    policy = _ACTIVE_GETADDRINFO_POLICY
+    if (
+        policy is None
+        or family not in (0, socket.AF_UNSPEC)
+        or not _is_google_api_host(host)
+    ):
+        return addresses
+    return _google_api_addresses_for_policy(addresses, policy)
+
+
+def _google_api_addresses_for_policy(addresses: list[Any], policy: str) -> list[Any]:
+    ipv4_addresses = [address for address in addresses if address[0] == socket.AF_INET]
+    if policy == "ipv4":
+        return ipv4_addresses or addresses
+    if policy == "ipv4_first" and ipv4_addresses:
+        non_ipv4_addresses = [
+            address for address in addresses if address[0] != socket.AF_INET
+        ]
+        return ipv4_addresses + non_ipv4_addresses
+    return addresses
+
+
+def _is_google_api_host(host: object) -> bool:
+    normalized_host = _normalize_host(host)
+    return normalized_host == "googleapis.com" or normalized_host.endswith(
+        ".googleapis.com"
+    )
+
+
+def _normalize_host(host: object) -> str:
+    if host is None:
+        return ""
+    if isinstance(host, bytes):
+        try:
+            host = host.decode("idna")
+        except UnicodeDecodeError:
+            return ""
+    return str(host).rstrip(".").lower()
+
+
+def _log_auto_fallback_once() -> None:
+    global _LOGGED_AUTO_FALLBACK
+
+    if _LOGGED_AUTO_FALLBACK:
+        return
+    logger.warning(
+        "Google GenAI IPv6 probe failed while IPv4 succeeded; preferring IPv4 "
+        "for googleapis.com hosts. Set %s=system to use resolver order.",
+        GOOGLE_GENAI_IP_FAMILY_ENV,
+    )
+    _LOGGED_AUTO_FALLBACK = True
 
 
 def build_google_genai_client(timeout_ms: int | None = None) -> genai.Client:
@@ -38,6 +234,7 @@ def build_google_genai_client(timeout_ms: int | None = None) -> genai.Client:
             raise ValueError(
                 "GOOGLE_CLOUD_LOCATION is required when GOOGLE_GENAI_USE_VERTEXAI is enabled."
             )
+        configure_google_genai_network()
         return genai.Client(
             vertexai=True,
             project=project,
@@ -52,4 +249,5 @@ def build_google_genai_client(timeout_ms: int | None = None) -> genai.Client:
             "GOOGLE_GENAI_USE_VERTEXAI, GOOGLE_CLOUD_PROJECT, and "
             "GOOGLE_CLOUD_LOCATION for Vertex AI mode."
         )
+    configure_google_genai_network()
     return genai.Client(api_key=api_key, **kwargs)

--- a/shinka/llm/providers/openai.py
+++ b/shinka/llm/providers/openai.py
@@ -12,6 +12,53 @@ MAX_VALUE = BACKOFF_MAX_VALUE
 MAX_TIME = BACKOFF_MAX_TIME
 
 
+def _field(value, name, default=None):
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _sequence(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return value
+    return [value]
+
+
+def _extract_response_text(response) -> str:
+    output_text = _field(response, "output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return output_text
+
+    output = _sequence(_field(response, "output"))
+    for item in output:
+        for content in _sequence(_field(item, "content")):
+            text = _field(content, "text")
+            if isinstance(text, str) and text.strip():
+                return text
+
+    output_types = [_field(item, "type", type(item).__name__) for item in output]
+    status = _field(response, "status")
+    incomplete = _field(response, "incomplete_details")
+    incomplete_reason = _field(incomplete, "reason")
+    raise ValueError(
+        "OpenAI response contained no text output; "
+        f"status={status}; output_types={output_types}; "
+        f"incomplete_reason={incomplete_reason}"
+    )
+
+
+def _extract_reasoning_summary(response) -> str:
+    summaries = []
+    for item in _sequence(_field(response, "output")):
+        for summary in _sequence(_field(item, "summary")):
+            text = _field(summary, "text")
+            if isinstance(text, str) and text.strip():
+                summaries.append(text)
+    return "\n".join(summaries)
+
+
 def backoff_handler(details):
     exc = details.get("exception")
     if exc:
@@ -97,16 +144,8 @@ def query_openai(
             ],
             **kwargs,
         )
-        try:
-            content = response.output[0].content[0].text
-        except Exception:
-            # Reasoning models - ResponseOutputMessage
-            content = response.output[1].content[0].text
-
-        try:
-            thought = response.output[0].summary[0].text
-        except Exception:
-            pass
+        content = _extract_response_text(response)
+        thought = _extract_reasoning_summary(response)
         new_msg_history.append({"role": "assistant", "content": content})
     else:
         response = client.responses.parse(
@@ -177,15 +216,8 @@ async def query_openai_async(
             ],
             **kwargs,
         )
-        try:
-            content = response.output[0].content[0].text
-        except Exception:
-            # Reasoning models - ResponseOutputMessage
-            content = response.output[1].content[0].text
-        try:
-            thought = response.output[0].summary[0].text
-        except Exception:
-            pass
+        content = _extract_response_text(response)
+        thought = _extract_reasoning_summary(response)
         new_msg_history.append({"role": "assistant", "content": content})
     else:
         response = await client.responses.parse(

--- a/shinka/llm/providers/openai.py
+++ b/shinka/llm/providers/openai.py
@@ -33,7 +33,11 @@ def _extract_response_text(response) -> str:
 
     output = _sequence(_field(response, "output"))
     for item in output:
+        if _field(item, "type") != "message":
+            continue
         for content in _sequence(_field(item, "content")):
+            if _field(content, "type") != "output_text":
+                continue
             text = _field(content, "text")
             if isinstance(text, str) and text.strip():
                 return text

--- a/shinka/llm/providers/pricing.py
+++ b/shinka/llm/providers/pricing.py
@@ -7,6 +7,7 @@
 import pandas as pd
 from pathlib import Path
 from typing import Optional, Tuple
+from pandas.api.types import is_object_dtype, is_string_dtype
 
 # Load pricing data from CSV
 _pricing_csv_path = Path(__file__).parent / "pricing.csv"
@@ -20,8 +21,8 @@ def _load_pricing_dataframe() -> pd.DataFrame:
 
     # Strip whitespace from string columns only
     for col in df.columns:
-        if df[col].dtype == "object":  # Only strip string columns
-            df[col] = df[col].str.strip()
+        if is_object_dtype(df[col]) or is_string_dtype(df[col]):
+            df[col] = df[col].astype("string").str.strip()
 
     # Strip column names
     df.columns = df.columns.str.strip()
@@ -51,19 +52,21 @@ def _load_pricing_dataframe() -> pd.DataFrame:
     df["input_price_tier2"] = df["input_price_tier2"] / M
     df["output_price_tier2"] = df["output_price_tier2"] / M
 
-    # Convert is_reasoning to boolean
-    df["is_reasoning"] = df["is_reasoning"] == "True"
-
-    # Convert think_temp_fixed to boolean (handle both string "1" and int 1)
-    df["think_temp_fixed"] = df["think_temp_fixed"].astype(str) == "1"
-
-    # Convert requires_reasoning to boolean (handle both string "1" and int 1)
-    df["requires_reasoning"] = df["requires_reasoning"].astype(str) == "1"
+    # Convert boolean metadata. The CSV historically contains mixed values such
+    # as True, " True", 1, and " 1".
+    df["is_reasoning"] = _truthy_column(df["is_reasoning"])
+    df["think_temp_fixed"] = _truthy_column(df["think_temp_fixed"])
+    df["requires_reasoning"] = _truthy_column(df["requires_reasoning"])
 
     # Set index to model_name for fast lookups
     df = df.set_index("model_name")
 
     return df
+
+
+def _truthy_column(series: pd.Series) -> pd.Series:
+    normalized = series.astype("string").str.strip().str.lower()
+    return normalized.isin({"1", "true", "yes", "y"})
 
 
 # Load pricing dataframe

--- a/tests/test_google_genai.py
+++ b/tests/test_google_genai.py
@@ -1,6 +1,132 @@
+import socket
+
 import pytest
 
 import shinka.google_genai as google_genai_module
+
+
+@pytest.fixture(autouse=True)
+def _use_system_google_genai_network(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SHINKA_GOOGLE_GENAI_IP_FAMILY", "system")
+
+
+def _addr(family: socket.AddressFamily, host: str):
+    sockaddr = (host, 443) if family == socket.AF_INET else (host, 443, 0, 0)
+    return (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr)
+
+
+def test_google_api_host_detection_is_scoped():
+    assert google_genai_module._is_google_api_host("generativelanguage.googleapis.com")
+    assert google_genai_module._is_google_api_host(
+        "us-central1-aiplatform.googleapis.com"
+    )
+    assert not google_genai_module._is_google_api_host("api.openai.com")
+    assert not google_genai_module._is_google_api_host("notgoogleapis.com")
+
+
+def test_configure_google_genai_network_ipv4_first_reorders_only_google_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mixed_addresses = [
+        _addr(socket.AF_INET6, "2001:db8::1"),
+        _addr(socket.AF_INET6, "2001:db8::2"),
+        _addr(socket.AF_INET, "203.0.113.1"),
+        _addr(socket.AF_INET, "203.0.113.2"),
+    ]
+
+    def _fake_getaddrinfo(*args, **kwargs):
+        return list(mixed_addresses)
+
+    monkeypatch.setenv("SHINKA_GOOGLE_GENAI_IP_FAMILY", "ipv4_first")
+    monkeypatch.setattr(google_genai_module, "_ORIGINAL_GETADDRINFO", _fake_getaddrinfo)
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    policy = google_genai_module.configure_google_genai_network()
+
+    assert policy == "ipv4_first"
+    google_addresses = socket.getaddrinfo("generativelanguage.googleapis.com", 443)
+    non_google_addresses = socket.getaddrinfo("api.openai.com", 443)
+    assert [address[0] for address in google_addresses] == [
+        socket.AF_INET,
+        socket.AF_INET,
+        socket.AF_INET6,
+        socket.AF_INET6,
+    ]
+    assert non_google_addresses == mixed_addresses
+
+
+def test_configure_google_genai_network_ipv4_filters_google_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mixed_addresses = [
+        _addr(socket.AF_INET6, "2001:db8::1"),
+        _addr(socket.AF_INET, "203.0.113.1"),
+    ]
+
+    def _fake_getaddrinfo(*args, **kwargs):
+        return list(mixed_addresses)
+
+    monkeypatch.setenv("SHINKA_GOOGLE_GENAI_IP_FAMILY", "ipv4")
+    monkeypatch.setattr(google_genai_module, "_ORIGINAL_GETADDRINFO", _fake_getaddrinfo)
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    policy = google_genai_module.configure_google_genai_network()
+
+    assert policy == "ipv4"
+    addresses = socket.getaddrinfo("generativelanguage.googleapis.com", 443)
+    assert [address[0] for address in addresses] == [socket.AF_INET]
+
+
+def test_configure_google_genai_network_respects_explicit_family(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mixed_addresses = [
+        _addr(socket.AF_INET6, "2001:db8::1"),
+        _addr(socket.AF_INET, "203.0.113.1"),
+    ]
+
+    def _fake_getaddrinfo(*args, **kwargs):
+        return list(mixed_addresses)
+
+    monkeypatch.setenv("SHINKA_GOOGLE_GENAI_IP_FAMILY", "ipv4")
+    monkeypatch.setattr(google_genai_module, "_ORIGINAL_GETADDRINFO", _fake_getaddrinfo)
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+
+    google_genai_module.configure_google_genai_network()
+
+    addresses = socket.getaddrinfo(
+        "generativelanguage.googleapis.com",
+        443,
+        family=socket.AF_INET6,
+    )
+    assert addresses == mixed_addresses
+
+
+def test_configure_google_genai_network_auto_installs_detected_policy(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mixed_addresses = [
+        _addr(socket.AF_INET6, "2001:db8::1"),
+        _addr(socket.AF_INET, "203.0.113.1"),
+    ]
+
+    def _fake_getaddrinfo(*args, **kwargs):
+        return list(mixed_addresses)
+
+    monkeypatch.setenv("SHINKA_GOOGLE_GENAI_IP_FAMILY", "auto")
+    monkeypatch.setattr(google_genai_module, "_ORIGINAL_GETADDRINFO", _fake_getaddrinfo)
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo)
+    monkeypatch.setattr(
+        google_genai_module,
+        "_detect_google_genai_ip_policy",
+        lambda: "ipv4_first",
+    )
+
+    policy = google_genai_module.configure_google_genai_network()
+
+    assert policy == "ipv4_first"
+    addresses = socket.getaddrinfo("generativelanguage.googleapis.com", 443)
+    assert [address[0] for address in addresses] == [socket.AF_INET, socket.AF_INET6]
 
 
 def test_google_genai_timeout_is_in_milliseconds():
@@ -25,6 +151,7 @@ def test_google_genai_auth_mode_defaults_to_api_key(monkeypatch: pytest.MonkeyPa
 def test_build_google_genai_client_uses_api_key(monkeypatch: pytest.MonkeyPatch):
     captured_kwargs = {}
     fake_client = object()
+    configured_policies = []
 
     class _FakeHttpOptions:
         def __init__(self, **kwargs):
@@ -34,14 +161,24 @@ def test_build_google_genai_client_uses_api_key(monkeypatch: pytest.MonkeyPatch)
         captured_kwargs.update(kwargs)
         return fake_client
 
+    def _fake_configure_google_genai_network():
+        configured_policies.append("system")
+        return "system"
+
     monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
     monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
     monkeypatch.setattr(google_genai_module.genai.types, "HttpOptions", _FakeHttpOptions)
     monkeypatch.setattr(google_genai_module.genai, "Client", _fake_client)
+    monkeypatch.setattr(
+        google_genai_module,
+        "configure_google_genai_network",
+        _fake_configure_google_genai_network,
+    )
 
     client = google_genai_module.build_google_genai_client(timeout_ms=1234)
 
     assert client is fake_client
+    assert configured_policies == ["system"]
     assert captured_kwargs["api_key"] == "test-gemini-key"
     assert captured_kwargs["http_options"].timeout == 1234
 
@@ -77,8 +214,19 @@ def test_build_google_genai_client_uses_vertexai(monkeypatch: pytest.MonkeyPatch
 def test_build_google_genai_client_requires_gemini_api_key(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    configured_policies = []
+
+    def _fake_configure_google_genai_network():
+        configured_policies.append("system")
+        return "system"
+
     monkeypatch.delenv("GOOGLE_GENAI_USE_VERTEXAI", raising=False)
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        google_genai_module,
+        "configure_google_genai_network",
+        _fake_configure_google_genai_network,
+    )
 
     with pytest.raises(ValueError, match="GEMINI_API_KEY") as exc_info:
         google_genai_module.build_google_genai_client()
@@ -88,6 +236,7 @@ def test_build_google_genai_client_requires_gemini_api_key(
     assert "GOOGLE_GENAI_USE_VERTEXAI" in error_message
     assert "GOOGLE_CLOUD_PROJECT" in error_message
     assert "GOOGLE_CLOUD_LOCATION" in error_message
+    assert configured_policies == []
 
 
 def test_build_google_genai_client_requires_vertex_project(

--- a/tests/test_llm_kwargs.py
+++ b/tests/test_llm_kwargs.py
@@ -1,4 +1,5 @@
 from shinka.llm.kwargs import sample_model_kwargs
+from shinka.llm.providers.pricing import is_reasoning_model, requires_reasoning
 
 
 def test_sample_model_kwargs_uses_max_tokens_for_local_openai():
@@ -27,3 +28,19 @@ def test_sample_model_kwargs_uses_max_output_tokens_for_dynamic_openrouter():
     assert kwargs["temperature"] == 0.15
     assert kwargs["max_output_tokens"] == 222
     assert "max_tokens" not in kwargs
+
+
+def test_gpt5_mini_pricing_metadata_enables_reasoning_kwargs():
+    assert is_reasoning_model("gpt-5-mini")
+    assert requires_reasoning("gpt-5-mini")
+
+    kwargs = sample_model_kwargs(
+        model_names=["gpt-5-mini"],
+        temperatures=[0.0],
+        max_tokens=[8192],
+        reasoning_efforts=["minimal"],
+    )
+
+    assert kwargs["temperature"] == 1.0
+    assert kwargs["max_output_tokens"] == 8192
+    assert kwargs["reasoning"] == {"effort": "minimal", "summary": "auto"}

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
-from shinka.llm.providers.openai import get_openai_costs
+import pytest
+
+from shinka.llm.providers.openai import get_openai_costs, query_openai
 
 
 def _usage(
@@ -55,3 +57,123 @@ def test_get_openai_costs_uses_openrouter_cost_details_when_available():
     assert costs["input_cost"] == 0.12
     assert costs["output_cost"] == 0.34
     assert costs["cost"] == 0.46
+
+
+class _FakeOpenAIClient:
+    def __init__(self, response):
+        self.responses = SimpleNamespace(create=lambda **kwargs: response)
+
+
+def _content(text: str):
+    return SimpleNamespace(text=text)
+
+
+def _response(*, output=None, output_text=None, status="completed"):
+    return SimpleNamespace(
+        output=[] if output is None else output,
+        output_text=output_text,
+        status=status,
+        usage=_usage(input_tokens=10, output_tokens=20),
+    )
+
+
+def test_query_openai_reads_text_from_first_output_item():
+    response = _response(
+        output=[SimpleNamespace(type="message", content=[_content("123")])]
+    )
+
+    result = query_openai(
+        _FakeOpenAIClient(response),
+        "gpt-5-mini",
+        "problem",
+        "system",
+        [],
+        None,
+        max_output_tokens=8192,
+    )
+
+    assert result.content == "123"
+    assert result.new_msg_history[-1] == {"role": "assistant", "content": "123"}
+
+
+def test_query_openai_reads_text_after_reasoning_output_item():
+    response = _response(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                summary=[SimpleNamespace(text="reasoning summary")],
+            ),
+            SimpleNamespace(type="message", content=[_content("456")]),
+        ]
+    )
+
+    result = query_openai(
+        _FakeOpenAIClient(response),
+        "gpt-5-mini",
+        "problem",
+        "system",
+        [],
+        None,
+        max_output_tokens=8192,
+    )
+
+    assert result.content == "456"
+    assert result.thought == "reasoning summary"
+
+
+def test_query_openai_scans_later_output_items_for_text():
+    response = _response(
+        output=[
+            {"type": "reasoning", "summary": [{"text": "first"}]},
+            {"type": "tool_call", "content": []},
+            {"type": "message", "content": [{"text": "789"}]},
+        ]
+    )
+
+    result = query_openai(
+        _FakeOpenAIClient(response),
+        "gpt-5-mini",
+        "problem",
+        "system",
+        [],
+        None,
+        max_output_tokens=8192,
+    )
+
+    assert result.content == "789"
+    assert result.thought == "first"
+
+
+def test_query_openai_uses_output_text_fallback():
+    response = _response(output_text="321")
+
+    result = query_openai(
+        _FakeOpenAIClient(response),
+        "gpt-5-mini",
+        "problem",
+        "system",
+        [],
+        None,
+        max_output_tokens=8192,
+    )
+
+    assert result.content == "321"
+
+
+def test_query_openai_raises_clear_error_when_response_has_no_text():
+    response = _response(
+        output=[SimpleNamespace(type="reasoning", summary=[])],
+        status="incomplete",
+    )
+    response.incomplete_details = SimpleNamespace(reason="max_output_tokens")
+
+    with pytest.raises(ValueError, match="OpenAI response contained no text output"):
+        query_openai(
+            _FakeOpenAIClient(response),
+            "gpt-5-mini",
+            "problem",
+            "system",
+            [],
+            None,
+            max_output_tokens=8192,
+        )

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -65,7 +65,7 @@ class _FakeOpenAIClient:
 
 
 def _content(text: str):
-    return SimpleNamespace(text=text)
+    return SimpleNamespace(type="output_text", text=text)
 
 
 def _response(*, output=None, output_text=None, status="completed"):
@@ -126,7 +126,7 @@ def test_query_openai_scans_later_output_items_for_text():
         output=[
             {"type": "reasoning", "summary": [{"text": "first"}]},
             {"type": "tool_call", "content": []},
-            {"type": "message", "content": [{"text": "789"}]},
+            {"type": "message", "content": [{"type": "output_text", "text": "789"}]},
         ]
     )
 
@@ -166,6 +166,31 @@ def test_query_openai_raises_clear_error_when_response_has_no_text():
         status="incomplete",
     )
     response.incomplete_details = SimpleNamespace(reason="max_output_tokens")
+
+    with pytest.raises(ValueError, match="OpenAI response contained no text output"):
+        query_openai(
+            _FakeOpenAIClient(response),
+            "gpt-5-mini",
+            "problem",
+            "system",
+            [],
+            None,
+            max_output_tokens=8192,
+        )
+
+
+def test_query_openai_does_not_treat_reasoning_text_as_output():
+    response = _response(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                content=[
+                    SimpleNamespace(type="reasoning_text", text="internal reasoning")
+                ],
+            )
+        ],
+        status="incomplete",
+    )
 
     with pytest.raises(ValueError, match="OpenAI response contained no text output"):
         query_openai(


### PR DESCRIPTION
## Summary
- add Google GenAI IP-family selection with IPv4 fallback when IPv6 connectivity is broken
- normalize pricing boolean metadata so GPT-5 reasoning models get the intended reasoning kwargs
- parse OpenAI Responses output by content shape instead of fixed output indexes

## Why
Autorouter AIME evals exposed two provider robustness issues: Gemini calls failed on environments with broken IPv6, and GPT-5-mini could return OpenAI Responses layouts where text was not in `output[0]` or `output[1]`. The pricing CSV also had whitespace/mixed-type booleans that prevented GPT-5-mini from being treated as a reasoning model.

## Validation
- `uv run pytest -q -m "not requires_secrets"` -> 488 passed
- `uv run pytest -q tests/test_openai_provider.py tests/test_llm_kwargs.py tests/test_model_resolver.py tests/test_model_availability.py` -> 34 passed
- `uv run ruff check shinka/llm/providers/openai.py shinka/llm/providers/pricing.py tests/test_openai_provider.py tests/test_llm_kwargs.py` -> passed

Note: full `uv run ruff check` still reports pre-existing unrelated issues in examples, notebooks, plots, DeepSeek provider, and `tests/file.py`.
