### PR TITLE
fix(launcher): clean up local evaluator descendants

### DIFF
--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -164,6 +164,7 @@ class AsyncRunningJob:
     completion_detected_at: Optional[float] = None
     discard_if_completed: bool = False
     evaluation_slot_released: bool = False
+    cleanup_cancel_attempted: bool = False
 
 
 @dataclass
@@ -5471,6 +5472,44 @@ class ShinkaEvolveRunner:
 
         logger.info("Meta summarizer task exited")
 
+    async def _cancel_running_jobs_for_cleanup(self) -> None:
+        """Cancel each evaluator still owned by the runner exactly once."""
+        surviving_jobs: List[AsyncRunningJob] = []
+        cancelled_count = 0
+
+        for job in list(self.running_jobs):
+            if job.cleanup_cancel_attempted:
+                surviving_jobs.append(job)
+                continue
+
+            job.cleanup_cancel_attempted = True
+            try:
+                cancelled = await self.scheduler.cancel_job_async(job.job_id)
+            except Exception as e:
+                logger.warning(
+                    f"Error cancelling active job {job.job_id} "
+                    f"(gen {job.generation}) during cleanup: {e}"
+                )
+                surviving_jobs.append(job)
+                continue
+
+            if cancelled:
+                self.submitted_jobs.pop(str(job.job_id), None)
+                await self._release_evaluation_slot_once(job)
+                cancelled_count += 1
+            else:
+                logger.warning(
+                    f"Failed to cancel active job {job.job_id} "
+                    f"(gen {job.generation}) during cleanup; keeping it tracked"
+                )
+                surviving_jobs.append(job)
+
+        self.running_jobs = surviving_jobs
+        if cancelled_count:
+            logger.info(
+                f"Cancelled {cancelled_count} active evaluation job(s) during cleanup"
+            )
+
     async def _cleanup_async(self):
         """Cleanup async resources."""
         try:
@@ -5484,6 +5523,8 @@ class ShinkaEvolveRunner:
                 await asyncio.gather(
                     *self.active_proposal_tasks.values(), return_exceptions=True
                 )
+
+            await self._cancel_running_jobs_for_cleanup()
 
             # Final recomputation of prompt percentiles to ensure fitness is accurate
             if self.prompt_db is not None and self.db is not None:

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -38,6 +38,7 @@ from shinka.llm import (
 )
 from shinka.embed import AsyncEmbeddingClient
 from shinka.launch import JobScheduler, JobConfig, LocalJobConfig
+from shinka.launch.scheduler import SchedulerSubmissionCleanupError
 from shinka.edit.async_apply import (
     apply_patch_async,
     get_code_embedding_async,
@@ -5152,6 +5153,24 @@ class ShinkaEvolveRunner:
             job_id = await asyncio.shield(submission_task)
         except asyncio.CancelledError:
             raise
+        except SchedulerSubmissionCleanupError as e:
+            getattr(self, "_pending_evaluation_submissions", {}).pop(
+                submission_task, None
+            )
+            if e.cleanup_succeeded:
+                await self.evaluation_slot_pool.release(evaluation_worker_id)
+                return
+            job_id = e.job_id
+            late_jobs = getattr(self, "_late_submission_jobs", None)
+            if late_jobs is None:
+                late_jobs = {}
+                self._late_submission_jobs = late_jobs
+            late_jobs[id(job_id)] = job_id
+            logger.error(
+                f"Scheduler shutdown cleanup did not finish for evaluation job "
+                f"{job_id}; retaining its evaluation slot"
+            )
+            return
         except Exception as e:
             logger.warning(f"Evaluation submission failed after cancellation: {e}")
             getattr(self, "_pending_evaluation_submissions", {}).pop(
@@ -5698,6 +5717,9 @@ class ShinkaEvolveRunner:
         """Cleanup async resources."""
         try:
             deadline = time.monotonic() + self._get_cleanup_retry_timeout()
+            begin_scheduler_shutdown = getattr(self.scheduler, "begin_shutdown", None)
+            if begin_scheduler_shutdown is not None:
+                begin_scheduler_shutdown()
 
             # Cancel remaining proposal tasks
             for task in self.active_proposal_tasks.values():
@@ -5741,9 +5763,6 @@ class ShinkaEvolveRunner:
                     timeout=max(0.0, deadline - time.monotonic()),
                 )
                 if pending:
-                    for task in pending:
-                        task.cancel()
-                    await asyncio.sleep(0)
                     late_job_ids = [
                         str(job_id)
                         for job_id in getattr(

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -77,6 +77,10 @@ from shinka.utils.languages import get_evolve_comment_prefix
 
 logger = logging.getLogger(__name__)
 
+_CLEANUP_RETRY_TIMEOUT_SECONDS = 10.0
+_CLEANUP_RETRY_INITIAL_DELAY_SECONDS = 0.05
+_CLEANUP_RETRY_MAX_DELAY_SECONDS = 1.0
+
 
 def _print_gradient_logo_and_mirror(
     log_path: Optional[Path] = None,
@@ -164,7 +168,6 @@ class AsyncRunningJob:
     completion_detected_at: Optional[float] = None
     discard_if_completed: bool = False
     evaluation_slot_released: bool = False
-    cleanup_cancel_attempted: bool = False
 
 
 @dataclass
@@ -536,6 +539,7 @@ class ShinkaEvolveRunner:
         self.proposal_queue = asyncio.Queue()
         self.active_proposal_tasks: Dict[str, asyncio.Task] = {}
         self._submission_cleanup_tasks: Set[asyncio.Task] = set()
+        self._late_submission_jobs: Dict[int, Union[str, Any]] = {}
 
         # Performance tracking
         self.total_proposals_generated = 0
@@ -5062,6 +5066,35 @@ class ShinkaEvolveRunner:
         tasks.add(task)
         task.add_done_callback(tasks.discard)
 
+    def _get_cleanup_retry_timeout(self) -> float:
+        return getattr(
+            self, "_cleanup_retry_timeout_seconds", _CLEANUP_RETRY_TIMEOUT_SECONDS
+        )
+
+    async def _try_cleanup_job(self, job_id: Any, results_dir: str) -> bool:
+        """Cancel a job, or confirm that it is terminal and reap it."""
+        try:
+            if await self.scheduler.cancel_job_async(job_id):
+                return True
+        except Exception as e:
+            logger.warning(f"Error cancelling evaluation job {job_id}: {e}")
+
+        try:
+            still_running = await self.scheduler.check_job_id_status_async(job_id)
+        except Exception as e:
+            logger.warning(f"Could not confirm state of evaluation job {job_id}: {e}")
+            return False
+
+        if still_running:
+            return False
+
+        try:
+            await self.scheduler.get_job_results_async(job_id, results_dir)
+        except Exception as e:
+            logger.warning(f"Could not reap terminal evaluation job {job_id}: {e}")
+            return False
+        return True
+
     async def _cleanup_late_evaluation_submission(
         self,
         submission_task: asyncio.Task,
@@ -5076,52 +5109,45 @@ class ShinkaEvolveRunner:
             await self.evaluation_slot_pool.release(evaluation_worker_id)
             return
 
-        retry_delay = 0.05
-        while True:
-            try:
-                cancelled = await self.scheduler.cancel_job_async(job_id)
-            except Exception as e:
-                logger.warning(
-                    "Error cancelling evaluation submitted after proposal "
-                    f"cancellation: {e}"
-                )
-            else:
-                if cancelled:
-                    await self.evaluation_slot_pool.release(evaluation_worker_id)
-                    return
+        late_jobs = getattr(self, "_late_submission_jobs", None)
+        if late_jobs is None:
+            late_jobs = {}
+            self._late_submission_jobs = late_jobs
+        late_job_key = id(job_id)
+        late_jobs[late_job_key] = job_id
 
-                try:
-                    still_running = await self.scheduler.check_job_id_status_async(
-                        job_id
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Could not confirm the state of an evaluation submitted "
-                        f"after proposal cancellation: {e}"
-                    )
-                else:
-                    if not still_running:
-                        try:
-                            await self.scheduler.get_job_results_async(
-                                job_id, results_dir
-                            )
-                        except Exception as e:
-                            logger.warning(
-                                "Could not reap an evaluation submitted after "
-                                f"proposal cancellation: {e}"
-                            )
-                        else:
-                            await self.evaluation_slot_pool.release(
-                                evaluation_worker_id
-                            )
-                            return
+        deadline = time.monotonic() + self._get_cleanup_retry_timeout()
+        retry_delay = _CLEANUP_RETRY_INITIAL_DELAY_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                cleaned = await asyncio.wait_for(
+                    self._try_cleanup_job(job_id, results_dir), timeout=remaining
+                )
+            except asyncio.TimeoutError:
+                break
+
+            if cleaned:
+                late_jobs.pop(late_job_key, None)
+                await self.evaluation_slot_pool.release(evaluation_worker_id)
+                return
 
             logger.warning(
                 "Evaluation submitted after proposal cancellation remains owned; "
                 "retrying cleanup"
             )
-            await asyncio.sleep(retry_delay)
-            retry_delay = min(1.0, retry_delay * 2)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(retry_delay, remaining))
+            retry_delay = min(_CLEANUP_RETRY_MAX_DELAY_SECONDS, retry_delay * 2)
+
+        logger.error(
+            f"Could not confirm cleanup of late evaluation job {job_id} before "
+            "the cleanup deadline; retaining its evaluation slot"
+        )
 
     async def _submit_evaluation_job_with_slot(
         self,
@@ -5556,41 +5582,52 @@ class ShinkaEvolveRunner:
         logger.info("Meta summarizer task exited")
 
     async def _cancel_running_jobs_for_cleanup(self) -> None:
-        """Cancel each evaluator still owned by the runner exactly once."""
-        surviving_jobs: List[AsyncRunningJob] = []
-        cancelled_count = 0
+        """Retry cleanup of active evaluators until success or a fixed deadline."""
+        pending_jobs = list(self.running_jobs)
+        cleaned_count = 0
+        deadline = time.monotonic() + self._get_cleanup_retry_timeout()
+        retry_delay = _CLEANUP_RETRY_INITIAL_DELAY_SECONDS
 
-        for job in list(self.running_jobs):
-            if job.cleanup_cancel_attempted:
-                surviving_jobs.append(job)
-                continue
+        while pending_jobs:
+            surviving_jobs: List[AsyncRunningJob] = []
+            for job in pending_jobs:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    surviving_jobs.append(job)
+                    continue
 
-            job.cleanup_cancel_attempted = True
-            try:
-                cancelled = await self.scheduler.cancel_job_async(job.job_id)
-            except Exception as e:
-                logger.warning(
-                    f"Error cancelling active job {job.job_id} "
-                    f"(gen {job.generation}) during cleanup: {e}"
-                )
-                surviving_jobs.append(job)
-                continue
+                try:
+                    cleaned = await asyncio.wait_for(
+                        self._try_cleanup_job(job.job_id, job.results_dir),
+                        timeout=remaining,
+                    )
+                except asyncio.TimeoutError:
+                    cleaned = False
 
-            if cancelled:
-                self.submitted_jobs.pop(str(job.job_id), None)
-                await self._release_evaluation_slot_once(job)
-                cancelled_count += 1
-            else:
-                logger.warning(
-                    f"Failed to cancel active job {job.job_id} "
-                    f"(gen {job.generation}) during cleanup; keeping it tracked"
-                )
-                surviving_jobs.append(job)
+                if cleaned:
+                    self.submitted_jobs.pop(str(job.job_id), None)
+                    await self._release_evaluation_slot_once(job)
+                    cleaned_count += 1
+                else:
+                    surviving_jobs.append(job)
 
-        self.running_jobs = surviving_jobs
-        if cancelled_count:
+            pending_jobs = surviving_jobs
+            remaining = deadline - time.monotonic()
+            if not pending_jobs or remaining <= 0:
+                break
+            await asyncio.sleep(min(retry_delay, remaining))
+            retry_delay = min(_CLEANUP_RETRY_MAX_DELAY_SECONDS, retry_delay * 2)
+
+        self.running_jobs = pending_jobs
+        for job in pending_jobs:
+            logger.error(
+                f"Could not confirm cleanup of active job {job.job_id} "
+                f"(gen {job.generation}) before the cleanup deadline; retaining "
+                "its evaluation slot"
+            )
+        if cleaned_count:
             logger.info(
-                f"Cancelled {cancelled_count} active evaluation job(s) during cleanup"
+                f"Cleaned up {cleaned_count} active evaluation job(s) during shutdown"
             )
 
     async def _cleanup_async(self):
@@ -5611,11 +5648,39 @@ class ShinkaEvolveRunner:
                 getattr(self, "_submission_cleanup_tasks", set())
             )
             if submission_cleanup_tasks:
-                await asyncio.gather(
-                    *submission_cleanup_tasks, return_exceptions=True
+                done, pending = await asyncio.wait(
+                    submission_cleanup_tasks,
+                    timeout=self._get_cleanup_retry_timeout(),
                 )
+                if pending:
+                    for task in pending:
+                        task.cancel()
+                    await asyncio.gather(*pending, return_exceptions=True)
+                    late_job_ids = [
+                        str(job_id)
+                        for job_id in getattr(
+                            self, "_late_submission_jobs", {}
+                        ).values()
+                    ]
+                    logger.error(
+                        "Timed out waiting for late-submission cleanup; surviving "
+                        f"job IDs: {late_job_ids or ['unknown (submission pending)']}"
+                    )
+                await asyncio.gather(*done, return_exceptions=True)
 
             await self._cancel_running_jobs_for_cleanup()
+
+            surviving_job_ids = [
+                str(job.job_id) for job in self.running_jobs
+            ] + [
+                str(job_id)
+                for job_id in getattr(self, "_late_submission_jobs", {}).values()
+            ]
+            if surviving_job_ids:
+                logger.error(
+                    "Evaluation jobs still owned after cleanup deadline: "
+                    f"{surviving_job_ids}"
+                )
 
             # Final recomputation of prompt percentiles to ensure fitness is accurate
             if self.prompt_db is not None and self.db is not None:

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -535,6 +535,7 @@ class ShinkaEvolveRunner:
         self.finalization_complete = asyncio.Event()
         self.proposal_queue = asyncio.Queue()
         self.active_proposal_tasks: Dict[str, asyncio.Task] = {}
+        self._submission_cleanup_tasks: Set[asyncio.Task] = set()
 
         # Performance tracking
         self.total_proposals_generated = 0
@@ -5052,6 +5053,76 @@ class ShinkaEvolveRunner:
         await self.evaluation_slot_pool.release(job.evaluation_worker_id)
         job.evaluation_slot_released = True
 
+    def _track_submission_cleanup_task(self, task: asyncio.Task) -> None:
+        """Keep late-submission cleanup owned by the runner until it finishes."""
+        tasks = getattr(self, "_submission_cleanup_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._submission_cleanup_tasks = tasks
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
+    async def _cleanup_late_evaluation_submission(
+        self,
+        submission_task: asyncio.Task,
+        results_dir: str,
+        evaluation_worker_id: int,
+    ) -> None:
+        """Drain a late submission and retain its slot until it is reaped."""
+        try:
+            job_id = await submission_task
+        except Exception as e:
+            logger.warning(f"Evaluation submission failed after cancellation: {e}")
+            await self.evaluation_slot_pool.release(evaluation_worker_id)
+            return
+
+        retry_delay = 0.05
+        while True:
+            try:
+                cancelled = await self.scheduler.cancel_job_async(job_id)
+            except Exception as e:
+                logger.warning(
+                    "Error cancelling evaluation submitted after proposal "
+                    f"cancellation: {e}"
+                )
+            else:
+                if cancelled:
+                    await self.evaluation_slot_pool.release(evaluation_worker_id)
+                    return
+
+                try:
+                    still_running = await self.scheduler.check_job_id_status_async(
+                        job_id
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Could not confirm the state of an evaluation submitted "
+                        f"after proposal cancellation: {e}"
+                    )
+                else:
+                    if not still_running:
+                        try:
+                            await self.scheduler.get_job_results_async(
+                                job_id, results_dir
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Could not reap an evaluation submitted after "
+                                f"proposal cancellation: {e}"
+                            )
+                        else:
+                            await self.evaluation_slot_pool.release(
+                                evaluation_worker_id
+                            )
+                            return
+
+            logger.warning(
+                "Evaluation submitted after proposal cancellation remains owned; "
+                "retrying cleanup"
+            )
+            await asyncio.sleep(retry_delay)
+            retry_delay = min(1.0, retry_delay * 2)
+
     async def _submit_evaluation_job_with_slot(
         self,
         exec_fname: str,
@@ -5063,10 +5134,22 @@ class ShinkaEvolveRunner:
             await self.sampling_slot_pool.release(sampling_worker_id)
 
         evaluation_worker_id = await self.evaluation_slot_pool.acquire()
+        submission_task = asyncio.create_task(
+            self.scheduler.submit_async_nonblocking(exec_fname, results_dir)
+        )
         try:
-            job_id = await self.scheduler.submit_async_nonblocking(
-                exec_fname, results_dir
+            job_id = await asyncio.shield(submission_task)
+        except asyncio.CancelledError:
+            cleanup_task = asyncio.create_task(
+                self._cleanup_late_evaluation_submission(
+                    submission_task,
+                    results_dir,
+                    evaluation_worker_id,
+                )
             )
+            self._track_submission_cleanup_task(cleanup_task)
+            await asyncio.shield(cleanup_task)
+            raise
         except Exception:
             await self.evaluation_slot_pool.release(evaluation_worker_id)
             raise
@@ -5522,6 +5605,14 @@ class ShinkaEvolveRunner:
             if self.active_proposal_tasks:
                 await asyncio.gather(
                     *self.active_proposal_tasks.values(), return_exceptions=True
+                )
+
+            submission_cleanup_tasks = list(
+                getattr(self, "_submission_cleanup_tasks", set())
+            )
+            if submission_cleanup_tasks:
+                await asyncio.gather(
+                    *submission_cleanup_tasks, return_exceptions=True
                 )
 
             await self._cancel_running_jobs_for_cleanup()

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -539,6 +539,12 @@ class ShinkaEvolveRunner:
         self.proposal_queue = asyncio.Queue()
         self.active_proposal_tasks: Dict[str, asyncio.Task] = {}
         self._submission_cleanup_tasks: Set[asyncio.Task] = set()
+        self._submission_cleanup_by_submission: Dict[
+            asyncio.Task, asyncio.Task
+        ] = {}
+        self._pending_evaluation_submissions: Dict[
+            asyncio.Task, Tuple[str, int]
+        ] = {}
         self._late_submission_jobs: Dict[int, Union[str, Any]] = {}
 
         # Performance tracking
@@ -5066,6 +5072,40 @@ class ShinkaEvolveRunner:
         tasks.add(task)
         task.add_done_callback(tasks.discard)
 
+    def _ensure_submission_cleanup_task(
+        self,
+        submission_task: asyncio.Task,
+        results_dir: str,
+        evaluation_worker_id: int,
+    ) -> asyncio.Task:
+        cleanup_by_submission = getattr(
+            self, "_submission_cleanup_by_submission", None
+        )
+        if cleanup_by_submission is None:
+            cleanup_by_submission = {}
+            self._submission_cleanup_by_submission = cleanup_by_submission
+
+        existing_task = cleanup_by_submission.get(submission_task)
+        if existing_task is not None:
+            return existing_task
+
+        cleanup_task = asyncio.create_task(
+            self._cleanup_late_evaluation_submission(
+                submission_task,
+                results_dir,
+                evaluation_worker_id,
+            )
+        )
+        cleanup_by_submission[submission_task] = cleanup_task
+        self._track_submission_cleanup_task(cleanup_task)
+
+        def clear_mapping(done_task: asyncio.Task) -> None:
+            if cleanup_by_submission.get(submission_task) is done_task:
+                cleanup_by_submission.pop(submission_task, None)
+
+        cleanup_task.add_done_callback(clear_mapping)
+        return cleanup_task
+
     def _get_cleanup_retry_timeout(self) -> float:
         return getattr(
             self, "_cleanup_retry_timeout_seconds", _CLEANUP_RETRY_TIMEOUT_SECONDS
@@ -5088,6 +5128,12 @@ class ShinkaEvolveRunner:
         if still_running:
             return False
 
+        if getattr(self.scheduler, "job_type", None) in [
+            "slurm_docker",
+            "slurm_conda",
+        ]:
+            return True
+
         try:
             await self.scheduler.get_job_results_async(job_id, results_dir)
         except Exception as e:
@@ -5103,11 +5149,20 @@ class ShinkaEvolveRunner:
     ) -> None:
         """Drain a late submission and retain its slot until it is reaped."""
         try:
-            job_id = await submission_task
+            job_id = await asyncio.shield(submission_task)
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.warning(f"Evaluation submission failed after cancellation: {e}")
+            getattr(self, "_pending_evaluation_submissions", {}).pop(
+                submission_task, None
+            )
             await self.evaluation_slot_pool.release(evaluation_worker_id)
             return
+
+        getattr(self, "_pending_evaluation_submissions", {}).pop(
+            submission_task, None
+        )
 
         late_jobs = getattr(self, "_late_submission_jobs", None)
         if late_jobs is None:
@@ -5163,22 +5218,28 @@ class ShinkaEvolveRunner:
         submission_task = asyncio.create_task(
             self.scheduler.submit_async_nonblocking(exec_fname, results_dir)
         )
+        pending_submissions = getattr(
+            self, "_pending_evaluation_submissions", None
+        )
+        if pending_submissions is None:
+            pending_submissions = {}
+            self._pending_evaluation_submissions = pending_submissions
+        pending_submissions[submission_task] = (results_dir, evaluation_worker_id)
         try:
             job_id = await asyncio.shield(submission_task)
         except asyncio.CancelledError:
-            cleanup_task = asyncio.create_task(
-                self._cleanup_late_evaluation_submission(
-                    submission_task,
-                    results_dir,
-                    evaluation_worker_id,
-                )
+            self._ensure_submission_cleanup_task(
+                submission_task,
+                results_dir,
+                evaluation_worker_id,
             )
-            self._track_submission_cleanup_task(cleanup_task)
-            await asyncio.shield(cleanup_task)
             raise
         except Exception:
+            pending_submissions.pop(submission_task, None)
             await self.evaluation_slot_pool.release(evaluation_worker_id)
             raise
+
+        pending_submissions.pop(submission_task, None)
 
         evaluation_submitted_at = time.time()
         evaluation_started_at = evaluation_submitted_at
@@ -5581,11 +5642,14 @@ class ShinkaEvolveRunner:
 
         logger.info("Meta summarizer task exited")
 
-    async def _cancel_running_jobs_for_cleanup(self) -> None:
+    async def _cancel_running_jobs_for_cleanup(
+        self, deadline: Optional[float] = None
+    ) -> None:
         """Retry cleanup of active evaluators until success or a fixed deadline."""
         pending_jobs = list(self.running_jobs)
         cleaned_count = 0
-        deadline = time.monotonic() + self._get_cleanup_retry_timeout()
+        if deadline is None:
+            deadline = time.monotonic() + self._get_cleanup_retry_timeout()
         retry_delay = _CLEANUP_RETRY_INITIAL_DELAY_SECONDS
 
         while pending_jobs:
@@ -5633,15 +5697,39 @@ class ShinkaEvolveRunner:
     async def _cleanup_async(self):
         """Cleanup async resources."""
         try:
+            deadline = time.monotonic() + self._get_cleanup_retry_timeout()
+
             # Cancel remaining proposal tasks
             for task in self.active_proposal_tasks.values():
                 if not task.done():
                     task.cancel()
 
-            # Wait for tasks to finish
+            # Drain proposal cancellation only within the shared cleanup budget.
             if self.active_proposal_tasks:
-                await asyncio.gather(
-                    *self.active_proposal_tasks.values(), return_exceptions=True
+                proposal_tasks = list(self.active_proposal_tasks.values())
+                done, pending = await asyncio.wait(
+                    proposal_tasks,
+                    timeout=max(0.0, deadline - time.monotonic()),
+                )
+                if done:
+                    await asyncio.gather(*done, return_exceptions=True)
+                if pending:
+                    logger.error(
+                        f"Proposal tasks still pending after cleanup deadline: "
+                        f"{len(pending)}"
+                    )
+
+            pending_submissions = getattr(
+                self, "_pending_evaluation_submissions", {}
+            )
+            for submission_task, (
+                results_dir,
+                evaluation_worker_id,
+            ) in list(pending_submissions.items()):
+                self._ensure_submission_cleanup_task(
+                    submission_task,
+                    results_dir,
+                    evaluation_worker_id,
                 )
 
             submission_cleanup_tasks = list(
@@ -5650,12 +5738,12 @@ class ShinkaEvolveRunner:
             if submission_cleanup_tasks:
                 done, pending = await asyncio.wait(
                     submission_cleanup_tasks,
-                    timeout=self._get_cleanup_retry_timeout(),
+                    timeout=max(0.0, deadline - time.monotonic()),
                 )
                 if pending:
                     for task in pending:
                         task.cancel()
-                    await asyncio.gather(*pending, return_exceptions=True)
+                    await asyncio.sleep(0)
                     late_job_ids = [
                         str(job_id)
                         for job_id in getattr(
@@ -5666,9 +5754,10 @@ class ShinkaEvolveRunner:
                         "Timed out waiting for late-submission cleanup; surviving "
                         f"job IDs: {late_job_ids or ['unknown (submission pending)']}"
                     )
-                await asyncio.gather(*done, return_exceptions=True)
+                if done:
+                    await asyncio.gather(*done, return_exceptions=True)
 
-            await self._cancel_running_jobs_for_cleanup()
+            await self._cancel_running_jobs_for_cleanup(deadline=deadline)
 
             surviving_job_ids = [
                 str(job.job_id) for job in self.running_jobs
@@ -5680,6 +5769,19 @@ class ShinkaEvolveRunner:
                 logger.error(
                     "Evaluation jobs still owned after cleanup deadline: "
                     f"{surviving_job_ids}"
+                )
+
+            pending_submission_slots = [
+                evaluation_worker_id
+                for _, evaluation_worker_id in getattr(
+                    self, "_pending_evaluation_submissions", {}
+                ).values()
+            ]
+            if pending_submission_slots:
+                logger.error(
+                    "Evaluation submissions still pending after cleanup deadline; "
+                    "job IDs are not yet available and evaluation slots remain "
+                    f"owned: {pending_submission_slots}"
                 )
 
             # Final recomputation of prompt percentiles to ensure fitness is accurate
@@ -5712,7 +5814,14 @@ class ShinkaEvolveRunner:
             await self.async_db.close_async()
 
             # Cleanup scheduler
-            self.scheduler.shutdown()
+            if surviving_job_ids or pending_submission_slots:
+                shutdown_nowait = getattr(self.scheduler, "shutdown_nowait", None)
+                if shutdown_nowait is not None:
+                    shutdown_nowait()
+                else:
+                    self.scheduler.shutdown()
+            else:
+                self.scheduler.shutdown()
 
         except Exception as e:
             logger.error(f"Error in async cleanup: {e}")

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -31,6 +31,19 @@ while True:
 logger = logging.getLogger(__name__)
 
 
+def _move_fd_above_standard_streams(fd: int) -> int:
+    """Return a close-on-exec duplicate whose descriptor is at least 3."""
+    if fd >= 3:
+        os.set_inheritable(fd, False)
+        return fd
+
+    import fcntl
+
+    moved_fd = fcntl.fcntl(fd, fcntl.F_DUPFD_CLOEXEC, 3)
+    os.close(fd)
+    return moved_fd
+
+
 class ProcessWithLogging:
     """Wrapper for subprocess.Popen with real-time logging capabilities."""
 
@@ -95,6 +108,9 @@ class ProcessWithLogging:
         self._completion_fd = None
         supervisor_returncode = self.process.poll()
         if supervisor_returncode is not None:
+            # Once the supervisor exits it no longer reserves the PGID. Do not
+            # retain an identifier that the kernel may subsequently reuse.
+            self._process_group = None
             self._returncode = supervisor_returncode
 
     def poll(self) -> Optional[int]:
@@ -110,6 +126,7 @@ class ProcessWithLogging:
         if supervisor_returncode is not None:
             self._read_completion()
             if self._returncode is None:
+                self._process_group = None
                 self._returncode = supervisor_returncode
         return self._returncode
 
@@ -147,6 +164,14 @@ class ProcessWithLogging:
             return
         self._signal_process_group(process_group, signal.SIGKILL)
 
+    def send_signal(self, sig: int) -> None:
+        """Signal the owned process group, or the direct child when ungrouped."""
+        process_group = self._process_group
+        if process_group is None:
+            self.process.send_signal(sig)
+            return
+        self._signal_process_group(process_group, sig)
+
     def terminate(self) -> None:
         """Terminate the process group on POSIX, or only the direct child elsewhere."""
         process_group = self._process_group
@@ -160,11 +185,14 @@ class ProcessWithLogging:
         if self._completion_fd is not None or self._returncode is not None:
             if self.process.poll() is None:
                 self.kill()
+            else:
+                self._process_group = None
             try:
                 self.process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
                 self.process.kill()
                 self.process.wait(timeout=5.0)
+            self._process_group = None
             if self._completion_fd is not None:
                 os.close(self._completion_fd)
                 self._completion_fd = None
@@ -238,8 +266,12 @@ def submit(
     completion_fd = None
     if os.name == "posix":
         completion_fd, completion_write_fd = os.pipe()
-        os.set_blocking(completion_fd, False)
         try:
+            completion_fd = _move_fd_above_standard_streams(completion_fd)
+            completion_write_fd = _move_fd_above_standard_streams(
+                completion_write_fd
+            )
+            os.set_blocking(completion_fd, False)
             process = subprocess.Popen(
                 [
                     sys.executable,

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -62,6 +62,7 @@ class ProcessWithLogging:
         self._completion_fd = completion_fd
         self._completion_buffer = b""
         self._returncode: Optional[int] = None
+        self._supervisor_exit_pending = False
 
     def __getattr__(self, name):
         """Delegate attribute access to the wrapped process."""
@@ -80,10 +81,9 @@ class ProcessWithLogging:
         """Return the evaluator's exit code rather than the supervisor's."""
         if self._returncode is not None:
             return self._returncode
-        if self._completion_fd is None:
+        if self._completion_fd is None and not self._supervisor_exit_pending:
             return self.process.returncode
-        self._read_completion()
-        return self._returncode
+        return self.poll()
 
     def _read_completion(self) -> None:
         """Read an evaluator exit code from the supervisor without blocking."""
@@ -106,13 +106,18 @@ class ProcessWithLogging:
 
         os.close(self._completion_fd)
         self._completion_fd = None
+        self._supervisor_exit_pending = True
         supervisor_returncode = self.process.poll()
         if supervisor_returncode is not None:
             self._handle_supervisor_exit(supervisor_returncode)
 
     def poll(self) -> Optional[int]:
         """Poll the evaluator while a supervisor keeps its process group alive."""
-        if self._completion_fd is None and self._returncode is None:
+        if (
+            self._completion_fd is None
+            and self._returncode is None
+            and not self._supervisor_exit_pending
+        ):
             return self.process.poll()
 
         self._read_completion()
@@ -128,7 +133,11 @@ class ProcessWithLogging:
 
     def wait(self, timeout: Optional[float] = None) -> int:
         """Wait for the evaluator, leaving its supervisor alive for cleanup."""
-        if self._completion_fd is None and self._returncode is None:
+        if (
+            self._completion_fd is None
+            and self._returncode is None
+            and not self._supervisor_exit_pending
+        ):
             return self.process.wait(timeout=timeout)
 
         deadline = None if timeout is None else time.monotonic() + timeout
@@ -163,6 +172,7 @@ class ProcessWithLogging:
             self._process_group = None
         if self._returncode is None:
             self._returncode = returncode
+        self._supervisor_exit_pending = False
 
     def kill(self) -> None:
         """Kill the process group on POSIX, or only the direct child elsewhere."""
@@ -190,17 +200,23 @@ class ProcessWithLogging:
 
     def cleanup_logging(self):
         """Clean up logging threads and files."""
-        if self._completion_fd is not None or self._returncode is not None:
+        if (
+            self._completion_fd is not None
+            or self._returncode is not None
+            or self._supervisor_exit_pending
+        ):
             supervisor_returncode = self.process.poll()
             if supervisor_returncode is None:
                 self.kill()
             else:
                 self._handle_supervisor_exit(supervisor_returncode)
             try:
-                self.process.wait(timeout=5.0)
+                supervisor_returncode = self.process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
                 self.process.kill()
-                self.process.wait(timeout=5.0)
+                supervisor_returncode = self.process.wait(timeout=5.0)
+            if self._supervisor_exit_pending:
+                self._handle_supervisor_exit(supervisor_returncode)
             self._process_group = None
             if self._completion_fd is not None:
                 os.close(self._completion_fd)

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -108,10 +108,7 @@ class ProcessWithLogging:
         self._completion_fd = None
         supervisor_returncode = self.process.poll()
         if supervisor_returncode is not None:
-            # Once the supervisor exits it no longer reserves the PGID. Do not
-            # retain an identifier that the kernel may subsequently reuse.
-            self._process_group = None
-            self._returncode = supervisor_returncode
+            self._handle_supervisor_exit(supervisor_returncode)
 
     def poll(self) -> Optional[int]:
         """Poll the evaluator while a supervisor keeps its process group alive."""
@@ -126,8 +123,7 @@ class ProcessWithLogging:
         if supervisor_returncode is not None:
             self._read_completion()
             if self._returncode is None:
-                self._process_group = None
-                self._returncode = supervisor_returncode
+                self._handle_supervisor_exit(supervisor_returncode)
         return self._returncode
 
     def wait(self, timeout: Optional[float] = None) -> int:
@@ -150,11 +146,23 @@ class ProcessWithLogging:
             os.killpg(process_group, sig)
         except ProcessLookupError:
             self._process_group = None
+        except PermissionError as e:
+            logger.error(f"Unable to signal process group {process_group}: {e}")
+            self._process_group = None
         else:
             # SIGTERM leaves the supervisor alive so callers can escalate. Once
             # SIGKILL releases it, never retain a PGID the kernel may reuse.
             if sig == signal.SIGKILL:
                 self._process_group = None
+
+    def _handle_supervisor_exit(self, returncode: int) -> None:
+        """Kill remaining group members before relinquishing a dead supervisor's PGID."""
+        process_group = self._process_group
+        if process_group is not None:
+            self._signal_process_group(process_group, signal.SIGKILL)
+            self._process_group = None
+        if self._returncode is None:
+            self._returncode = returncode
 
     def kill(self) -> None:
         """Kill the process group on POSIX, or only the direct child elsewhere."""
@@ -183,10 +191,11 @@ class ProcessWithLogging:
     def cleanup_logging(self):
         """Clean up logging threads and files."""
         if self._completion_fd is not None or self._returncode is not None:
-            if self.process.poll() is None:
+            supervisor_returncode = self.process.poll()
+            if supervisor_returncode is None:
                 self.kill()
             else:
-                self._process_group = None
+                self._handle_supervisor_exit(supervisor_returncode)
             try:
                 self.process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 import threading
 import os
+import signal
 from pathlib import Path
 from typing import Optional, Tuple, TextIO, Dict
 from shinka.utils import load_results, parse_time_to_seconds
@@ -18,10 +19,12 @@ class ProcessWithLogging:
         process: subprocess.Popen,
         log_files: Tuple[TextIO, TextIO],
         log_threads: Tuple[threading.Thread, threading.Thread],
+        process_group: Optional[int] = None,
     ):
         self.process = process
         self.log_files = log_files
         self.log_threads = log_threads
+        self._process_group = process_group
 
     def __getattr__(self, name):
         """Delegate attribute access to the wrapped process."""
@@ -34,6 +37,30 @@ class ProcessWithLogging:
     def __repr__(self):
         """Return a detailed string representation."""
         return f"ProcessWithLogging(PID: {self.process.pid}, returncode: {self.process.returncode})"
+
+    def _signal_process_group(self, process_group: int, sig: int) -> None:
+        if self.process.poll() is not None:
+            return
+        try:
+            os.killpg(process_group, sig)
+        except ProcessLookupError:
+            pass
+
+    def kill(self) -> None:
+        """Kill the process group on POSIX, or only the direct child elsewhere."""
+        process_group = self._process_group
+        if process_group is None:
+            self.process.kill()
+            return
+        self._signal_process_group(process_group, signal.SIGKILL)
+
+    def terminate(self) -> None:
+        """Terminate the process group on POSIX, or only the direct child elsewhere."""
+        process_group = self._process_group
+        if process_group is None:
+            self.process.terminate()
+            return
+        self._signal_process_group(process_group, signal.SIGTERM)
 
     def cleanup_logging(self):
         """Clean up logging threads and files."""
@@ -110,6 +137,7 @@ def submit(
         bufsize=1,  # Line buffered
         universal_newlines=True,
         env=env,
+        start_new_session=os.name == "posix",
     )
 
     # Open log files for writing with line buffering
@@ -133,7 +161,10 @@ def submit(
 
     # Create wrapper with logging capabilities
     wrapped_process = ProcessWithLogging(
-        process, (stdout_file, stderr_file), (stdout_thread, stderr_thread)
+        process,
+        (stdout_file, stderr_file),
+        (stdout_thread, stderr_thread),
+        process_group=process.pid if os.name == "posix" else None,
     )
 
     if verbose:

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -3,11 +3,31 @@ import time
 import threading
 import os
 import signal
+import sys
 from pathlib import Path
 from typing import Optional, Tuple, TextIO, Dict
 from shinka.utils import load_results, parse_time_to_seconds
 import logging
 
+_SUPERVISOR_CODE = """
+import os
+import signal
+import subprocess
+import sys
+
+def ignore_termination(_signum, _frame):
+    pass
+
+
+result_fd = int(sys.argv[1])
+signal.signal(signal.SIGTERM, ignore_termination)
+child = subprocess.Popen(sys.argv[2:])
+return_code = child.wait()
+os.write(result_fd, f"{return_code}\\n".encode("ascii"))
+os.close(result_fd)
+while True:
+    signal.pause()
+"""
 logger = logging.getLogger(__name__)
 
 
@@ -20,11 +40,15 @@ class ProcessWithLogging:
         log_files: Tuple[TextIO, TextIO],
         log_threads: Tuple[threading.Thread, threading.Thread],
         process_group: Optional[int] = None,
+        completion_fd: Optional[int] = None,
     ):
         self.process = process
         self.log_files = log_files
         self.log_threads = log_threads
         self._process_group = process_group
+        self._completion_fd = completion_fd
+        self._completion_buffer = b""
+        self._returncode: Optional[int] = None
 
     def __getattr__(self, name):
         """Delegate attribute access to the wrapped process."""
@@ -36,15 +60,84 @@ class ProcessWithLogging:
 
     def __repr__(self):
         """Return a detailed string representation."""
-        return f"ProcessWithLogging(PID: {self.process.pid}, returncode: {self.process.returncode})"
+        return f"ProcessWithLogging(PID: {self.process.pid}, returncode: {self.returncode})"
+
+    @property
+    def returncode(self) -> Optional[int]:
+        """Return the evaluator's exit code rather than the supervisor's."""
+        if self._returncode is not None:
+            return self._returncode
+        if self._completion_fd is None:
+            return self.process.returncode
+        self._read_completion()
+        return self._returncode
+
+    def _read_completion(self) -> None:
+        """Read an evaluator exit code from the supervisor without blocking."""
+        if self._completion_fd is None or self._returncode is not None:
+            return
+
+        try:
+            chunk = os.read(self._completion_fd, 64)
+        except BlockingIOError:
+            return
+
+        if chunk:
+            self._completion_buffer += chunk
+            if b"\n" in self._completion_buffer:
+                line, _, _ = self._completion_buffer.partition(b"\n")
+                self._returncode = int(line)
+                os.close(self._completion_fd)
+                self._completion_fd = None
+            return
+
+        os.close(self._completion_fd)
+        self._completion_fd = None
+        supervisor_returncode = self.process.poll()
+        if supervisor_returncode is not None:
+            self._returncode = supervisor_returncode
+
+    def poll(self) -> Optional[int]:
+        """Poll the evaluator while a supervisor keeps its process group alive."""
+        if self._completion_fd is None and self._returncode is None:
+            return self.process.poll()
+
+        self._read_completion()
+        if self._returncode is not None:
+            return self._returncode
+
+        supervisor_returncode = self.process.poll()
+        if supervisor_returncode is not None:
+            self._read_completion()
+            if self._returncode is None:
+                self._returncode = supervisor_returncode
+        return self._returncode
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        """Wait for the evaluator, leaving its supervisor alive for cleanup."""
+        if self._completion_fd is None and self._returncode is None:
+            return self.process.wait(timeout=timeout)
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            returncode = self.poll()
+            if returncode is not None:
+                return returncode
+            if deadline is not None and time.monotonic() >= deadline:
+                assert timeout is not None
+                raise subprocess.TimeoutExpired(self.process.args, timeout)
+            time.sleep(0.01)
 
     def _signal_process_group(self, process_group: int, sig: int) -> None:
-        if self.process.poll() is not None:
-            return
         try:
             os.killpg(process_group, sig)
         except ProcessLookupError:
-            pass
+            self._process_group = None
+        else:
+            # SIGTERM leaves the supervisor alive so callers can escalate. Once
+            # SIGKILL releases it, never retain a PGID the kernel may reuse.
+            if sig == signal.SIGKILL:
+                self._process_group = None
 
     def kill(self) -> None:
         """Kill the process group on POSIX, or only the direct child elsewhere."""
@@ -64,6 +157,18 @@ class ProcessWithLogging:
 
     def cleanup_logging(self):
         """Clean up logging threads and files."""
+        if self._completion_fd is not None or self._returncode is not None:
+            if self.process.poll() is None:
+                self.kill()
+            try:
+                self.process.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5.0)
+            if self._completion_fd is not None:
+                os.close(self._completion_fd)
+                self._completion_fd = None
+
         # Wait for logging threads to finish
         for thread in self.log_threads:
             thread.join(timeout=1.0)
@@ -128,17 +233,45 @@ def submit(
     if env_overrides:
         env.update(env_overrides)
 
-    # Use PIPE to capture output and redirect to files in real-time
-    process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        bufsize=1,  # Line buffered
-        universal_newlines=True,
-        env=env,
-        start_new_session=os.name == "posix",
-    )
+    # A live supervisor keeps the process group allocated after the evaluator
+    # exits, so descendants can still be signalled without risking PGID reuse.
+    completion_fd = None
+    if os.name == "posix":
+        completion_fd, completion_write_fd = os.pipe()
+        os.set_blocking(completion_fd, False)
+        try:
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    _SUPERVISOR_CODE,
+                    str(completion_write_fd),
+                    *cmd,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,  # Line buffered
+                universal_newlines=True,
+                env=env,
+                start_new_session=True,
+                pass_fds=(completion_write_fd,),
+            )
+        except Exception:
+            os.close(completion_fd)
+            raise
+        finally:
+            os.close(completion_write_fd)
+    else:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,  # Line buffered
+            universal_newlines=True,
+            env=env,
+        )
 
     # Open log files for writing with line buffering
     stdout_file = open(stdout_path, "w", buffering=1)
@@ -165,6 +298,7 @@ def submit(
         (stdout_file, stderr_file),
         (stdout_thread, stderr_thread),
         process_group=process.pid if os.name == "posix" else None,
+        completion_fd=completion_fd,
     )
 
     if verbose:

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 _SLURM_CANCEL_TIMEOUT_SECONDS = 5.0
 _SLURM_CANCEL_POLL_INTERVAL_SECONDS = 0.1
+_SLURM_COMMAND_TIMEOUT_SECONDS = 5.0
 
 
 def _has_value(value: Optional[str]) -> bool:
@@ -340,8 +341,6 @@ class JobScheduler:
     def check_job_id_status(self, job_id: Union[str, ProcessWithLogging]) -> bool:
         """Check whether a raw scheduler job ID is still running."""
         if self.job_type in ["slurm_docker", "slurm_conda"]:
-            from .slurm import get_job_status
-
             if isinstance(job_id, str):
                 return get_job_status(job_id) != ""
             return False
@@ -462,16 +461,21 @@ class JobScheduler:
                 if self.job_type in ["slurm_docker", "slurm_conda"]:
                     if isinstance(job_id, str):
                         # For SLURM jobs, use scancel command
+                        deadline = time.monotonic() + _SLURM_CANCEL_TIMEOUT_SECONDS
+                        remaining = deadline - time.monotonic()
                         result = subprocess.run(
-                            ["scancel", job_id], capture_output=True, text=True
+                            ["scancel", job_id],
+                            capture_output=True,
+                            text=True,
+                            timeout=max(
+                                0.001,
+                                min(_SLURM_COMMAND_TIMEOUT_SECONDS, remaining),
+                            ),
                         )
                         if result.returncode != 0:
                             return False
 
-                        deadline = time.monotonic() + _SLURM_CANCEL_TIMEOUT_SECONDS
                         while True:
-                            if get_job_status(job_id) == "":
-                                return True
                             remaining = deadline - time.monotonic()
                             if remaining <= 0:
                                 logger.warning(
@@ -479,6 +483,20 @@ class JobScheduler:
                                     "to leave the queue after scancel"
                                 )
                                 return False
+                            if (
+                                get_job_status(
+                                    job_id,
+                                    timeout=max(
+                                        0.001,
+                                        min(
+                                            _SLURM_COMMAND_TIMEOUT_SECONDS,
+                                            remaining,
+                                        ),
+                                    ),
+                                )
+                                == ""
+                            ):
+                                return True
                             time.sleep(
                                 min(_SLURM_CANCEL_POLL_INTERVAL_SECONDS, remaining)
                             )
@@ -506,3 +524,7 @@ class JobScheduler:
     def shutdown(self):
         """Shutdown the thread pool executor."""
         self.executor.shutdown(wait=True)
+
+    def shutdown_nowait(self):
+        """Stop accepting work without waiting for in-flight scheduler commands."""
+        self.executor.shutdown(wait=False, cancel_futures=True)

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from .local import submit as submit_local, monitor as monitor_local
 from .local import ProcessWithLogging
 from .slurm import (
+    get_job_status,
     submit_docker as submit_slurm_docker,
     submit_conda as submit_slurm_conda,
     monitor as monitor_slurm,
@@ -17,6 +18,9 @@ from .slurm import (
 from shinka.utils import parse_time_to_seconds
 
 logger = logging.getLogger(__name__)
+
+_SLURM_CANCEL_TIMEOUT_SECONDS = 5.0
+_SLURM_CANCEL_POLL_INTERVAL_SECONDS = 0.1
 
 
 def _has_value(value: Optional[str]) -> bool:
@@ -461,7 +465,23 @@ class JobScheduler:
                         result = subprocess.run(
                             ["scancel", job_id], capture_output=True, text=True
                         )
-                        return result.returncode == 0
+                        if result.returncode != 0:
+                            return False
+
+                        deadline = time.monotonic() + _SLURM_CANCEL_TIMEOUT_SECONDS
+                        while True:
+                            if get_job_status(job_id) == "":
+                                return True
+                            remaining = deadline - time.monotonic()
+                            if remaining <= 0:
+                                logger.warning(
+                                    f"Timed out waiting for Slurm job {job_id} "
+                                    "to leave the queue after scancel"
+                                )
+                                return False
+                            time.sleep(
+                                min(_SLURM_CANCEL_POLL_INTERVAL_SECONDS, remaining)
+                            )
                 else:
                     # For local jobs, kill the process
                     if isinstance(job_id, ProcessWithLogging):

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 import time
 import asyncio
 import shlex
@@ -446,8 +447,6 @@ class JobScheduler:
                 if self.job_type in ["slurm_docker", "slurm_conda"]:
                     if isinstance(job_id, str):
                         # For SLURM jobs, use scancel command
-                        import subprocess
-
                         result = subprocess.run(
                             ["scancel", job_id], capture_output=True, text=True
                         )
@@ -456,6 +455,15 @@ class JobScheduler:
                     # For local jobs, kill the process
                     if isinstance(job_id, ProcessWithLogging):
                         job_id.kill()
+                        try:
+                            job_id.wait(timeout=5.0)
+                        except subprocess.TimeoutExpired:
+                            logger.error(
+                                f"Timed out waiting for local job {job_id} "
+                                "to exit after cancellation"
+                            )
+                            return False
+                        job_id.cleanup_logging()
                         return True
                 return False
             except Exception as e:

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -333,60 +333,61 @@ class JobScheduler:
             )
         raise ValueError(f"Unknown job type: {self.job_type}")
 
-    def check_job_status(self, job) -> bool:
-        """Check if job is running. Returns True if running, False if done."""
+    def check_job_id_status(self, job_id: Union[str, ProcessWithLogging]) -> bool:
+        """Check whether a raw scheduler job ID is still running."""
         if self.job_type in ["slurm_docker", "slurm_conda"]:
             from .slurm import get_job_status
 
-            if isinstance(job.job_id, str):
-                status = get_job_status(job.job_id)
-                return status != ""
-            return False  # Should not happen with slurm
-        else:
-            if isinstance(job.job_id, ProcessWithLogging):
-                if (
-                    isinstance(self.config, LocalJobConfig)
-                    and self.config.time
-                    and job.start_time
-                ):
-                    timeout = parse_time_to_seconds(self.config.time)
-                    if time.time() - job.start_time > timeout:
-                        if self.verbose:
-                            logger.warning(
-                                f"Process {job.job_id.pid} exceeded "
-                                f"timeout of {self.config.time}. Killing. "
-                                f"=> Gen. {job.generation}"
-                            )
-                        job.job_id.kill()
-                        return False
-
-                # More robust status checking with exception handling
-                try:
-                    return job.job_id.poll() is None
-                except Exception as e:
-                    # If poll() fails, try alternative methods to determine if process is running
-                    logger.warning(f"poll() failed for PID {job.job_id.pid}: {e}")
-                    try:
-                        # Try using psutil as fallback if available
-                        import psutil
-
-                        return psutil.pid_exists(job.job_id.pid)
-                    except ImportError:
-                        # Fallback: check if PID exists using os.kill with signal 0
-                        try:
-                            import os
-
-                            os.kill(job.job_id.pid, 0)
-                            return True  # Process exists
-                        except (OSError, ProcessLookupError):
-                            return False  # Process doesn't exist
-                    except Exception as e2:
-                        logger.warning(
-                            f"All status check methods failed for PID {job.job_id.pid}: {e2}"
-                        )
-                        # If all methods fail, assume process is dead
-                        return False
+            if isinstance(job_id, str):
+                return get_job_status(job_id) != ""
             return False
+
+        if not isinstance(job_id, ProcessWithLogging):
+            return False
+
+        try:
+            return job_id.poll() is None
+        except Exception as e:
+            logger.warning(f"poll() failed for PID {job_id.pid}: {e}")
+            try:
+                import psutil
+
+                return psutil.pid_exists(job_id.pid)
+            except ImportError:
+                try:
+                    import os
+
+                    os.kill(job_id.pid, 0)
+                    return True
+                except (OSError, ProcessLookupError):
+                    return False
+            except Exception as e2:
+                logger.warning(
+                    f"All status check methods failed for PID {job_id.pid}: {e2}"
+                )
+                return False
+
+    def check_job_status(self, job) -> bool:
+        """Check if job is running. Returns True if running, False if done."""
+        if (
+            self.job_type == "local"
+            and isinstance(job.job_id, ProcessWithLogging)
+            and isinstance(self.config, LocalJobConfig)
+            and self.config.time
+            and job.start_time
+        ):
+            timeout = parse_time_to_seconds(self.config.time)
+            if time.time() - job.start_time > timeout:
+                if self.verbose:
+                    logger.warning(
+                        f"Process {job.job_id.pid} exceeded "
+                        f"timeout of {self.config.time}. Killing. "
+                        f"=> Gen. {job.generation}"
+                    )
+                job.job_id.kill()
+                return False
+
+        return self.check_job_id_status(job.job_id)
 
     def get_job_results(
         self, job_id: Union[str, ProcessWithLogging], results_dir: str
@@ -421,6 +422,16 @@ class JobScheduler:
         loop = asyncio.get_event_loop()
 
         return await loop.run_in_executor(self.executor, self.check_job_status, job)
+
+    async def check_job_id_status_async(
+        self, job_id: Union[str, ProcessWithLogging]
+    ) -> bool:
+        """Async version of raw scheduler job-ID status checking."""
+        loop = asyncio.get_event_loop()
+
+        return await loop.run_in_executor(
+            self.executor, self.check_job_id_status, job_id
+        )
 
     async def get_job_results_async(
         self, job_id: Union[str, ProcessWithLogging], results_dir: str

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -4,6 +4,7 @@ import time
 import asyncio
 import shlex
 import sys
+import threading
 from dataclasses import dataclass, asdict, field
 from typing import Optional, Dict, Any, Tuple, Union, List
 from concurrent.futures import ThreadPoolExecutor
@@ -22,6 +23,25 @@ logger = logging.getLogger(__name__)
 _SLURM_CANCEL_TIMEOUT_SECONDS = 5.0
 _SLURM_CANCEL_POLL_INTERVAL_SECONDS = 0.1
 _SLURM_COMMAND_TIMEOUT_SECONDS = 5.0
+_SHUTDOWN_CLEANUP_RETRY_TIMEOUT_SECONDS = 10.0
+_SHUTDOWN_CLEANUP_RETRY_INITIAL_DELAY_SECONDS = 0.05
+_SHUTDOWN_CLEANUP_RETRY_MAX_DELAY_SECONDS = 1.0
+
+
+class SchedulerSubmissionCleanupError(RuntimeError):
+    """Report whether a scheduler-owned shutdown cleanup reached a terminal state."""
+
+    def __init__(
+        self,
+        token: object,
+        job_id: Union[str, ProcessWithLogging],
+        cleanup_succeeded: bool,
+    ):
+        self.token = token
+        self.job_id = job_id
+        self.cleanup_succeeded = cleanup_succeeded
+        state = "completed" if cleanup_succeeded else "remains owned"
+        super().__init__(f"Evaluation submission cleanup {state} during shutdown")
 
 
 def _has_value(value: Optional[str]) -> bool:
@@ -142,6 +162,13 @@ class JobScheduler:
         self.config = config
         self.verbose = verbose
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._submission_lock = threading.Lock()
+        self._shutdown_requested = False
+        self._unclaimed_submissions: Dict[
+            object, Union[str, ProcessWithLogging]
+        ] = {}
+        self._shutdown_submissions: Dict[object, Union[str, ProcessWithLogging]] = {}
+        self._shutdown_cleanup_futures: Dict[object, Any] = {}
         if self.job_type == "slurm_env":
             self.job_type = "slurm_conda"
 
@@ -410,15 +437,104 @@ class JobScheduler:
                 )
         return None
 
+    def _cleanup_unclaimed_submission(
+        self, token: object, job_id: Union[str, ProcessWithLogging]
+    ) -> bool:
+        """Retry cleanup of a submitted job that shutdown claimed before the runner."""
+        deadline = time.monotonic() + getattr(
+            self,
+            "_shutdown_cleanup_retry_timeout_seconds",
+            _SHUTDOWN_CLEANUP_RETRY_TIMEOUT_SECONDS,
+        )
+        retry_delay = _SHUTDOWN_CLEANUP_RETRY_INITIAL_DELAY_SECONDS
+        while True:
+            if self._cancel_job_sync(job_id):
+                with self._submission_lock:
+                    self._shutdown_submissions.pop(token, None)
+                return True
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.error(
+                    f"Could not clean up evaluation job {job_id} submitted during "
+                    "scheduler shutdown; retaining ownership"
+                )
+                return False
+            time.sleep(min(retry_delay, remaining))
+            retry_delay = min(
+                _SHUTDOWN_CLEANUP_RETRY_MAX_DELAY_SECONDS, retry_delay * 2
+            )
+
+    def _submit_tracked(
+        self,
+        token: object,
+        exec_fname_t: str,
+        results_dir_t: str,
+    ) -> Union[str, ProcessWithLogging]:
+        """Submit while retaining ownership until the event loop claims the job."""
+        with self._submission_lock:
+            if self._shutdown_requested:
+                raise RuntimeError("Scheduler shutdown has started")
+
+        job_id = self.submit_async(exec_fname_t, results_dir_t)
+        with self._submission_lock:
+            if self._shutdown_requested:
+                self._shutdown_submissions[token] = job_id
+                cleanup_here = True
+            else:
+                self._unclaimed_submissions[token] = job_id
+                cleanup_here = False
+
+        if cleanup_here:
+            cleaned = self._cleanup_unclaimed_submission(token, job_id)
+            raise SchedulerSubmissionCleanupError(token, job_id, cleaned)
+        return job_id
+
     async def submit_async_nonblocking(
         self, exec_fname_t: str, results_dir_t: str
     ) -> Union[str, ProcessWithLogging]:
         """Submit a job asynchronously without blocking the event loop."""
         loop = asyncio.get_event_loop()
-
-        return await loop.run_in_executor(
-            self.executor, self.submit_async, exec_fname_t, results_dir_t
+        token = object()
+        job_id = await loop.run_in_executor(
+            self.executor,
+            self._submit_tracked,
+            token,
+            exec_fname_t,
+            results_dir_t,
         )
+
+        with self._submission_lock:
+            if token in self._unclaimed_submissions:
+                self._unclaimed_submissions.pop(token)
+                return job_id
+            shutdown_job = self._shutdown_submissions.get(token)
+            cleanup_future = self._shutdown_cleanup_futures.get(token)
+
+        if shutdown_job is None:
+            raise RuntimeError("Evaluation submission was lost during scheduler shutdown")
+
+        if cleanup_future is None:
+            raise SchedulerSubmissionCleanupError(token, shutdown_job, False)
+
+        cleaned = await asyncio.wrap_future(cleanup_future)
+        with self._submission_lock:
+            self._shutdown_cleanup_futures.pop(token, None)
+        raise SchedulerSubmissionCleanupError(token, shutdown_job, cleaned)
+
+    def begin_shutdown(self) -> None:
+        """Stop submission handoffs and asynchronously clean jobs not yet claimed."""
+        with self._submission_lock:
+            if self._shutdown_requested:
+                return
+            self._shutdown_requested = True
+            unclaimed_jobs = list(self._unclaimed_submissions.items())
+            self._unclaimed_submissions.clear()
+            self._shutdown_submissions.update(unclaimed_jobs)
+            for token, job_id in unclaimed_jobs:
+                self._shutdown_cleanup_futures[token] = self.executor.submit(
+                    self._cleanup_unclaimed_submission, token, job_id
+                )
 
     async def check_job_status_async(self, job) -> bool:
         """Async version of job status checking."""
@@ -451,80 +567,82 @@ class JobScheduler:
         tasks = [self.check_job_status_async(job) for job in jobs]
         return await asyncio.gather(*tasks, return_exceptions=True)
 
+    def _cancel_job_sync(self, job_id: Union[str, ProcessWithLogging]) -> bool:
+        """Cancel a running job from a scheduler worker."""
+        try:
+            if self.job_type in ["slurm_docker", "slurm_conda"]:
+                if isinstance(job_id, str):
+                    # For SLURM jobs, use scancel command
+                    deadline = time.monotonic() + _SLURM_CANCEL_TIMEOUT_SECONDS
+                    remaining = deadline - time.monotonic()
+                    result = subprocess.run(
+                        ["scancel", job_id],
+                        capture_output=True,
+                        text=True,
+                        timeout=max(
+                            0.001,
+                            min(_SLURM_COMMAND_TIMEOUT_SECONDS, remaining),
+                        ),
+                    )
+                    if result.returncode != 0:
+                        return False
+
+                    while True:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            logger.warning(
+                                f"Timed out waiting for Slurm job {job_id} "
+                                "to leave the queue after scancel"
+                            )
+                            return False
+                        if (
+                            get_job_status(
+                                job_id,
+                                timeout=max(
+                                    0.001,
+                                    min(
+                                        _SLURM_COMMAND_TIMEOUT_SECONDS,
+                                        remaining,
+                                    ),
+                                ),
+                            )
+                            == ""
+                        ):
+                            return True
+                        time.sleep(
+                            min(_SLURM_CANCEL_POLL_INTERVAL_SECONDS, remaining)
+                        )
+            else:
+                # For local jobs, kill the process
+                if isinstance(job_id, ProcessWithLogging):
+                    job_id.kill()
+                    try:
+                        job_id.wait(timeout=5.0)
+                    except subprocess.TimeoutExpired:
+                        logger.error(
+                            f"Timed out waiting for local job {job_id} "
+                            "to exit after cancellation"
+                        )
+                        return False
+                    job_id.cleanup_logging()
+                    return True
+            return False
+        except Exception as e:
+            logger.error(f"Error cancelling job {job_id}: {e}")
+            return False
+
     async def cancel_job_async(self, job_id: Union[str, ProcessWithLogging]) -> bool:
         """Cancel a running job asynchronously."""
         loop = asyncio.get_event_loop()
 
-        def cancel_job():
-            """Cancel job in thread executor."""
-            try:
-                if self.job_type in ["slurm_docker", "slurm_conda"]:
-                    if isinstance(job_id, str):
-                        # For SLURM jobs, use scancel command
-                        deadline = time.monotonic() + _SLURM_CANCEL_TIMEOUT_SECONDS
-                        remaining = deadline - time.monotonic()
-                        result = subprocess.run(
-                            ["scancel", job_id],
-                            capture_output=True,
-                            text=True,
-                            timeout=max(
-                                0.001,
-                                min(_SLURM_COMMAND_TIMEOUT_SECONDS, remaining),
-                            ),
-                        )
-                        if result.returncode != 0:
-                            return False
-
-                        while True:
-                            remaining = deadline - time.monotonic()
-                            if remaining <= 0:
-                                logger.warning(
-                                    f"Timed out waiting for Slurm job {job_id} "
-                                    "to leave the queue after scancel"
-                                )
-                                return False
-                            if (
-                                get_job_status(
-                                    job_id,
-                                    timeout=max(
-                                        0.001,
-                                        min(
-                                            _SLURM_COMMAND_TIMEOUT_SECONDS,
-                                            remaining,
-                                        ),
-                                    ),
-                                )
-                                == ""
-                            ):
-                                return True
-                            time.sleep(
-                                min(_SLURM_CANCEL_POLL_INTERVAL_SECONDS, remaining)
-                            )
-                else:
-                    # For local jobs, kill the process
-                    if isinstance(job_id, ProcessWithLogging):
-                        job_id.kill()
-                        try:
-                            job_id.wait(timeout=5.0)
-                        except subprocess.TimeoutExpired:
-                            logger.error(
-                                f"Timed out waiting for local job {job_id} "
-                                "to exit after cancellation"
-                            )
-                            return False
-                        job_id.cleanup_logging()
-                        return True
-                return False
-            except Exception as e:
-                logger.error(f"Error cancelling job {job_id}: {e}")
-                return False
-
-        return await loop.run_in_executor(self.executor, cancel_job)
+        return await loop.run_in_executor(self.executor, self._cancel_job_sync, job_id)
 
     def shutdown(self):
         """Shutdown the thread pool executor."""
+        self.begin_shutdown()
         self.executor.shutdown(wait=True)
 
     def shutdown_nowait(self):
         """Stop accepting work without waiting for in-flight scheduler commands."""
-        self.executor.shutdown(wait=False, cancel_futures=True)
+        self.begin_shutdown()
+        self.executor.shutdown(wait=False, cancel_futures=False)

--- a/shinka/launch/slurm.py
+++ b/shinka/launch/slurm.py
@@ -12,6 +12,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_SLURM_COMMAND_TIMEOUT_SECONDS = 5.0
+
 
 def _render_env_exports(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as newline-joined ``export K=V`` lines for a script."""
@@ -496,7 +498,7 @@ def submit_local_conda(
     return job_id
 
 
-def get_job_status(job_id: str) -> Optional[str]:
+def get_job_status(job_id: str, timeout: Optional[float] = None) -> Optional[str]:
     """Get status for Slurm or local jobs."""
     if job_id.startswith("local-"):
         job = LOCAL_JOBS.get(job_id)
@@ -507,14 +509,20 @@ def get_job_status(job_id: str) -> Optional[str]:
             return job_id
         return ""
     try:
+        command_timeout = (
+            _SLURM_COMMAND_TIMEOUT_SECONDS if timeout is None else timeout
+        )
+        if command_timeout <= 0:
+            return None
         result = subprocess.run(
             ["squeue", "-j", str(job_id), "--noheader"],
             capture_output=True,
             text=True,
             check=True,
+            timeout=command_timeout,
         )
         return result.stdout.strip()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
         return None
 
 

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1348,6 +1348,75 @@ def test_cancel_surplus_inflight_work_cancels_backlog_once_target_hit():
     asyncio.run(_run())
 
 
+def test_cleanup_cancels_active_jobs_before_scheduler_shutdown(caplog):
+    async def _run():
+        events = []
+
+        class _CleanupScheduler:
+            async def cancel_job_async(self, job_id):
+                events.append(f"cancel:{job_id}")
+                return job_id == "job-cancelled"
+
+            def shutdown(self):
+                events.append("scheduler.shutdown")
+
+        class _CleanupAsyncDB(_FakeAsyncDB):
+            async def close_async(self):
+                events.append("db.close")
+
+        now = time.time()
+        cancelled_job = AsyncRunningJob(
+            job_id="job-cancelled",
+            exec_fname="program_1.py",
+            results_dir="results_1",
+            start_time=now,
+            proposal_started_at=now,
+            evaluation_submitted_at=now,
+            generation=51,
+            evaluation_worker_id=3,
+        )
+        failed_job = AsyncRunningJob(
+            job_id="job-failed",
+            exec_fname="program_2.py",
+            results_dir="results_2",
+            start_time=now,
+            proposal_started_at=now,
+            evaluation_submitted_at=now,
+            generation=52,
+            evaluation_worker_id=4,
+        )
+        evaluation_slot_pool = _FakeSlotPool()
+        runner = _build_runner(
+            async_db=_CleanupAsyncDB(total_programs=0),
+            scheduler=_CleanupScheduler(),
+            running_jobs=[cancelled_job, failed_job],
+            submitted_jobs={
+                "job-cancelled": cancelled_job,
+                "job-failed": failed_job,
+            },
+            evaluation_slot_pool=evaluation_slot_pool,
+        )
+
+        await runner._cleanup_async()
+        await runner._cancel_running_jobs_for_cleanup()
+
+        assert events == [
+            "cancel:job-cancelled",
+            "cancel:job-failed",
+            "db.close",
+            "scheduler.shutdown",
+        ]
+        assert runner.running_jobs == [failed_job]
+        assert runner.submitted_jobs == {"job-failed": failed_job}
+        assert evaluation_slot_pool.released == [3]
+        assert cancelled_job.evaluation_slot_released is True
+        assert failed_job.evaluation_slot_released is False
+
+    asyncio.run(_run())
+
+    assert "Failed to cancel active job job-failed" in caplog.text
+
+
 def test_process_single_job_skips_persistence_for_discarded_surplus_job():
     async def _run():
         async_db = _FakeAsyncDBWithGuard()

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -16,7 +16,7 @@ from shinka.core.async_runner import (
 )
 from shinka.core.runtime_slots import LogicalSlotPool
 from shinka.launch import scheduler as scheduler_module
-from shinka.launch.scheduler import JobScheduler, SlurmCondaJobConfig
+from shinka.launch.scheduler import JobScheduler, LocalJobConfig, SlurmCondaJobConfig
 
 
 class _FakeAsyncDB:
@@ -2059,6 +2059,122 @@ def test_cleanup_bounds_submission_that_never_returns(
 
     assert "job IDs are not yet available" in caplog.text
     assert "evaluation slots remain owned:" in caplog.text
+
+
+def test_cleanup_cancels_submission_that_finishes_after_shutdown(monkeypatch):
+    async def _run():
+        submission_started = threading.Event()
+        allow_submission = threading.Event()
+        cancellation_finished = threading.Event()
+        cancelled_job_ids = []
+
+        scheduler = JobScheduler("local", LocalJobConfig(), max_workers=1)
+
+        def delayed_submit(exec_fname, results_dir):
+            assert exec_fname == "program.py"
+            assert results_dir == "results"
+            submission_started.set()
+            assert allow_submission.wait(timeout=1.0)
+            return "late-job"
+
+        def cancel_job(job_id):
+            cancelled_job_ids.append(job_id)
+            cancellation_finished.set()
+            return True
+
+        monkeypatch.setattr(scheduler, "submit_async", delayed_submit)
+        monkeypatch.setattr(scheduler, "_cancel_job_sync", cancel_job)
+
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+        )
+        runner._cleanup_retry_timeout_seconds = 0.02
+        proposal_task = asyncio.create_task(
+            runner._submit_evaluation_job_with_slot(
+                exec_fname="program.py",
+                results_dir="results",
+                sampling_worker_id=None,
+            )
+        )
+        runner.active_proposal_tasks = {"proposal": proposal_task}
+
+        assert await asyncio.to_thread(submission_started.wait, 0.2)
+        await asyncio.wait_for(runner._cleanup_async(), timeout=0.2)
+        assert proposal_task.cancelled()
+        assert cancelled_job_ids == []
+        assert evaluation_slots.in_use == 1
+
+        # The scheduler owns the in-flight submission after cleanup returns.
+        allow_submission.set()
+        assert await asyncio.to_thread(cancellation_finished.wait, 0.5)
+
+        submission_tasks = list(runner._pending_evaluation_submissions)
+        await asyncio.gather(*submission_tasks, return_exceptions=True)
+        cleanup_tasks = list(runner._submission_cleanup_tasks)
+        await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+
+        assert cancelled_job_ids == ["late-job"]
+        assert runner._pending_evaluation_submissions == {}
+        assert evaluation_slots.in_use == 0
+
+    asyncio.run(_run())
+
+
+def test_cleanup_retains_late_job_when_scheduler_shutdown_cleanup_fails(monkeypatch):
+    async def _run():
+        submission_started = threading.Event()
+        allow_submission = threading.Event()
+        cleanup_attempts = []
+
+        scheduler = JobScheduler("local", LocalJobConfig(), max_workers=1)
+
+        def delayed_submit(exec_fname, results_dir):
+            assert exec_fname == "program.py"
+            assert results_dir == "results"
+            submission_started.set()
+            assert allow_submission.wait(timeout=1.0)
+            return "late-job"
+
+        def failed_cleanup(job_id):
+            cleanup_attempts.append(job_id)
+            return False
+
+        monkeypatch.setattr(scheduler, "submit_async", delayed_submit)
+        monkeypatch.setattr(scheduler, "_cancel_job_sync", failed_cleanup)
+
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+        )
+        runner._cleanup_retry_timeout_seconds = 0.02
+        scheduler._shutdown_cleanup_retry_timeout_seconds = 0.02
+        proposal_task = asyncio.create_task(
+            runner._submit_evaluation_job_with_slot(
+                exec_fname="program.py",
+                results_dir="results",
+                sampling_worker_id=None,
+            )
+        )
+        runner.active_proposal_tasks = {"proposal": proposal_task}
+
+        assert await asyncio.to_thread(submission_started.wait, 0.2)
+        await asyncio.wait_for(runner._cleanup_async(), timeout=0.2)
+        assert proposal_task.cancelled()
+        assert evaluation_slots.in_use == 1
+
+        allow_submission.set()
+        cleanup_task = next(iter(runner._submission_cleanup_tasks))
+        await asyncio.wait_for(asyncio.shield(cleanup_task), timeout=0.5)
+
+        assert cleanup_attempts
+        assert evaluation_slots.in_use == 1
+        assert list(runner._late_submission_jobs.values()) == ["late-job"]
+        assert list(scheduler._shutdown_submissions.values()) == ["late-job"]
+
+    asyncio.run(_run())
 
 
 def test_terminal_slurm_cleanup_does_not_enter_monitor():

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -14,6 +15,8 @@ from shinka.core.async_runner import (
     ShinkaEvolveRunner,
 )
 from shinka.core.runtime_slots import LogicalSlotPool
+from shinka.launch import scheduler as scheduler_module
+from shinka.launch.scheduler import JobScheduler, SlurmCondaJobConfig
 
 
 class _FakeAsyncDB:
@@ -1696,9 +1699,15 @@ def test_cancelled_executor_submission_reaps_late_job_and_releases_slot():
         assert await loop.run_in_executor(None, scheduler.started.wait, 5)
 
         submission.cancel()
-        scheduler.allow_submit.set()
         with pytest.raises(asyncio.CancelledError):
-            await submission
+            await asyncio.wait_for(submission, timeout=0.2)
+
+        assert evaluation_slots.in_use == 1
+        assert len(runner._submission_cleanup_tasks) == 1
+
+        scheduler.allow_submit.set()
+        cleanup_task = next(iter(runner._submission_cleanup_tasks))
+        await asyncio.wait_for(asyncio.shield(cleanup_task), timeout=0.5)
 
         assert scheduler.cancelled_job_ids == [scheduler.job_id]
         assert evaluation_slots.in_use == 0
@@ -1757,15 +1766,14 @@ def test_repeated_cancellation_keeps_late_submission_owned_until_reaped():
         assert await loop.run_in_executor(None, scheduler.started.wait, 5)
 
         submission.cancel()
-        scheduler.allow_submit.set()
-        await asyncio.wait_for(scheduler.first_cancel.wait(), timeout=0.2)
-        submission.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await submission
+            await asyncio.wait_for(submission, timeout=0.2)
 
         assert evaluation_slots.in_use == 1
         assert len(runner._submission_cleanup_tasks) == 1
 
+        scheduler.allow_submit.set()
+        await asyncio.wait_for(scheduler.first_cancel.wait(), timeout=0.2)
         scheduler.allow_cancel.set()
         cleanup_task = next(iter(runner._submission_cleanup_tasks))
         await asyncio.wait_for(asyncio.shield(cleanup_task), timeout=0.5)
@@ -1821,9 +1829,14 @@ def test_cancelled_submission_reaps_job_that_finished_before_cancel():
         await asyncio.wait_for(scheduler.started.wait(), timeout=0.2)
 
         submission.cancel()
-        scheduler.allow_submit.set()
         with pytest.raises(asyncio.CancelledError):
-            await submission
+            await asyncio.wait_for(submission, timeout=0.2)
+
+        assert evaluation_slots.in_use == 1
+
+        scheduler.allow_submit.set()
+        cleanup_task = next(iter(runner._submission_cleanup_tasks))
+        await asyncio.wait_for(asyncio.shield(cleanup_task), timeout=0.5)
 
         assert scheduler.reaped_job_ids == [(scheduler.job_id, "results")]
         assert evaluation_slots.in_use == 0
@@ -1980,3 +1993,170 @@ def test_cleanup_bounds_permanently_failing_late_submission(
 
     assert "surviving job IDs: ['late-job']" in caplog.text
     assert "Evaluation jobs still owned after cleanup deadline: ['late-job']" in caplog.text
+
+
+def test_cleanup_bounds_submission_that_never_returns(
+    caplog: pytest.LogCaptureFixture,
+):
+    async def _run():
+        events = []
+
+        class _NeverReturningScheduler:
+            def __init__(self):
+                self.started = asyncio.Event()
+                self.wait_forever = asyncio.Event()
+
+            async def submit_async_nonblocking(self, exec_fname, results_dir):
+                self.started.set()
+                await self.wait_forever.wait()
+                raise AssertionError("submission unexpectedly resumed")
+
+            def shutdown(self):
+                events.append("scheduler.shutdown")
+
+        class _ClosingAsyncDB(_FakeAsyncDB):
+            async def close_async(self):
+                events.append("db.close")
+
+        scheduler = _NeverReturningScheduler()
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        runner = _build_runner(
+            async_db=_ClosingAsyncDB(total_programs=0),
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+        )
+        runner._cleanup_retry_timeout_seconds = 0.02
+        proposal_task = asyncio.create_task(
+            runner._submit_evaluation_job_with_slot(
+                exec_fname="program.py",
+                results_dir="results",
+                sampling_worker_id=None,
+            )
+        )
+        runner.active_proposal_tasks = {"proposal": proposal_task}
+        await asyncio.wait_for(scheduler.started.wait(), timeout=0.2)
+
+        start = time.monotonic()
+        await asyncio.wait_for(runner._cleanup_async(), timeout=0.2)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.2
+        assert proposal_task.cancelled()
+        assert events == ["db.close", "scheduler.shutdown"]
+        assert evaluation_slots.in_use == 1
+        pending_submissions = list(
+            runner._pending_evaluation_submissions.values()
+        )
+        assert len(pending_submissions) == 1
+        assert pending_submissions[0][0] == "results"
+        assert pending_submissions[0][1] is not None
+
+        pending_submission = next(iter(runner._pending_evaluation_submissions))
+        pending_submission.cancel()
+        await asyncio.gather(pending_submission, return_exceptions=True)
+
+    asyncio.run(_run())
+
+    assert "job IDs are not yet available" in caplog.text
+    assert "evaluation slots remain owned:" in caplog.text
+
+
+def test_terminal_slurm_cleanup_does_not_enter_monitor():
+    async def _run():
+        class _TerminalSlurmScheduler:
+            job_type = "slurm_conda"
+
+            async def cancel_job_async(self, job_id):
+                return False
+
+            async def check_job_id_status_async(self, job_id):
+                return False
+
+            async def get_job_results_async(self, job_id, results_dir):
+                raise AssertionError("cleanup must not enter monitor_slurm")
+
+        runner = _build_runner(scheduler=_TerminalSlurmScheduler())
+
+        assert await runner._try_cleanup_job("terminal-job", "results") is True
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    ("failed_command", "raises_error"),
+    [("scancel", False), ("squeue", False), ("squeue", True)],
+    ids=["blocked-scancel", "blocked-squeue", "erroring-squeue"],
+)
+def test_cleanup_deadline_bounds_blocked_slurm_command(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failed_command: str,
+    raises_error: bool,
+):
+    async def _run():
+        release_command = threading.Event()
+        command_started = threading.Event()
+        events = []
+
+        def run(command, *args, **kwargs):
+            if command[0] == failed_command and not release_command.is_set():
+                command_started.set()
+                if raises_error:
+                    raise subprocess.CalledProcessError(1, command)
+                if not release_command.wait(timeout=0.5):
+                    raise TimeoutError("test command was not released")
+            stdout = (
+                ""
+                if command[0] == "squeue" and release_command.is_set()
+                else "RUNNING"
+            )
+            return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(scheduler_module.subprocess, "run", run)
+
+        class _ClosingAsyncDB(_FakeAsyncDB):
+            async def close_async(self):
+                events.append("db.close")
+
+        scheduler = JobScheduler("slurm_conda", SlurmCondaJobConfig())
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        worker_id = await evaluation_slots.acquire()
+        now = time.time()
+        job = AsyncRunningJob(
+            job_id="blocked-job",
+            exec_fname="program.py",
+            results_dir="results",
+            start_time=now,
+            proposal_started_at=now,
+            evaluation_submitted_at=now,
+            generation=3,
+            evaluation_worker_id=worker_id,
+        )
+        runner = _build_runner(
+            async_db=_ClosingAsyncDB(total_programs=0),
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+            running_jobs=[job],
+            submitted_jobs={"blocked-job": job},
+        )
+        runner._cleanup_retry_timeout_seconds = 0.03
+
+        try:
+            start = time.monotonic()
+            await asyncio.wait_for(runner._cleanup_async(), timeout=0.2)
+            elapsed = time.monotonic() - start
+
+            assert elapsed < 0.2
+            assert command_started.is_set()
+            assert events == ["db.close"]
+            assert scheduler.executor._shutdown is True
+            assert evaluation_slots.in_use == 1
+            assert runner.running_jobs == [job]
+        finally:
+            release_command.set()
+            scheduler.shutdown()
+
+    asyncio.run(_run())
+
+    assert "active job blocked-job" in caplog.text
+    assert "Evaluation jobs still owned after cleanup deadline: ['blocked-job']" in caplog.text

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -1650,5 +1651,181 @@ def test_job_monitor_processes_completed_jobs_inline():
         runner.should_stop.set()
         allow_finish.set()
         await asyncio.wait_for(monitor_task, timeout=0.2)
+
+    asyncio.run(_run())
+
+
+def test_cancelled_executor_submission_reaps_late_job_and_releases_slot():
+    async def _run():
+        class _LateSubmissionScheduler:
+            def __init__(self):
+                self.started = threading.Event()
+                self.allow_submit = threading.Event()
+                self.job_id = object()
+                self.cancelled_job_ids = []
+
+            async def submit_async_nonblocking(self, exec_fname, results_dir):
+                def submit():
+                    self.started.set()
+                    if not self.allow_submit.wait(timeout=5):
+                        raise TimeoutError("test submission was not released")
+                    return self.job_id
+
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(None, submit)
+
+            async def cancel_job_async(self, job_id):
+                self.cancelled_job_ids.append(job_id)
+                return True
+
+        scheduler = _LateSubmissionScheduler()
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+        )
+
+        submission = asyncio.create_task(
+            runner._submit_evaluation_job_with_slot(
+                exec_fname="program.py",
+                results_dir="results",
+                sampling_worker_id=None,
+            )
+        )
+        loop = asyncio.get_running_loop()
+        assert await loop.run_in_executor(None, scheduler.started.wait, 5)
+
+        submission.cancel()
+        scheduler.allow_submit.set()
+        with pytest.raises(asyncio.CancelledError):
+            await submission
+
+        assert scheduler.cancelled_job_ids == [scheduler.job_id]
+        assert evaluation_slots.in_use == 0
+
+    asyncio.run(_run())
+
+
+def test_repeated_cancellation_keeps_late_submission_owned_until_reaped():
+    async def _run():
+        class _RetryingCancellationScheduler:
+            def __init__(self):
+                self.started = threading.Event()
+                self.allow_submit = threading.Event()
+                self.first_cancel = asyncio.Event()
+                self.allow_cancel = asyncio.Event()
+                self.job_id = object()
+                self.cancel_attempts = 0
+
+            async def submit_async_nonblocking(self, exec_fname, results_dir):
+                def submit():
+                    self.started.set()
+                    if not self.allow_submit.wait(timeout=5):
+                        raise TimeoutError("test submission was not released")
+                    return self.job_id
+
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(None, submit)
+
+            async def cancel_job_async(self, job_id):
+                assert job_id is self.job_id
+                self.cancel_attempts += 1
+                if self.cancel_attempts == 1:
+                    self.first_cancel.set()
+                    return False
+                return self.allow_cancel.is_set()
+
+            async def check_job_id_status_async(self, job_id):
+                assert job_id is self.job_id
+                return True
+
+        scheduler = _RetryingCancellationScheduler()
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+        )
+
+        submission = asyncio.create_task(
+            runner._submit_evaluation_job_with_slot(
+                exec_fname="program.py",
+                results_dir="results",
+                sampling_worker_id=None,
+            )
+        )
+        loop = asyncio.get_running_loop()
+        assert await loop.run_in_executor(None, scheduler.started.wait, 5)
+
+        submission.cancel()
+        scheduler.allow_submit.set()
+        await asyncio.wait_for(scheduler.first_cancel.wait(), timeout=0.2)
+        submission.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await submission
+
+        assert evaluation_slots.in_use == 1
+        assert len(runner._submission_cleanup_tasks) == 1
+
+        scheduler.allow_cancel.set()
+        cleanup_task = next(iter(runner._submission_cleanup_tasks))
+        await asyncio.wait_for(asyncio.shield(cleanup_task), timeout=0.5)
+
+        assert scheduler.cancel_attempts >= 2
+        assert evaluation_slots.in_use == 0
+        assert runner._submission_cleanup_tasks == set()
+
+    asyncio.run(_run())
+
+
+def test_cancelled_submission_reaps_job_that_finished_before_cancel():
+    async def _run():
+        class _CompletedLateScheduler:
+            def __init__(self):
+                self.started = asyncio.Event()
+                self.allow_submit = asyncio.Event()
+                self.job_id = object()
+                self.reaped_job_ids = []
+
+            async def submit_async_nonblocking(self, exec_fname, results_dir):
+                self.started.set()
+                await self.allow_submit.wait()
+                return self.job_id
+
+            async def cancel_job_async(self, job_id):
+                assert job_id is self.job_id
+                return False
+
+            async def check_job_id_status_async(self, job_id):
+                assert job_id is self.job_id
+                return False
+
+            async def get_job_results_async(self, job_id, results_dir):
+                assert job_id is self.job_id
+                self.reaped_job_ids.append((job_id, results_dir))
+                return {}
+
+        scheduler = _CompletedLateScheduler()
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+        )
+
+        submission = asyncio.create_task(
+            runner._submit_evaluation_job_with_slot(
+                exec_fname="program.py",
+                results_dir="results",
+                sampling_worker_id=None,
+            )
+        )
+        await asyncio.wait_for(scheduler.started.wait(), timeout=0.2)
+
+        submission.cancel()
+        scheduler.allow_submit.set()
+        with pytest.raises(asyncio.CancelledError):
+            await submission
+
+        assert scheduler.reaped_job_ids == [(scheduler.job_id, "results")]
+        assert evaluation_slots.in_use == 0
 
     asyncio.run(_run())

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1358,6 +1358,9 @@ def test_cleanup_cancels_active_jobs_before_scheduler_shutdown(caplog):
                 events.append(f"cancel:{job_id}")
                 return job_id == "job-cancelled"
 
+            async def check_job_id_status_async(self, job_id):
+                return job_id == "job-failed"
+
             def shutdown(self):
                 events.append("scheduler.shutdown")
 
@@ -1397,16 +1400,13 @@ def test_cleanup_cancels_active_jobs_before_scheduler_shutdown(caplog):
             },
             evaluation_slot_pool=evaluation_slot_pool,
         )
+        runner._cleanup_retry_timeout_seconds = 0.02
 
         await runner._cleanup_async()
-        await runner._cancel_running_jobs_for_cleanup()
 
-        assert events == [
-            "cancel:job-cancelled",
-            "cancel:job-failed",
-            "db.close",
-            "scheduler.shutdown",
-        ]
+        assert events[0] == "cancel:job-cancelled"
+        assert events.count("cancel:job-failed") >= 1
+        assert events[-2:] == ["db.close", "scheduler.shutdown"]
         assert runner.running_jobs == [failed_job]
         assert runner.submitted_jobs == {"job-failed": failed_job}
         assert evaluation_slot_pool.released == [3]
@@ -1415,7 +1415,7 @@ def test_cleanup_cancels_active_jobs_before_scheduler_shutdown(caplog):
 
     asyncio.run(_run())
 
-    assert "Failed to cancel active job job-failed" in caplog.text
+    assert "Could not confirm cleanup of active job job-failed" in caplog.text
 
 
 def test_process_single_job_skips_persistence_for_discarded_surplus_job():
@@ -1829,3 +1829,154 @@ def test_cancelled_submission_reaps_job_that_finished_before_cancel():
         assert evaluation_slots.in_use == 0
 
     asyncio.run(_run())
+
+
+def test_cleanup_keeps_slot_until_cancellation_is_confirmed():
+    async def _run():
+        class _DelayedCancellationScheduler:
+            def __init__(self):
+                self.cancel_started = asyncio.Event()
+                self.termination_confirmed = asyncio.Event()
+
+            async def cancel_job_async(self, job_id):
+                assert job_id == "delayed-job"
+                self.cancel_started.set()
+                await self.termination_confirmed.wait()
+                return True
+
+        scheduler = _DelayedCancellationScheduler()
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        worker_id = await evaluation_slots.acquire()
+        now = time.time()
+        job = AsyncRunningJob(
+            job_id="delayed-job",
+            exec_fname="program.py",
+            results_dir="results",
+            start_time=now,
+            proposal_started_at=now,
+            evaluation_submitted_at=now,
+            generation=1,
+            evaluation_worker_id=worker_id,
+        )
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+            running_jobs=[job],
+            submitted_jobs={"delayed-job": job},
+        )
+        runner._cleanup_retry_timeout_seconds = 0.5
+
+        cleanup_task = asyncio.create_task(
+            runner._cancel_running_jobs_for_cleanup()
+        )
+        await asyncio.wait_for(scheduler.cancel_started.wait(), timeout=0.2)
+
+        assert evaluation_slots.in_use == 1
+        assert job.evaluation_slot_released is False
+
+        scheduler.termination_confirmed.set()
+        await asyncio.wait_for(cleanup_task, timeout=0.2)
+
+        assert evaluation_slots.in_use == 0
+        assert job.evaluation_slot_released is True
+
+    asyncio.run(_run())
+
+
+def test_cleanup_retries_transient_active_job_cancellation():
+    async def _run():
+        class _TransientCancellationScheduler:
+            def __init__(self):
+                self.cancel_attempts = 0
+
+            async def cancel_job_async(self, job_id):
+                assert job_id == "transient-job"
+                self.cancel_attempts += 1
+                return self.cancel_attempts >= 2
+
+            async def check_job_id_status_async(self, job_id):
+                assert job_id == "transient-job"
+                return True
+
+        scheduler = _TransientCancellationScheduler()
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        worker_id = await evaluation_slots.acquire()
+        now = time.time()
+        job = AsyncRunningJob(
+            job_id="transient-job",
+            exec_fname="program.py",
+            results_dir="results",
+            start_time=now,
+            proposal_started_at=now,
+            evaluation_submitted_at=now,
+            generation=2,
+            evaluation_worker_id=worker_id,
+        )
+        runner = _build_runner(
+            scheduler=scheduler,
+            evaluation_slot_pool=evaluation_slots,
+            running_jobs=[job],
+            submitted_jobs={"transient-job": job},
+        )
+        runner._cleanup_retry_timeout_seconds = 0.2
+
+        await runner._cancel_running_jobs_for_cleanup()
+
+        assert scheduler.cancel_attempts == 2
+        assert runner.running_jobs == []
+        assert runner.submitted_jobs == {}
+        assert evaluation_slots.in_use == 0
+
+    asyncio.run(_run())
+
+
+def test_cleanup_bounds_permanently_failing_late_submission(
+    caplog: pytest.LogCaptureFixture,
+):
+    async def _run():
+        events = []
+
+        class _PermanentFailureScheduler:
+            async def cancel_job_async(self, job_id):
+                raise RuntimeError("scheduler unavailable")
+
+            async def check_job_id_status_async(self, job_id):
+                raise RuntimeError("status unavailable")
+
+            def shutdown(self):
+                events.append("scheduler.shutdown")
+
+        class _ClosingAsyncDB(_FakeAsyncDB):
+            async def close_async(self):
+                events.append("db.close")
+
+        evaluation_slots = LogicalSlotPool(1, "evaluation")
+        worker_id = await evaluation_slots.acquire()
+        runner = _build_runner(
+            async_db=_ClosingAsyncDB(total_programs=0),
+            scheduler=_PermanentFailureScheduler(),
+            evaluation_slot_pool=evaluation_slots,
+        )
+        runner._cleanup_retry_timeout_seconds = 0.02
+        submission_task = asyncio.create_task(
+            asyncio.sleep(0, result="late-job")
+        )
+        cleanup_task = asyncio.create_task(
+            runner._cleanup_late_evaluation_submission(
+                submission_task,
+                "results",
+                worker_id,
+            )
+        )
+        runner._track_submission_cleanup_task(cleanup_task)
+
+        await asyncio.wait_for(runner._cleanup_async(), timeout=0.2)
+
+        assert events == ["db.close", "scheduler.shutdown"]
+        assert evaluation_slots.in_use == 1
+        assert list(runner._late_submission_jobs.values()) == ["late-job"]
+
+    asyncio.run(_run())
+
+    assert "surviving job IDs: ['late-job']" in caplog.text
+    assert "Evaluation jobs still owned after cleanup deadline: ['late-job']" in caplog.text

--- a/tests/test_local_process_cleanup.py
+++ b/tests/test_local_process_cleanup.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import threading
+import time
+from typing import Iterator, TextIO, cast
+from unittest.mock import Mock
+
+import psutil
+import pytest
+
+from shinka.launch import local
+from shinka.launch.scheduler import JobScheduler, LocalJobConfig
+
+_GRANDCHILD_CODE = """
+import os
+from pathlib import Path
+import signal
+import sys
+
+Path(sys.argv[1]).write_text(str(os.getpid()), encoding="ascii")
+signal.pause()
+"""
+
+_CHILD_CODE = """
+import subprocess
+import sys
+
+grandchild = subprocess.Popen(
+    [sys.executable, "-c", sys.argv[2], sys.argv[1]],
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+grandchild.wait()
+"""
+
+
+class _ExpiredClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def time(self) -> float:
+        self.now += 2.0
+        return self.now
+
+    def sleep(self, _seconds: float) -> None:
+        raise AssertionError("timeout should be detected before sleeping")
+
+
+def _wait_for_ready_pid(path: Path, process: local.ProcessWithLogging) -> int:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            return int(path.read_text(encoding="ascii"))
+        except (FileNotFoundError, ValueError):
+            if process.poll() is not None:
+                raise AssertionError("child exited before its grandchild was ready")
+            time.sleep(0.01)
+    raise AssertionError("grandchild did not signal readiness")
+
+
+def _wait_for_process_exit(pid: int) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            process = psutil.Process(pid)
+            if not process.is_running() or process.status() == psutil.STATUS_ZOMBIE:
+                return
+        except psutil.NoSuchProcess:
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"descendant process {pid} is still running")
+
+
+@pytest.fixture
+def process_tree(
+    tmp_path: Path,
+) -> Iterator[tuple[local.ProcessWithLogging, int, Path]]:
+    if os.name != "posix":
+        pytest.skip("POSIX process groups are required")
+
+    log_dir = tmp_path / "logs"
+    ready_path = tmp_path / "grandchild.ready"
+    process = local.submit(
+        str(log_dir),
+        [sys.executable, "-c", _CHILD_CODE, str(ready_path), _GRANDCHILD_CODE],
+    )
+    grandchild_pid = _wait_for_ready_pid(ready_path, process)
+
+    try:
+        yield process, grandchild_pid, log_dir
+    finally:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            os.kill(grandchild_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        if process.poll() is None:
+            process.process.kill()
+        process.wait(timeout=5)
+        process.cleanup_logging()
+
+
+def test_direct_child_signals_delegate_to_popen() -> None:
+    process_mock = Mock(spec=subprocess.Popen)
+    process = local.ProcessWithLogging(
+        cast(subprocess.Popen[str], process_mock),
+        cast(tuple[TextIO, TextIO], (Mock(), Mock())),
+        cast(tuple[threading.Thread, threading.Thread], (Mock(), Mock())),
+    )
+
+    process.kill()
+    process.terminate()
+
+    process_mock.kill.assert_called_once_with()
+    process_mock.terminate.assert_called_once_with()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
+def test_completed_process_ignores_repeated_group_signals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = local.submit(str(tmp_path), [sys.executable, "-c", "pass"])
+    process.wait(timeout=5)
+    process.cleanup_logging()
+    group_signals: list[tuple[int, int]] = []
+
+    def record_group_signal(process_group: int, sig: int) -> None:
+        group_signals.append((process_group, sig))
+
+    monkeypatch.setattr(local.os, "killpg", record_group_signal)
+
+    process.kill()
+    process.terminate()
+    process.kill()
+
+    assert group_signals == []
+
+
+def test_scheduler_cancellation_reaps_process_tree(
+    process_tree: tuple[local.ProcessWithLogging, int, Path],
+) -> None:
+    process, grandchild_pid, _log_dir = process_tree
+    scheduler = JobScheduler("local", LocalJobConfig())
+
+    try:
+        cancelled = asyncio.run(scheduler.cancel_job_async(process))
+    finally:
+        scheduler.shutdown()
+
+    assert cancelled is True
+    assert process.returncode is not None
+    assert all(not thread.is_alive() for thread in process.log_threads)
+    assert all(file_handle.closed for file_handle in process.log_files)
+    _wait_for_process_exit(grandchild_pid)
+
+
+def test_timeout_kills_descendant_processes(
+    process_tree: tuple[local.ProcessWithLogging, int, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process, grandchild_pid, log_dir = process_tree
+    assert os.getpgid(process.pid) == process.pid
+    monkeypatch.setattr(local, "time", _ExpiredClock())
+
+    local.monitor(
+        process,
+        str(log_dir),
+        poll_interval=0,
+        timeout="00:00:01",
+    )
+
+    process.wait(timeout=5)
+    _wait_for_process_exit(grandchild_pid)
+
+
+def test_terminate_cancellation_kills_descendant_processes(
+    process_tree: tuple[local.ProcessWithLogging, int, Path],
+) -> None:
+    process, grandchild_pid, _log_dir = process_tree
+    assert os.getpgid(process.pid) == process.pid
+
+    process.terminate()
+
+    process.wait(timeout=5)
+    process.cleanup_logging()
+    _wait_for_process_exit(grandchild_pid)

--- a/tests/test_local_process_cleanup.py
+++ b/tests/test_local_process_cleanup.py
@@ -127,11 +127,11 @@ def process_tree(
     finally:
         try:
             os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             pass
         try:
             os.kill(grandchild_pid, signal.SIGKILL)
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             pass
         if process.poll() is None:
             process.process.kill()
@@ -252,7 +252,7 @@ def test_group_signal_reaps_descendant_after_leader_exits(tmp_path: Path) -> Non
     finally:
         try:
             os.killpg(process.pid, signal.SIGKILL)
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             pass
         process.cleanup_logging()
 
@@ -344,6 +344,7 @@ def test_abnormal_supervisor_exit_relinquishes_process_group(
     )
     evaluator_pid = _wait_for_ready_pid(ready_path, process)
     group_signals: list[tuple[int, int]] = []
+    killpg = os.killpg
 
     try:
         process.process.kill()
@@ -351,6 +352,7 @@ def test_abnormal_supervisor_exit_relinquishes_process_group(
 
         assert process.poll() == -signal.SIGKILL
         assert process._process_group is None
+        _wait_for_process_exit(evaluator_pid)
 
         monkeypatch.setattr(
             local.os,
@@ -361,8 +363,8 @@ def test_abnormal_supervisor_exit_relinquishes_process_group(
         assert group_signals == []
     finally:
         try:
-            os.kill(evaluator_pid, signal.SIGKILL)
-        except ProcessLookupError:
+            killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
             pass
         process.cleanup_logging()
 

--- a/tests/test_local_process_cleanup.py
+++ b/tests/test_local_process_cleanup.py
@@ -39,6 +39,36 @@ grandchild = subprocess.Popen(
 grandchild.wait()
 """
 
+_TERM_RESISTANT_CODE = """
+from pathlib import Path
+import signal
+import sys
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+Path(sys.argv[1]).touch()
+signal.pause()
+"""
+
+
+_LEADER_EXITS_CODE = """
+import subprocess
+from pathlib import Path
+import sys
+import time
+
+ready_path = Path(sys.argv[1])
+subprocess.Popen(
+    [sys.executable, "-c", sys.argv[2], sys.argv[1]],
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
+)
+deadline = time.monotonic() + 5
+while not ready_path.exists():
+    if time.monotonic() >= deadline:
+        raise TimeoutError("grandchild did not become ready")
+    time.sleep(0.01)
+"""
+
 
 class _ExpiredClock:
     def __init__(self) -> None:
@@ -125,7 +155,27 @@ def test_direct_child_signals_delegate_to_popen() -> None:
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
-def test_completed_process_ignores_repeated_group_signals(
+def test_scheduler_raw_status_api_accepts_process_wrapper(tmp_path: Path) -> None:
+    process = local.submit(
+        str(tmp_path),
+        [sys.executable, "-c", "import signal; signal.pause()"],
+    )
+    scheduler = JobScheduler("local", LocalJobConfig())
+
+    try:
+        assert asyncio.run(scheduler.check_job_id_status_async(process)) is True
+
+        process.kill()
+        process.wait(timeout=5)
+
+        assert asyncio.run(scheduler.check_job_id_status_async(process)) is False
+    finally:
+        process.cleanup_logging()
+        scheduler.shutdown()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
+def test_completed_process_relinquishes_group_during_cleanup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -136,6 +186,7 @@ def test_completed_process_ignores_repeated_group_signals(
 
     def record_group_signal(process_group: int, sig: int) -> None:
         group_signals.append((process_group, sig))
+        raise ProcessLookupError
 
     monkeypatch.setattr(local.os, "killpg", record_group_signal)
 
@@ -144,6 +195,66 @@ def test_completed_process_ignores_repeated_group_signals(
     process.kill()
 
     assert group_signals == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
+def test_terminate_can_escalate_when_evaluator_ignores_signal(tmp_path: Path) -> None:
+    ready_path = tmp_path / "ready"
+    process = local.submit(
+        str(tmp_path / "logs"),
+        [sys.executable, "-c", _TERM_RESISTANT_CODE, str(ready_path)],
+    )
+    deadline = time.monotonic() + 5
+    while not ready_path.exists():
+        if process.poll() is not None or time.monotonic() >= deadline:
+            raise AssertionError("evaluator did not signal readiness")
+        time.sleep(0.01)
+
+    try:
+        process.terminate()
+        with pytest.raises(subprocess.TimeoutExpired):
+            process.wait(timeout=0.1)
+        assert process._process_group == process.pid
+
+        process.kill()
+        process.wait(timeout=5)
+        assert process._process_group is None
+    finally:
+        process.cleanup_logging()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
+def test_group_signal_reaps_descendant_after_leader_exits(tmp_path: Path) -> None:
+    log_dir = tmp_path / "logs"
+    ready_path = tmp_path / "grandchild.ready"
+    process = local.submit(
+        str(log_dir),
+        [
+            sys.executable,
+            "-c",
+            _LEADER_EXITS_CODE,
+            str(ready_path),
+            _GRANDCHILD_CODE,
+        ],
+    )
+    grandchild_pid = _wait_for_ready_pid(ready_path, process)
+
+    try:
+        process.wait(timeout=5)
+        assert process.returncode == 0
+        assert process.process.poll() is None
+        assert os.getpgid(process.pid) == process.pid
+        assert os.getpgid(grandchild_pid) == process.pid
+
+        process.kill()
+
+        _wait_for_process_exit(grandchild_pid)
+    finally:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.cleanup_logging()
 
 
 def test_scheduler_cancellation_reaps_process_tree(

--- a/tests/test_local_process_cleanup.py
+++ b/tests/test_local_process_cleanup.py
@@ -332,6 +332,44 @@ def test_send_signal_sigkill_reaches_process_group(
     _wait_for_process_exit(grandchild_pid)
 
 
+@pytest.mark.parametrize("exit_accessor", ["poll", "returncode"])
+def test_completion_eof_preserves_supervisor_ownership_until_exit(
+    monkeypatch: pytest.MonkeyPatch,
+    exit_accessor: str,
+) -> None:
+    read_fd, write_fd = os.pipe()
+    os.close(write_fd)
+    process_mock = Mock(spec=subprocess.Popen)
+    process_mock.poll.side_effect = [None, None, -signal.SIGKILL]
+    process_mock.returncode = -signal.SIGKILL
+    process = local.ProcessWithLogging(
+        cast(subprocess.Popen[str], process_mock),
+        cast(tuple[TextIO, TextIO], (Mock(), Mock())),
+        cast(tuple[threading.Thread, threading.Thread], (Mock(), Mock())),
+        process_group=4321,
+        completion_fd=read_fd,
+    )
+    group_signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        local.os,
+        "killpg",
+        lambda process_group, sig: group_signals.append((process_group, sig)),
+    )
+
+    assert process.poll() is None
+    assert process._completion_fd is None
+    assert process._supervisor_exit_pending is True
+
+    returncode = (
+        process.poll() if exit_accessor == "poll" else process.returncode
+    )
+
+    assert returncode == -signal.SIGKILL
+    assert group_signals == [(4321, signal.SIGKILL)]
+    assert process._process_group is None
+    assert process._supervisor_exit_pending is False
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
 def test_abnormal_supervisor_exit_relinquishes_process_group(
     tmp_path: Path,
@@ -348,11 +386,10 @@ def test_abnormal_supervisor_exit_relinquishes_process_group(
 
     try:
         process.process.kill()
-        process.process.wait(timeout=5)
-
+        process.cleanup_logging()
+        _wait_for_process_exit(evaluator_pid)
         assert process.poll() == -signal.SIGKILL
         assert process._process_group is None
-        _wait_for_process_exit(evaluator_pid)
 
         monkeypatch.setattr(
             local.os,

--- a/tests/test_local_process_cleanup.py
+++ b/tests/test_local_process_cleanup.py
@@ -305,3 +305,99 @@ def test_terminate_cancellation_kills_descendant_processes(
     process.wait(timeout=5)
     process.cleanup_logging()
     _wait_for_process_exit(grandchild_pid)
+
+
+def test_send_signal_sigterm_reaches_process_group(
+    process_tree: tuple[local.ProcessWithLogging, int, Path],
+) -> None:
+    process, grandchild_pid, _log_dir = process_tree
+
+    process.send_signal(signal.SIGTERM)
+
+    process.wait(timeout=5)
+    process.cleanup_logging()
+    _wait_for_process_exit(grandchild_pid)
+
+
+def test_send_signal_sigkill_reaches_process_group(
+    process_tree: tuple[local.ProcessWithLogging, int, Path],
+) -> None:
+    process, grandchild_pid, _log_dir = process_tree
+
+    process.send_signal(signal.SIGKILL)
+
+    process.wait(timeout=5)
+    assert process._process_group is None
+    process.cleanup_logging()
+    _wait_for_process_exit(grandchild_pid)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process groups are required")
+def test_abnormal_supervisor_exit_relinquishes_process_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ready_path = tmp_path / "evaluator.ready"
+    process = local.submit(
+        str(tmp_path / "logs"),
+        [sys.executable, "-c", _GRANDCHILD_CODE, str(ready_path)],
+    )
+    evaluator_pid = _wait_for_ready_pid(ready_path, process)
+    group_signals: list[tuple[int, int]] = []
+
+    try:
+        process.process.kill()
+        process.process.wait(timeout=5)
+
+        assert process.poll() == -signal.SIGKILL
+        assert process._process_group is None
+
+        monkeypatch.setattr(
+            local.os,
+            "killpg",
+            lambda process_group, sig: group_signals.append((process_group, sig)),
+        )
+        process.cleanup_logging()
+        assert group_signals == []
+    finally:
+        try:
+            os.kill(evaluator_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.cleanup_logging()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file descriptors are required")
+def test_completion_pipe_avoids_closed_standard_fds(tmp_path: Path) -> None:
+    result_path = tmp_path / "returncode"
+    harness = f"""
+import os
+from pathlib import Path
+import sys
+from shinka.launch import local
+
+os.close(0)
+os.close(1)
+process = local.submit(
+    {str(tmp_path / "logs")!r},
+    [sys.executable, "-c", "raise SystemExit(7)"],
+)
+completion_fd = process._completion_fd
+completion_fd_inheritable = os.get_inheritable(completion_fd)
+returncode = process.wait(timeout=5)
+process.cleanup_logging()
+Path({str(result_path)!r}).write_text(
+    f"{{completion_fd}},{{completion_fd_inheritable}},{{returncode}}",
+    encoding="ascii",
+)
+"""
+
+    completed = subprocess.run([sys.executable, "-c", harness], timeout=10)
+
+    assert completed.returncode == 0
+    completion_fd, inheritable, returncode = result_path.read_text(
+        encoding="ascii"
+    ).split(",")
+    assert int(completion_fd) >= 3
+    assert inheritable == "False"
+    assert returncode == "7"

--- a/tests/test_scheduler_cancel.py
+++ b/tests/test_scheduler_cancel.py
@@ -1,0 +1,54 @@
+import asyncio
+import subprocess
+
+from shinka.launch import scheduler as scheduler_module
+from shinka.launch.scheduler import JobScheduler, SlurmCondaJobConfig
+
+
+def test_slurm_cancel_waits_for_job_to_leave_queue(monkeypatch) -> None:
+    statuses = iter(["RUNNING", "COMPLETING", ""])
+    status_checks: list[str] = []
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(
+        scheduler_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
+    )
+
+    def get_job_status(job_id: str) -> str:
+        status_checks.append(job_id)
+        return next(statuses)
+
+    monkeypatch.setattr(scheduler_module, "get_job_status", get_job_status)
+    monkeypatch.setattr(scheduler_module.time, "sleep", sleeps.append)
+
+    scheduler = JobScheduler("slurm_conda", SlurmCondaJobConfig())
+    try:
+        cancelled = asyncio.run(scheduler.cancel_job_async("12345"))
+    finally:
+        scheduler.shutdown()
+
+    assert cancelled is True
+    assert status_checks == ["12345", "12345", "12345"]
+    assert len(sleeps) == 2
+
+
+def test_slurm_cancel_fails_when_job_remains_queued(monkeypatch) -> None:
+    monkeypatch.setattr(
+        scheduler_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
+    )
+    monkeypatch.setattr(
+        scheduler_module, "get_job_status", lambda _job_id: "COMPLETING"
+    )
+    monkeypatch.setattr(scheduler_module, "_SLURM_CANCEL_TIMEOUT_SECONDS", 0.0)
+
+    scheduler = JobScheduler("slurm_conda", SlurmCondaJobConfig())
+    try:
+        cancelled = asyncio.run(scheduler.cancel_job_async("12345"))
+    finally:
+        scheduler.shutdown()
+
+    assert cancelled is False

--- a/tests/test_scheduler_cancel.py
+++ b/tests/test_scheduler_cancel.py
@@ -1,11 +1,12 @@
 import asyncio
 import subprocess
+import threading
 
 import pytest
 
 from shinka.launch import scheduler as scheduler_module
 from shinka.launch import slurm as slurm_module
-from shinka.launch.scheduler import JobScheduler, SlurmCondaJobConfig
+from shinka.launch.scheduler import JobScheduler, LocalJobConfig, SlurmCondaJobConfig
 
 
 def test_slurm_cancel_waits_for_job_to_leave_queue(monkeypatch) -> None:
@@ -108,3 +109,64 @@ def test_scheduler_treats_unknown_slurm_status_as_running(monkeypatch) -> None:
         assert scheduler.check_job_id_status("12345") is True
     finally:
         scheduler.shutdown()
+
+
+def test_begin_shutdown_queues_cleanup_before_concurrent_executor_shutdown():
+    class _ControlledExecutor:
+        def __init__(self):
+            self.submit_started = threading.Event()
+            self.allow_submit = threading.Event()
+            self.cleanup_calls = []
+            self.closed = False
+
+        def submit(self, callback, *args):
+            self.submit_started.set()
+            assert self.allow_submit.wait(timeout=0.2)
+            if self.closed:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            self.cleanup_calls.append((callback, args))
+            return object()
+
+        def shutdown(self, wait=True, cancel_futures=False):
+            self.closed = True
+
+    scheduler = JobScheduler("local", LocalJobConfig())
+    original_executor = scheduler.executor
+    controlled_executor = _ControlledExecutor()
+    scheduler.executor = controlled_executor
+    original_executor.shutdown(wait=True)
+
+    token = object()
+    with scheduler._submission_lock:
+        scheduler._unclaimed_submissions[token] = "late-job"
+
+    errors = []
+    shutdown_started = threading.Event()
+
+    def begin_shutdown():
+        try:
+            scheduler.begin_shutdown()
+        except Exception as error:
+            errors.append(error)
+
+    def shutdown_nowait():
+        shutdown_started.set()
+        scheduler.shutdown_nowait()
+
+    begin_thread = threading.Thread(target=begin_shutdown)
+    shutdown_thread = threading.Thread(target=shutdown_nowait)
+    begin_thread.start()
+    assert controlled_executor.submit_started.wait(timeout=0.2)
+    shutdown_thread.start()
+    assert shutdown_started.wait(timeout=0.2)
+    shutdown_thread.join(timeout=0.05)
+    assert shutdown_thread.is_alive()
+    controlled_executor.allow_submit.set()
+    begin_thread.join(timeout=0.2)
+    shutdown_thread.join(timeout=0.2)
+
+    assert not begin_thread.is_alive()
+    assert not shutdown_thread.is_alive()
+    assert errors == []
+    assert len(controlled_executor.cleanup_calls) == 1
+    assert token in scheduler._shutdown_cleanup_futures

--- a/tests/test_scheduler_cancel.py
+++ b/tests/test_scheduler_cancel.py
@@ -1,7 +1,10 @@
 import asyncio
 import subprocess
 
+import pytest
+
 from shinka.launch import scheduler as scheduler_module
+from shinka.launch import slurm as slurm_module
 from shinka.launch.scheduler import JobScheduler, SlurmCondaJobConfig
 
 
@@ -9,15 +12,18 @@ def test_slurm_cancel_waits_for_job_to_leave_queue(monkeypatch) -> None:
     statuses = iter(["RUNNING", "COMPLETING", ""])
     status_checks: list[str] = []
     sleeps: list[float] = []
+    command_timeouts: list[float] = []
+    status_timeouts: list[float] = []
 
-    monkeypatch.setattr(
-        scheduler_module.subprocess,
-        "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
-    )
+    def run(*args, **kwargs):
+        command_timeouts.append(kwargs["timeout"])
+        return subprocess.CompletedProcess(args[0], 0)
 
-    def get_job_status(job_id: str) -> str:
+    monkeypatch.setattr(scheduler_module.subprocess, "run", run)
+
+    def get_job_status(job_id: str, timeout: float) -> str:
         status_checks.append(job_id)
+        status_timeouts.append(timeout)
         return next(statuses)
 
     monkeypatch.setattr(scheduler_module, "get_job_status", get_job_status)
@@ -32,6 +38,8 @@ def test_slurm_cancel_waits_for_job_to_leave_queue(monkeypatch) -> None:
     assert cancelled is True
     assert status_checks == ["12345", "12345", "12345"]
     assert len(sleeps) == 2
+    assert command_timeouts and all(timeout > 0 for timeout in command_timeouts)
+    assert status_timeouts and all(timeout > 0 for timeout in status_timeouts)
 
 
 def test_slurm_cancel_fails_when_job_remains_queued(monkeypatch) -> None:
@@ -41,7 +49,9 @@ def test_slurm_cancel_fails_when_job_remains_queued(monkeypatch) -> None:
         lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
     )
     monkeypatch.setattr(
-        scheduler_module, "get_job_status", lambda _job_id: "COMPLETING"
+        scheduler_module,
+        "get_job_status",
+        lambda _job_id, timeout: "COMPLETING",
     )
     monkeypatch.setattr(scheduler_module, "_SLURM_CANCEL_TIMEOUT_SECONDS", 0.0)
 
@@ -52,3 +62,49 @@ def test_slurm_cancel_fails_when_job_remains_queued(monkeypatch) -> None:
         scheduler.shutdown()
 
     assert cancelled is False
+
+
+def test_slurm_cancel_command_timeout_is_failure(monkeypatch) -> None:
+    timeouts: list[float] = []
+
+    def timeout(*args, **kwargs):
+        timeouts.append(kwargs["timeout"])
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(scheduler_module.subprocess, "run", timeout)
+    scheduler = JobScheduler("slurm_conda", SlurmCondaJobConfig())
+    try:
+        assert asyncio.run(scheduler.cancel_job_async("12345")) is False
+    finally:
+        scheduler.shutdown()
+
+    assert timeouts and all(command_timeout > 0 for command_timeout in timeouts)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        subprocess.TimeoutExpired(["squeue"], 0.1),
+        subprocess.CalledProcessError(1, ["squeue"]),
+    ],
+)
+def test_slurm_status_errors_are_unknown(monkeypatch, error: Exception) -> None:
+    def fail(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(slurm_module.subprocess, "run", fail)
+
+    assert slurm_module.get_job_status("12345", timeout=0.1) is None
+
+
+def test_scheduler_treats_unknown_slurm_status_as_running(monkeypatch) -> None:
+    monkeypatch.setattr(
+        scheduler_module,
+        "get_job_status",
+        lambda _job_id: None,
+    )
+    scheduler = JobScheduler("slurm_conda", SlurmCondaJobConfig())
+    try:
+        assert scheduler.check_job_id_status("12345") is True
+    finally:
+        scheduler.shutdown()


### PR DESCRIPTION
## Summary

- Keep each POSIX evaluator process group owned by a live supervisor until cleanup, even when the evaluator leader exits first.
- Report the evaluator exit code through a private pipe while preserving the existing ProcessWithLogging interface.
- Retain group ownership after SIGTERM so cancellation can escalate safely to SIGKILL without signalling a reused process-group ID.
- Track executor-backed submissions through caller cancellation; late jobs stay runner-owned until cancellation or result reaping is confirmed, and their evaluation slot remains reserved until then.
- Add raw-job-ID status checks plus process-tree, repeated-cancellation, late-result, timeout, and shutdown regressions.

## Why

Local evaluators can launch workers of their own. Killing only the direct child leaves those workers alive. A second race occurs when a proposal task is cancelled while its executor-backed evaluation submission is still in progress: the submission can complete later without being tracked, leaving both a live job and a permanently occupied evaluation slot.

The process group must remain owned after its leader exits, and late-submission cleanup must outlive repeated cancellation of the proposal task. This patch makes both lifetimes explicit and releases ownership only after the corresponding process or scheduler job has been reaped.

## Linked issue or context

- Fixes #143. PR #144 handled the retry-budget portion separately.
- The initial process-tree direction came from [autoresearch with Weco](https://dashboard.weco.ai/share/qD-HzpDHi_61B5cMNFZF_ltXRyUUAQIe); the review-race fixes were rebuilt and validated manually.

## Testing

Required base: current main at 5bb134a.

- Current-base paired process-tree probe: leader_exit_orphan_descendants=1 on main, 0 on this branch.
- Current-base paired cancellation probe: late_jobs_created=1 late_jobs_cancelled=0 slots_in_use=1 on main; late_jobs_created=1 late_jobs_cancelled=1 slots_in_use=0 on this branch.
- uv run --python 3.11 pytest -q tests/test_local_process_cleanup.py tests/test_async_runner_recovery.py: 50 passed.
- uv run pytest -q: 717 passed, with 5 existing bandit-persistence warnings.
- uv run ruff check tests --exclude tests/file.py: passed.
- uv run ruff check shinka/core/async_runner.py shinka/launch/local.py shinka/launch/scheduler.py: passed.
- uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py: no issues in 66 source files.
- Changed-source mypy reports the same 35 existing errors on this branch and current main; no new error was introduced.
- uv run black --check --target-version py311 shinka/launch/local.py tests/test_local_process_cleanup.py: passed.
- git diff --check and diff secret/forbidden-term scans: passed.
- uvx ruff check --fix . was run as required; it reports 11 unrelated pre-existing repository violations after four unrelated auto-fixes, which were reverted. The scoped checks above pass.

## Risks and compatibility

- Windows behavior is unchanged and still targets only the direct child.
- POSIX descendants that deliberately detach into a separate session remain outside the evaluator process group.
- The supervisor is internal. Manually constructed ProcessWithLogging wrappers continue to use direct-child behavior unless group ownership is explicitly provided.
- A failed scheduler cancellation keeps the evaluation slot reserved and retries. If the job has already finished, the result path is reaped before the slot is released.

## Core evolution pipeline evidence

- Primary metric: leader_exit_orphan_descendants (minimize), from 1 on current main to 0.
- Cancellation invariant: late submitted jobs are cancelled or reaped before their evaluation slot is released.
- Ordinary completed jobs, timeout cleanup, scheduler cancellation, graceful termination, escalation, repeated cancellation, and runner shutdown are covered.

## Docs and UI

- No user-facing CLI or WebUI behavior changed.
