### PR TITLE
Bound OpenAI-compatible LLM retry stalls with configurable budgets

### DIFF
--- a/shinka/llm/client.py
+++ b/shinka/llm/client.py
@@ -6,7 +6,7 @@ import instructor
 from shinka.env import load_shinka_dotenv
 from shinka.google_genai import _google_genai_timeout_ms, build_google_genai_client
 from shinka.local_openai_config import resolve_local_openai_api_key
-from .constants import TIMEOUT
+from .constants import OPENAI_MAX_RETRIES, TIMEOUT
 from .providers.model_resolver import resolve_model_backend
 
 load_shinka_dotenv()
@@ -40,7 +40,7 @@ def get_client_llm(
     api_model_name = resolved.api_model_name
 
     if provider == "anthropic":
-        client = anthropic.Anthropic(timeout=TIMEOUT)  # 20 minutes
+        client = anthropic.Anthropic(timeout=TIMEOUT)
         if structured_output:
             client = instructor.from_anthropic(
                 client, mode=instructor.mode.Mode.ANTHROPIC_JSON
@@ -50,14 +50,14 @@ def get_client_llm(
             aws_access_key=os.getenv("AWS_ACCESS_KEY_ID"),
             aws_secret_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
             aws_region=os.getenv("AWS_REGION_NAME"),
-            timeout=TIMEOUT,  # 20 minutes
+            timeout=TIMEOUT,
         )
         if structured_output:
             client = instructor.from_anthropic(
                 client, mode=instructor.mode.Mode.ANTHROPIC_JSON
             )
     elif provider == "openai":
-        client = openai.OpenAI(timeout=TIMEOUT)  # 20 minutes
+        client = openai.OpenAI(timeout=TIMEOUT, max_retries=OPENAI_MAX_RETRIES)
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.TOOLS_STRICT)
     elif provider == "azure_openai":
@@ -66,7 +66,8 @@ def get_client_llm(
             api_key=os.getenv("AZURE_OPENAI_API_KEY"),
             api_version=os.getenv("AZURE_API_VERSION"),
             azure_endpoint=_build_azure_endpoint(),
-            timeout=TIMEOUT,  # 20 minutes
+            timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.TOOLS_STRICT)
@@ -74,7 +75,8 @@ def get_client_llm(
         client = openai.OpenAI(
             api_key=os.environ["DEEPSEEK_API_KEY"],
             base_url="https://api.deepseek.com",
-            timeout=TIMEOUT,  # 20 minutes
+            timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
@@ -89,7 +91,8 @@ def get_client_llm(
         client = openai.OpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],
             base_url="https://openrouter.ai/api/v1",
-            timeout=TIMEOUT,  # 20 minutes
+            timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
@@ -98,6 +101,7 @@ def get_client_llm(
             api_key=resolve_local_openai_api_key(resolved.api_key_env_name),
             base_url=resolved.base_url,
             timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
     elif provider == "headless":
         client = None
@@ -143,7 +147,7 @@ def get_async_client_llm(
                 client, mode=instructor.mode.Mode.ANTHROPIC_JSON
             )
     elif provider == "openai":
-        client = openai.AsyncOpenAI(timeout=TIMEOUT)
+        client = openai.AsyncOpenAI(timeout=TIMEOUT, max_retries=OPENAI_MAX_RETRIES)
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.TOOLS_STRICT)
     elif provider == "azure_openai":
@@ -152,6 +156,7 @@ def get_async_client_llm(
             api_version=os.getenv("AZURE_API_VERSION"),
             azure_endpoint=_build_azure_endpoint(),
             timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.TOOLS_STRICT)
@@ -160,6 +165,7 @@ def get_async_client_llm(
             api_key=os.environ["DEEPSEEK_API_KEY"],
             base_url="https://api.deepseek.com",
             timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
@@ -172,6 +178,7 @@ def get_async_client_llm(
             api_key=os.environ["OPENROUTER_API_KEY"],
             base_url="https://openrouter.ai/api/v1",
             timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
@@ -180,6 +187,7 @@ def get_async_client_llm(
             api_key=resolve_local_openai_api_key(resolved.api_key_env_name),
             base_url=resolved.base_url,
             timeout=TIMEOUT,
+            max_retries=OPENAI_MAX_RETRIES,
         )
     elif provider == "headless":
         client = None

--- a/shinka/llm/constants.py
+++ b/shinka/llm/constants.py
@@ -5,16 +5,19 @@ from shinka.env import load_shinka_dotenv
 load_shinka_dotenv()
 
 
-def _env_int(name: str, default: int) -> int:
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
     value = os.getenv(name)
     if value is None or value == "":
         return default
-    return int(value)
+    parsed = int(value)
+    if parsed < minimum:
+        raise ValueError(f"{name} must be >= {minimum}, got {parsed}")
+    return parsed
 
 
 TIMEOUT = _env_int("SHINKA_LLM_TIMEOUT", 1200)
 MAX_RETRIES = _env_int("SHINKA_LLM_MAX_RETRIES", 3)
-OPENAI_MAX_RETRIES = _env_int("SHINKA_OPENAI_MAX_RETRIES", 0)
+OPENAI_MAX_RETRIES = _env_int("SHINKA_OPENAI_MAX_RETRIES", 0, minimum=0)
 BACKOFF_MAX_TRIES = _env_int("SHINKA_LLM_BACKOFF_MAX_TRIES", 20)
 BACKOFF_MAX_VALUE = _env_int("SHINKA_LLM_BACKOFF_MAX_VALUE", 20)
 BACKOFF_MAX_TIME_MULTIPLIER = _env_int("SHINKA_LLM_BACKOFF_MAX_TIME_MULTIPLIER", 5)

--- a/shinka/llm/constants.py
+++ b/shinka/llm/constants.py
@@ -1,5 +1,24 @@
-TIMEOUT = 1200
-BACKOFF_MAX_TRIES = 20
-BACKOFF_MAX_VALUE = 20
-BACKOFF_MAX_TIME_MULTIPLIER = 5
-BACKOFF_MAX_TIME = TIMEOUT * BACKOFF_MAX_TIME_MULTIPLIER
+import os
+
+from shinka.env import load_shinka_dotenv
+
+load_shinka_dotenv()
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+TIMEOUT = _env_int("SHINKA_LLM_TIMEOUT", 1200)
+MAX_RETRIES = _env_int("SHINKA_LLM_MAX_RETRIES", 3)
+OPENAI_MAX_RETRIES = _env_int("SHINKA_OPENAI_MAX_RETRIES", 0)
+BACKOFF_MAX_TRIES = _env_int("SHINKA_LLM_BACKOFF_MAX_TRIES", 20)
+BACKOFF_MAX_VALUE = _env_int("SHINKA_LLM_BACKOFF_MAX_VALUE", 20)
+BACKOFF_MAX_TIME_MULTIPLIER = _env_int("SHINKA_LLM_BACKOFF_MAX_TIME_MULTIPLIER", 5)
+BACKOFF_MAX_TIME = _env_int(
+    "SHINKA_LLM_BACKOFF_MAX_TIME",
+    TIMEOUT * BACKOFF_MAX_TIME_MULTIPLIER,
+)

--- a/shinka/llm/llm.py
+++ b/shinka/llm/llm.py
@@ -10,8 +10,7 @@ from .query import query, query_async
 from .kwargs import sample_model_kwargs
 from .providers import QueryResult
 from .providers.model_resolver import resolve_model_backend
-
-MAX_RETRIES = 3
+from .constants import MAX_RETRIES
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_llm_client_backends.py
+++ b/tests/test_llm_client_backends.py
@@ -55,6 +55,7 @@ def test_get_async_client_llm_openai_sets_timeout(monkeypatch):
     assert provider == "openai"
     assert model_name == "gpt-5.4-mini"
     assert captured_kwargs["timeout"] == llm_client_module.TIMEOUT
+    assert captured_kwargs["max_retries"] == llm_client_module.OPENAI_MAX_RETRIES
 
 
 def test_get_client_llm_gemini_sets_timeout(monkeypatch):
@@ -120,6 +121,7 @@ def test_get_client_llm_local_openai_uses_api_key_env_query_param(monkeypatch):
     assert model_name == "dummy-model"
     assert str(client.base_url).startswith("https://api.example.test/v1")
     assert captured_kwargs["api_key"] == "test-custom-key"
+    assert captured_kwargs["max_retries"] == llm_client_module.OPENAI_MAX_RETRIES
 
 
 def test_get_async_client_llm_local_openai_missing_api_key_env_raises(monkeypatch):

--- a/tests/test_llm_retry_constants.py
+++ b/tests/test_llm_retry_constants.py
@@ -1,7 +1,13 @@
+import json
+import os
+import subprocess
+import sys
+
 from shinka.llm.constants import (
     BACKOFF_MAX_TIME,
     BACKOFF_MAX_TRIES,
     BACKOFF_MAX_VALUE,
+    OPENAI_MAX_RETRIES,
     TIMEOUT,
 )
 from shinka.llm.providers.anthropic import MAX_TIME as ANTHROPIC_MAX_TIME
@@ -44,3 +50,47 @@ def test_llm_backoff_retry_constants_are_shared():
     assert DEEPSEEK_MAX_VALUE == BACKOFF_MAX_VALUE
     assert ANTHROPIC_MAX_VALUE == BACKOFF_MAX_VALUE
     assert GEMINI_MAX_VALUE == BACKOFF_MAX_VALUE
+
+
+def test_llm_retry_env_overrides():
+    env = {
+        **os.environ,
+        "SHINKA_LLM_TIMEOUT": "7",
+        "SHINKA_LLM_MAX_RETRIES": "2",
+        "SHINKA_OPENAI_MAX_RETRIES": "1",
+        "SHINKA_LLM_BACKOFF_MAX_TRIES": "3",
+        "SHINKA_LLM_BACKOFF_MAX_VALUE": "4",
+        "SHINKA_LLM_BACKOFF_MAX_TIME": "5",
+    }
+    code = """
+import json
+from shinka.llm import constants as c
+print(json.dumps({
+    'timeout': c.TIMEOUT,
+    'max_retries': c.MAX_RETRIES,
+    'openai_max_retries': c.OPENAI_MAX_RETRIES,
+    'backoff_max_tries': c.BACKOFF_MAX_TRIES,
+    'backoff_max_value': c.BACKOFF_MAX_VALUE,
+    'backoff_max_time': c.BACKOFF_MAX_TIME,
+}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == {
+        "timeout": 7,
+        "max_retries": 2,
+        "openai_max_retries": 1,
+        "backoff_max_tries": 3,
+        "backoff_max_value": 4,
+        "backoff_max_time": 5,
+    }
+
+
+def test_openai_sdk_retries_default_to_single_shinka_retry_layer():
+    assert OPENAI_MAX_RETRIES == 0

--- a/tests/test_llm_retry_constants.py
+++ b/tests/test_llm_retry_constants.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 from shinka.llm.constants import (
     BACKOFF_MAX_TIME,
     BACKOFF_MAX_TRIES,
@@ -94,3 +96,44 @@ print(json.dumps({
 
 def test_openai_sdk_retries_default_to_single_shinka_retry_layer():
     assert OPENAI_MAX_RETRIES == 0
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "minimum"),
+    [
+        ("SHINKA_LLM_TIMEOUT", "0", 1),
+        ("SHINKA_LLM_MAX_RETRIES", "0", 1),
+        ("SHINKA_LLM_BACKOFF_MAX_TRIES", "0", 1),
+        ("SHINKA_LLM_BACKOFF_MAX_VALUE", "-1", 1),
+        ("SHINKA_LLM_BACKOFF_MAX_TIME_MULTIPLIER", "0", 1),
+        ("SHINKA_LLM_BACKOFF_MAX_TIME", "0", 1),
+        ("SHINKA_OPENAI_MAX_RETRIES", "-1", 0),
+    ],
+)
+def test_llm_retry_env_rejects_invalid_bounds(name: str, value: str, minimum: int):
+    env = {**os.environ, name: value}
+    result = subprocess.run(
+        [sys.executable, "-c", "import shinka.llm.constants"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert f"{name} must be >= {minimum}, got {value}" in result.stderr
+
+
+def test_openai_sdk_retries_allows_zero_override():
+    env = {**os.environ, "SHINKA_OPENAI_MAX_RETRIES": "0"}
+    code = (
+        "from shinka.llm.constants import OPENAI_MAX_RETRIES; print(OPENAI_MAX_RETRIES)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "0"

--- a/tests/test_llm_stall_timeout.py
+++ b/tests/test_llm_stall_timeout.py
@@ -1,0 +1,130 @@
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_stalled_local_openai_query_respects_configured_retry_bounds():
+    code = textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import asyncio
+        import http.server
+        import json
+        import socketserver
+        import threading
+        import time
+
+
+        class StallingHandler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def _stall(self) -> None:
+                self.server.request_count += 1
+                length = int(self.headers.get("Content-Length", 0) or 0)
+                if length:
+                    self.rfile.read(length)
+                while not getattr(self.server, "_shutting_down", False):
+                    time.sleep(0.05)
+
+            do_GET = _stall
+            do_POST = _stall
+
+            def log_message(self, *_args) -> None:
+                pass
+
+
+        class StallingServer(socketserver.ThreadingTCPServer):
+            allow_reuse_address = True
+            daemon_threads = True
+            request_count = 0
+
+
+        server = StallingServer(("127.0.0.1", 0), StallingHandler)
+        port = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+
+        from shinka.llm.client import get_async_client_llm
+        from shinka.llm.constants import (
+            BACKOFF_MAX_TIME,
+            BACKOFF_MAX_TRIES,
+            MAX_RETRIES,
+            OPENAI_MAX_RETRIES,
+            TIMEOUT,
+        )
+        from shinka.llm.providers.local_openai import query_local_openai_async
+
+
+        async def main() -> None:
+            client, model, provider = get_async_client_llm(
+                f"local/stalled@http://127.0.0.1:{port}/v1?api_key_env=CUSTOM_LOCAL_KEY"
+            )
+            started = time.monotonic()
+            try:
+                await query_local_openai_async(
+                    client,
+                    model,
+                    "hello",
+                    "system",
+                    [],
+                    None,
+                    max_tokens=1,
+                )
+                exception = None
+            except Exception as exc:
+                exception = type(exc).__name__
+            elapsed = time.monotonic() - started
+            server._shutting_down = True
+            server.shutdown()
+            print(
+                json.dumps(
+                    {
+                        "provider": provider,
+                        "elapsed": elapsed,
+                        "exception": exception,
+                        "request_count": server.request_count,
+                        "timeout": TIMEOUT,
+                        "max_retries": MAX_RETRIES,
+                        "openai_max_retries": OPENAI_MAX_RETRIES,
+                        "backoff_max_tries": BACKOFF_MAX_TRIES,
+                        "backoff_max_time": BACKOFF_MAX_TIME,
+                    },
+                    sort_keys=True,
+                )
+            )
+
+
+        asyncio.run(main())
+        """
+    )
+    env = {
+        **os.environ,
+        "CUSTOM_LOCAL_KEY": "test-local-key",
+        "SHINKA_LLM_TIMEOUT": "1",
+        "SHINKA_LLM_MAX_RETRIES": "1",
+        "SHINKA_OPENAI_MAX_RETRIES": "0",
+        "SHINKA_LLM_BACKOFF_MAX_TRIES": "1",
+        "SHINKA_LLM_BACKOFF_MAX_TIME": "1",
+        "PYTHONUNBUFFERED": "1",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    payload = json.loads(result.stdout.splitlines()[-1])
+
+    assert payload["provider"] == "local_openai"
+    assert payload["exception"] == "APITimeoutError"
+    assert payload["request_count"] == 1
+    assert payload["timeout"] == 1
+    assert payload["max_retries"] == 1
+    assert payload["openai_max_retries"] == 0
+    assert payload["backoff_max_tries"] == 1
+    assert payload["backoff_max_time"] == 1
+    assert payload["elapsed"] < 3


### PR DESCRIPTION
## Summary

- Expose environment overrides for LLM request timeout, Shinka retry count, OpenAI SDK retry count, and provider backoff budgets.
- Route OpenAI-compatible clients through `OPENAI_MAX_RETRIES`, defaulting to `0`, so SDK retries do not silently stack under Shinka's own retry/backoff layers.
- Add a local stalling OpenAI-compatible endpoint regression test that verifies configured retry bounds produce one request and a fast `APITimeoutError`.

## Motivation

This addresses the configurable timeout/retry-budget portion of #143. Today a stalled OpenAI-compatible endpoint can hold an evolution run because `TIMEOUT`, provider `backoff` budgets, and Shinka's outer LLM retry count are hard-coded, while OpenAI-compatible clients also keep SDK retries enabled by default.

This PR keeps the long default request timeout intact for normal science-generation workloads, but allows users and tests to bound stalled local/OpenAI-compatible providers explicitly.

## Validation

- `uvx ruff check --fix shinka/llm/constants.py shinka/llm/client.py shinka/llm/llm.py tests/test_llm_retry_constants.py tests/test_llm_client_backends.py tests/test_llm_stall_timeout.py`
- `uv run pytest tests/test_llm_client_backends.py tests/test_llm_retry_constants.py tests/test_llm_stall_timeout.py tests/test_headless_provider.py -q`
  - `24 passed`
- External wall-clock eval against a fake endpoint that accepts a request and never responds:
  - clean `main`: `60.0s` capped by the eval timeout
  - this patch: `2.210s`, `request_count=1`, no retry penalty

Note: I also tried full-repo `uvx ruff check --fix .`; current `main` has unrelated pre-existing lint failures in examples/plotting/test fixture files, so I kept the final lint run scoped to the files changed here.


## Autoresearch

Supplementary autoresearch: [20-step public dashboard](https://dashboard.weco.ai/share/VkBbyn4cd_AsWwa6ObmENCloa97rKc4P).