### PR TITLE
Add optional Weights & Biases logging

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,6 +24,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION_NAME: ${{ secrets.AWS_REGION_NAME }}
+      WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
 
     steps:
       - name: Checkout
@@ -38,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install project
-        run: uv sync --dev
+        run: uv sync --dev --extra wandb
 
       - name: Run secret-backed integration tests
         run: |

--- a/README.md
+++ b/README.md
@@ -174,6 +174,32 @@ Set `SHINKA_PRICING_MODE=offline` to skip the network check, or
 validated. Run `shinka_models --verbose` to inspect catalog provenance and the
 models available for configured provider credentials.
 
+### Weights & Biases logging
+
+Install the optional W&B integration and enable it for a run:
+
+```bash
+pip install 'shinka-evolve[wandb]'
+
+# Authenticate online runs. In CI, provide this through a secret manager.
+export WANDB_API_KEY=<your-api-key>
+
+shinka_run --task-dir examples/circle_packing \
+  --results_dir results/circle_wandb \
+  --num_generations 20 \
+  --set evo.enable_wandb_logging=true \
+  --set evo.wandb_project=shinka-evolve
+```
+
+W&B logging is additive: the existing SQLite database and WebUI logging remain
+enabled. Each evaluated individual logs `score/individual` against `generation`,
+along with compact evaluation, cost, and timing metrics. Resuming the same
+results directory reuses its persisted W&B run ID by default. Online mode uses
+the credentials from `wandb login` or `WANDB_API_KEY`; use `wandb_mode=offline`
+to record locally without uploading. See
+[Configuration](docs/configuration.md#evolutionconfig-shinkacoreconfigevolutionconfig)
+for all W&B options.
+
 <details>
 <summary><strong>EvolutionConfig Parameters</strong> (click to expand)</summary>
 
@@ -201,6 +227,18 @@ Class defaults below come from `shinka/core/config.py` (`EvolutionConfig`). Hydr
 | `embedding_model` | `"text-embedding-3-small"` | `Optional[str]` | Model for code embeddings. Also accepts `local/<model>@http(s)://host[:port]/v1` for local OpenAI-compatible embedding servers, with optional `?api_key_env=ENV_VAR` for per-model credentials. |
 | `init_program_path` | `"initial.py"` | `Optional[str]` | Path to initial program to evolve |
 | `results_dir` | `None` | `Optional[str]` | Directory to save results (auto-generated if None) |
+| `enable_wandb_logging` | `False` | `bool` | Mirror evolution metrics to W&B without disabling SQLite or WebUI logging |
+| `wandb_project` | `"shinka-evolve"` | `Optional[str]` | W&B project used when logging is enabled |
+| `wandb_entity` | `None` | `Optional[str]` | Optional W&B entity or team |
+| `wandb_group` | `None` | `Optional[str]` | Optional W&B run group |
+| `wandb_name` | `None` | `Optional[str]` | Optional run name; defaults to the results directory name |
+| `wandb_mode` | `None` | `Optional[str]` | Optional W&B mode such as `offline` or `disabled` |
+| `wandb_tags` | `[]` | `List[str]` | Optional W&B tags |
+| `wandb_notes` | `None` | `Optional[str]` | Optional W&B run notes |
+| `wandb_dir` | `None` | `Optional[str]` | Optional local W&B directory; defaults to `results_dir` |
+| `wandb_run_id` | `None` | `Optional[str]` | Optional W&B run ID; otherwise generated and persisted in the results directory |
+| `wandb_resume` | `"allow"` | `str` | W&B resume policy used with the persisted run ID |
+| `wandb_config` | `{}` | `Dict[str, Any]` | Extra values merged into the W&B run config |
 | `max_novelty_attempts` | `3` | `int` | Max attempts for novelty generation |
 | `code_embed_sim_threshold` | `0.99` | `float` | Similarity threshold for code embeddings |
 | `novelty_llm_models` | `None` | `Optional[List[str]]` | LLM models for novelty judgment |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,18 @@ Concurrency is configured on `ShinkaEvolveRunner`, not on `EvolutionConfig`.
 | `embedding_model` | `Optional[str]` | `'text-embedding-3-small'` | Embedding model for code similarity. Also supports `local/<model>@http(s)://host[:port]/v1` for local OpenAI-compatible embedding endpoints, with optional `?api_key_env=ENV_VAR` for per-model credentials. |
 | `init_program_path` | `Optional[str]` | `'initial.py'` | Initial program path. |
 | `results_dir` | `Optional[str]` | `None` | Results directory; auto-assigned when `None`. |
+| `enable_wandb_logging` | `bool` | `False` | Mirror evolution metrics to W&B. Existing SQLite and WebUI logging remains enabled. Install the `wandb` extra first. |
+| `wandb_project` | `Optional[str]` | `'shinka-evolve'` | W&B project used when wandb logging is enabled. |
+| `wandb_entity` | `Optional[str]` | `None` | Optional W&B entity/team. |
+| `wandb_group` | `Optional[str]` | `None` | Optional W&B run group. |
+| `wandb_name` | `Optional[str]` | `None` | Optional W&B run name; defaults to the results directory name. |
+| `wandb_mode` | `Optional[str]` | `None` | Optional W&B mode, e.g. `offline` or `disabled`. |
+| `wandb_tags` | `List[str]` | `[]` | Optional W&B tags. |
+| `wandb_notes` | `Optional[str]` | `None` | Optional W&B run notes. |
+| `wandb_dir` | `Optional[str]` | `None` | Optional local W&B directory; defaults to `results_dir`. |
+| `wandb_run_id` | `Optional[str]` | `None` | Optional W&B run ID; otherwise generated and persisted in the results directory. |
+| `wandb_resume` | `str` | `'allow'` | W&B resume policy used with the persisted run ID. |
+| `wandb_config` | `Dict[str, Any]` | `{}` | Extra W&B config values merged into the run config. |
 | `max_novelty_attempts` | `int` | `3` | Max novelty loops per generation. |
 | `code_embed_sim_threshold` | `float` | `0.99` | Similarity threshold used by novelty checks. |
 | `novelty_llm_models` | `Optional[List[str]]` | `None` | Optional novelty-judge model pool. |
@@ -72,6 +84,28 @@ Concurrency is configured on `ShinkaEvolveRunner`, not on `EvolutionConfig`.
 | `prompt_epsilon` | `float` | `0.1` | Epsilon-greedy exploration for prompt sampler. |
 | `prompt_evo_top_k_programs` | `int` | `3` | Number of top programs used during prompt evolution. |
 | `prompt_percentile_recompute_interval` | `int` | `20` | Generations between prompt percentile recomputations. |
+
+W&B logging examples:
+
+```bash
+# Install the optional integration.
+pip install 'shinka-evolve[wandb]'
+
+# Authenticate online runs. In CI, provide this through a secret manager.
+export WANDB_API_KEY=<your-api-key>
+
+# Add W&B metrics and a compact individuals table alongside the WebUI database.
+shinka_run --task-dir examples/circle_packing --results_dir results/circle_wandb --num_generations 20 \
+  --set evo.enable_wandb_logging=true \
+  --set evo.wandb_project=shinka-evolve
+```
+
+Each evaluated individual logs `score/individual` against `generation`. When a
+results directory is resumed, its `.wandb_run_id` is reused with
+`wandb_resume='allow'` by default. Online mode uses the credentials from
+`wandb login` or `WANDB_API_KEY`; set `wandb_mode=offline` to record locally
+without uploading. W&B failures are non-fatal and do not alter the existing
+database or WebUI path.
 
 ### DatabaseConfig (`shinka.database.DatabaseConfig`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dependencies = [
     "httpx==0.27"
 ]
 
+[project.optional-dependencies]
+wandb = ["wandb"]
+
 [project.scripts]
 shinka_launch = "shinka.cli.launch:main"
 shinka_models = "shinka.cli.models:main"

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -68,6 +68,7 @@ from shinka.pricing.catalog import (
     refresh_model_catalog,
     write_run_pricing_snapshot,
 )
+from shinka.wandb_logging import ShinkaWandbLogger
 from shinka.utils import (
     get_language_extension,
     parse_time_to_seconds,
@@ -280,6 +281,7 @@ class ShinkaEvolveRunner:
         self.evo_config = evo_config
         self.job_config = job_config
         self.db_config = db_config
+        self.wandb_logger = ShinkaWandbLogger(enabled=evo_config.enable_wandb_logging)
         self.banner_style = banner_style
         self.enable_deadlock_debugging = debug
         log_filename = f"{self.results_dir}/evolution_run.log"
@@ -1181,6 +1183,13 @@ class ShinkaEvolveRunner:
         if self.evo_config.evolve_prompts:
             await self._setup_prompt_evolution()
 
+        self.wandb_logger.start(
+            evo_config=self.evo_config,
+            db_config=self.db_config,
+            job_config=self.job_config,
+            results_dir=Path(self.results_dir),
+        )
+
         # Check if we're resuming from an existing database
         resuming_run = db_path.exists() and self.db.last_iteration > 0
 
@@ -1796,6 +1805,7 @@ class ShinkaEvolveRunner:
             postprocess_finished_at=postprocess_finished_at,
         )
         await self._persist_program_metadata_async(initial_program)
+        self._log_program_to_wandb(initial_program)
 
         if self.verbose:
             logger.info(f"Setup initial program: {initial_program.id}")
@@ -4013,6 +4023,7 @@ class ShinkaEvolveRunner:
             await self._update_completed_generations()
             self._record_progress()
             self.slot_available.set()
+            self._log_program_to_wandb(program)
             logger.info(
                 "Persisted failed generation %s as incorrect program %s (%s)",
                 generation,
@@ -4531,6 +4542,7 @@ class ShinkaEvolveRunner:
                         f"Apply-stage metadata persistence error for {job.job_id}: {e}"
                     )
 
+        self._log_program_to_wandb(program)
         logger.info(
             "✅ JOB COMPLETE: Finished processing %s - program %s added (gen %s)",
             job.job_id,
@@ -5512,6 +5524,7 @@ class ShinkaEvolveRunner:
                     logger.warning(f"Failed to recompute prompt percentiles: {e}")
 
             # Cleanup database
+            self._finish_wandb_logging()
             await self.async_db.close_async()
 
             # Cleanup scheduler
@@ -5519,6 +5532,22 @@ class ShinkaEvolveRunner:
 
         except Exception as e:
             logger.error(f"Error in async cleanup: {e}")
+
+    def _log_program_to_wandb(self, program: Program) -> None:
+        wandb_logger = getattr(self, "wandb_logger", None)
+        if wandb_logger is not None:
+            wandb_logger.log_program(program)
+
+    def _finish_wandb_logging(self) -> None:
+        wandb_logger = getattr(self, "wandb_logger", None)
+        if wandb_logger is None:
+            return
+        wandb_logger.log_final(
+            db=getattr(self, "db", None),
+            total_proposals_generated=getattr(self, "total_proposals_generated", None),
+            total_api_cost=getattr(self, "total_api_cost", None),
+        )
+        wandb_logger.finish()
 
     async def _print_final_summary(self):
         """Print final evolution summary."""

--- a/shinka/core/config.py
+++ b/shinka/core/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from shinka.llm import BanditBase
 from shinka.defaults import (
@@ -40,6 +40,21 @@ class EvolutionConfig:
     embedding_model: Optional[str] = "text-embedding-3-small"
     init_program_path: Optional[str] = "initial.py"
     results_dir: Optional[str] = None
+
+    # Optional W&B logging is additive to the existing database/WebUI logging.
+    enable_wandb_logging: bool = False
+    wandb_project: Optional[str] = "shinka-evolve"
+    wandb_entity: Optional[str] = None
+    wandb_group: Optional[str] = None
+    wandb_name: Optional[str] = None
+    wandb_mode: Optional[str] = None
+    wandb_tags: List[str] = field(default_factory=list)
+    wandb_notes: Optional[str] = None
+    wandb_dir: Optional[str] = None
+    wandb_run_id: Optional[str] = None
+    wandb_resume: str = "allow"
+    wandb_config: Dict[str, Any] = field(default_factory=dict)
+
     max_novelty_attempts: int = 3
     code_embed_sim_threshold: float = 0.99
     novelty_llm_models: Optional[List[str]] = None

--- a/shinka/wandb_logging.py
+++ b/shinka/wandb_logging.py
@@ -1,0 +1,376 @@
+"""Optional Weights & Biases logging for evolution runs."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import math
+import re
+import uuid
+from dataclasses import fields, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from shinka.database import Program, ProgramDatabase
+
+logger = logging.getLogger(__name__)
+
+GENERATION_METRIC = "generation"
+INDIVIDUAL_SCORE_METRIC = "score/individual"
+PROGRAM_TABLE_KEY = "individuals"
+WANDB_RUN_ID_FILENAME = ".wandb_run_id"
+PROGRAM_TABLE_COLUMNS = [
+    "id",
+    "generation",
+    "score",
+    "correct",
+    "parent_id",
+    "island_idx",
+    "in_archive",
+    "patch_type",
+    "model_name",
+    "cost",
+]
+
+_COST_KEYS = {
+    "api": "api_costs",
+    "embedding": "embed_cost",
+    "novelty": "novelty_cost",
+    "meta": "meta_cost",
+}
+_TIMING_KEYS = (
+    "sampling_seconds",
+    "evaluation_seconds",
+    "postprocess_seconds",
+    "pipeline_seconds",
+)
+
+
+def ensure_wandb_run_id(
+    results_dir: Path,
+    configured_id: Optional[str] = None,
+) -> str:
+    """Persist and return the W&B run ID associated with a results directory."""
+    results_dir = Path(results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    run_id_path = results_dir / WANDB_RUN_ID_FILENAME
+    run_id = str(configured_id).strip() if configured_id else ""
+
+    if not run_id and run_id_path.is_file():
+        run_id = run_id_path.read_text(encoding="utf-8").strip()
+    if not run_id:
+        run_id = uuid.uuid4().hex
+
+    run_id_path.write_text(f"{run_id}\n", encoding="utf-8")
+    return run_id
+
+
+def build_program_log_payload(program: Program) -> Dict[str, Any]:
+    """Build one compact W&B history event for an evaluated individual."""
+    metadata = program.metadata or {}
+    costs = program_costs(program)
+    individual_score = _finite_float(program.combined_score)
+    payload: Dict[str, Any] = {
+        GENERATION_METRIC: program.generation,
+        INDIVIDUAL_SCORE_METRIC: individual_score,
+        "individual/id": program.id,
+        "individual/parent_id": program.parent_id,
+        "individual/island_idx": program.island_idx,
+        "individual/correct": bool(program.correct),
+        "individual/in_archive": bool(program.in_archive),
+        "individual/patch_type": metadata.get("patch_type"),
+        "individual/model_name": _program_model_name(program),
+        **{f"cost/{name}": value for name, value in costs.items()},
+    }
+
+    for key in _TIMING_KEYS:
+        value = _finite_float(metadata.get(key))
+        if value is not None:
+            payload[f"timing/{key}"] = value
+
+    for prefix, metrics in (
+        ("public_metrics", program.public_metrics),
+        ("private_metrics", program.private_metrics),
+    ):
+        for key, value in flatten_numeric_metrics(metrics, prefix).items():
+            leaf_name = key.rsplit("/", 1)[-1]
+            if leaf_name in {"score", "combined_score"} and value == individual_score:
+                continue
+            payload[key] = value
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def flatten_numeric_metrics(
+    data: Any,
+    prefix: str,
+    *,
+    max_depth: int = 3,
+) -> Dict[str, float]:
+    """Flatten only numeric evaluation metrics, excluding bulky text and arrays."""
+    flattened: Dict[str, float] = {}
+
+    def visit(value: Any, parts: List[str], depth: int) -> None:
+        if depth > max_depth:
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                visit(child, [*parts, _metric_segment(key)], depth + 1)
+            return
+        numeric_value = _finite_float(value)
+        if numeric_value is not None:
+            flattened["/".join([prefix, *parts])] = numeric_value
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            visit(value, [_metric_segment(key)], 1)
+    return flattened
+
+
+def program_costs(program: Program) -> Dict[str, float]:
+    """Return the non-duplicated cost breakdown for one individual."""
+    metadata = program.metadata or {}
+    return {
+        name: _finite_float(metadata.get(metadata_key)) or 0.0
+        for name, metadata_key in _COST_KEYS.items()
+    }
+
+
+def program_table_row(program: Program) -> List[Any]:
+    """Return a compact row; detailed program data remains in the WebUI database."""
+    metadata = program.metadata or {}
+    return [
+        program.id,
+        program.generation,
+        _finite_float(program.combined_score),
+        bool(program.correct),
+        program.parent_id,
+        program.island_idx,
+        bool(program.in_archive),
+        metadata.get("patch_type"),
+        _program_model_name(program),
+        sum(program_costs(program).values()),
+    ]
+
+
+def build_run_summary(
+    programs: Sequence[Program],
+    *,
+    total_proposals_generated: Optional[int] = None,
+    total_api_cost: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build concise final values for the W&B run summary."""
+    correct_programs = [program for program in programs if program.correct]
+    correct_scores = [
+        score
+        for program in correct_programs
+        if (score := _finite_float(program.combined_score)) is not None
+    ]
+    summary = {
+        "run/program_count": len(programs),
+        "run/correct_rate": (
+            len(correct_programs) / len(programs) if programs else 0.0
+        ),
+        "run/max_generation": max(
+            (program.generation for program in programs), default=0
+        ),
+        "run/best_score": max(correct_scores) if correct_scores else None,
+        "run/total_proposals_generated": total_proposals_generated,
+        "run/total_api_cost": _finite_float(total_api_cost),
+    }
+    return {key: value for key, value in summary.items() if value is not None}
+
+
+class ShinkaWandbLogger:
+    """Best-effort W&B sink that leaves database/WebUI logging unchanged."""
+
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+        self._wandb: Optional[Any] = None
+        self._run: Optional[Any] = None
+        self._logged_program_ids: set[str] = set()
+
+    @property
+    def active(self) -> bool:
+        return self.enabled and self._run is not None
+
+    def start(
+        self,
+        *,
+        evo_config: Any,
+        db_config: Any,
+        job_config: Any,
+        results_dir: Path,
+    ) -> None:
+        if not self.enabled:
+            return
+
+        try:
+            self._wandb = importlib.import_module("wandb")
+        except ImportError:
+            logger.warning(
+                "W&B logging is enabled, but wandb is not installed. "
+                "Install shinka-evolve[wandb] to use it."
+            )
+            self.enabled = False
+            return
+        except Exception as exc:
+            logger.warning("Failed to import W&B: %s", exc)
+            self.enabled = False
+            return
+
+        try:
+            extra_config = _json_safe(getattr(evo_config, "wandb_config", {}) or {})
+            if not isinstance(extra_config, dict):
+                raise ValueError("wandb_config must be a dictionary")
+
+            run_id = ensure_wandb_run_id(
+                results_dir,
+                getattr(evo_config, "wandb_run_id", None),
+            )
+            evo_config.wandb_run_id = run_id
+            config = {
+                "evolution": _json_safe(evo_config),
+                "database": _json_safe(db_config),
+                "job": _json_safe(job_config),
+            }
+            config.update(extra_config)
+            init_kwargs = {
+                "project": getattr(evo_config, "wandb_project", None)
+                or "shinka-evolve",
+                "entity": getattr(evo_config, "wandb_entity", None),
+                "group": getattr(evo_config, "wandb_group", None),
+                "name": getattr(evo_config, "wandb_name", None)
+                or Path(results_dir).name,
+                "mode": getattr(evo_config, "wandb_mode", None),
+                "tags": getattr(evo_config, "wandb_tags", None) or None,
+                "notes": getattr(evo_config, "wandb_notes", None),
+                "dir": getattr(evo_config, "wandb_dir", None) or str(results_dir),
+                "id": run_id,
+                "resume": getattr(evo_config, "wandb_resume", "allow"),
+                "config": config,
+            }
+            self._run = self._wandb.init(
+                **{
+                    key: value
+                    for key, value in init_kwargs.items()
+                    if value is not None
+                }
+            )
+            self._define_metrics()
+            logger.info("W&B logging initialized for '%s'", init_kwargs["project"])
+        except Exception as exc:
+            logger.warning("Failed to initialize W&B logging: %s", exc)
+            self.finish()
+            self.enabled = False
+
+    def log_program(self, program: Program) -> None:
+        if not self.active or program.id in self._logged_program_ids:
+            return
+        try:
+            self._run.log(build_program_log_payload(program))
+            self._logged_program_ids.add(program.id)
+        except Exception as exc:
+            logger.warning("Failed to log individual %s to W&B: %s", program.id, exc)
+
+    def log_final(
+        self,
+        *,
+        db: Optional[ProgramDatabase],
+        total_proposals_generated: Optional[int] = None,
+        total_api_cost: Optional[float] = None,
+    ) -> None:
+        if not self.active or db is None:
+            return
+        try:
+            programs = db.get_all_programs()
+            self._run.summary.update(
+                build_run_summary(
+                    programs,
+                    total_proposals_generated=total_proposals_generated,
+                    total_api_cost=total_api_cost,
+                )
+            )
+            table = self._wandb.Table(
+                columns=PROGRAM_TABLE_COLUMNS,
+                data=[program_table_row(program) for program in programs],
+            )
+            self._run.log({PROGRAM_TABLE_KEY: table})
+        except Exception as exc:
+            logger.warning("Failed to log final W&B summary: %s", exc)
+
+    def finish(self) -> None:
+        if self._run is None:
+            return
+        try:
+            self._run.finish()
+        except Exception as exc:
+            logger.warning("Failed to finish W&B run cleanly: %s", exc)
+        finally:
+            self._run = None
+
+    def _define_metrics(self) -> None:
+        if not hasattr(self._run, "define_metric"):
+            return
+        self._run.define_metric(GENERATION_METRIC)
+        self._run.define_metric(
+            INDIVIDUAL_SCORE_METRIC,
+            step_metric=GENERATION_METRIC,
+        )
+        for metric_glob in (
+            "cost/*",
+            "timing/*",
+            "public_metrics/*",
+            "private_metrics/*",
+        ):
+            self._run.define_metric(metric_glob, step_metric=GENERATION_METRIC)
+
+
+def _program_model_name(program: Program) -> Optional[str]:
+    metadata = program.metadata or {}
+    llm_result = metadata.get("llm_result")
+    nested_model = llm_result.get("model") if isinstance(llm_result, dict) else None
+    value = metadata.get("model_name") or metadata.get("model") or nested_model
+    return str(value) if value is not None else None
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, (bool, str, bytes)):
+        return None
+    if hasattr(value, "item") and callable(value.item):
+        try:
+            value = value.item()
+        except Exception:
+            return None
+    if not isinstance(value, (int, float)):
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def _metric_segment(value: Any) -> str:
+    segment = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip())
+    return segment.strip("_") or "value"
+
+
+def _json_safe(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _json_safe(getattr(value, field.name))
+            for field in fields(value)
+        }
+    if isinstance(value, Path):
+        return str(value)
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if hasattr(value, "item") and callable(value.item):
+        try:
+            return _json_safe(value.item())
+        except Exception:
+            pass
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return repr(value)

--- a/tests/test_wandb_logging.py
+++ b/tests/test_wandb_logging.py
@@ -1,0 +1,291 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from shinka.core.config import EvolutionConfig
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.wandb_logging import (
+    INDIVIDUAL_SCORE_METRIC,
+    PROGRAM_TABLE_COLUMNS,
+    PROGRAM_TABLE_KEY,
+    ShinkaWandbLogger,
+    build_program_log_payload,
+    build_run_summary,
+    ensure_wandb_run_id,
+)
+
+
+def _make_db(tmp_path):
+    db = ProgramDatabase(DatabaseConfig(db_path=str(tmp_path / "programs.sqlite")))
+    first = Program(
+        id="p0",
+        code="print(0)",
+        generation=0,
+        correct=True,
+        combined_score=1.0,
+        public_metrics={
+            "score": 1.0,
+            "nested": {"accuracy": 0.5},
+            "bulky_text": "not a chart metric",
+        },
+        private_metrics={"hidden": 2.0},
+        metadata={
+            "api_costs": 0.10,
+            "embed_cost": 0.01,
+            "novelty_cost": 0.02,
+            "meta_cost": 0.03,
+            "patch_type": "init",
+            "pipeline_seconds": 2.0,
+            "evaluation_seconds": 1.5,
+            "model_name": "test-model",
+        },
+    )
+    second = Program(
+        id="p1",
+        code="print(1)",
+        generation=1,
+        parent_id="p0",
+        correct=False,
+        combined_score=0.25,
+        public_metrics={"score": 0.25},
+        metadata={
+            "api_costs": 0.20,
+            "embed_cost": 0.02,
+            "novelty_cost": 0.03,
+            "meta_cost": 0.04,
+            "patch_type": "diff",
+            "llm_result": {"model": "fallback-model"},
+        },
+    )
+    db.add(first, defer_maintenance=True)
+    db.add(second, defer_maintenance=True)
+    return db, first, second
+
+
+def test_wandb_logging_is_opt_in_and_does_not_configure_webui():
+    config = EvolutionConfig()
+
+    assert config.enable_wandb_logging is False
+    assert config.wandb_run_id is None
+    assert config.wandb_resume == "allow"
+    assert not hasattr(config, "enable_webui_logging")
+
+
+def test_wandb_run_id_is_reused_and_can_be_overridden(tmp_path):
+    first_run_id = ensure_wandb_run_id(tmp_path)
+
+    assert first_run_id
+    assert ensure_wandb_run_id(tmp_path) == first_run_id
+    assert ensure_wandb_run_id(tmp_path, "configured-id") == "configured-id"
+    assert (tmp_path / ".wandb_run_id").read_text(encoding="utf-8") == (
+        "configured-id\n"
+    )
+
+
+def test_program_payload_logs_one_compact_event_per_individual(tmp_path):
+    _, _, second = _make_db(tmp_path)
+
+    payload = build_program_log_payload(second)
+
+    assert payload["generation"] == 1
+    assert payload[INDIVIDUAL_SCORE_METRIC] == 0.25
+    assert payload["individual/model_name"] == "fallback-model"
+    assert "public_metrics/score" not in payload
+    assert payload["cost/api"] == pytest.approx(0.20)
+    assert "program/combined_score" not in payload
+    assert not any(key.startswith("metadata/") for key in payload)
+    assert not any("latest" in key for key in payload)
+
+
+def test_program_payload_skips_bulky_values_and_duplicate_timing(tmp_path):
+    _, first, _ = _make_db(tmp_path)
+
+    payload = build_program_log_payload(first)
+
+    assert payload["public_metrics/nested/accuracy"] == 0.5
+    assert payload["private_metrics/hidden"] == 2.0
+    assert "public_metrics/bulky_text" not in payload
+    assert payload["timing/pipeline_seconds"] == 2.0
+    assert "metadata/pipeline_seconds" not in payload
+
+
+def test_run_summary_uses_correct_programs_for_best_score(tmp_path):
+    db, _, _ = _make_db(tmp_path)
+
+    summary = build_run_summary(
+        db.get_all_programs(),
+        total_proposals_generated=2,
+        total_api_cost=0.5,
+    )
+
+    assert summary["run/program_count"] == 2
+    assert summary["run/correct_rate"] == 0.5
+    assert summary["run/best_score"] == 1.0
+    assert summary["run/max_generation"] == 1
+    assert summary["run/total_proposals_generated"] == 2
+    assert summary["run/total_api_cost"] == 0.5
+
+
+def test_invalid_wandb_config_is_non_fatal(tmp_path, monkeypatch, caplog):
+    fake_wandb = ModuleType("wandb")
+    fake_wandb.init = lambda **kwargs: pytest.fail("wandb.init should not be called")
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+    logger = ShinkaWandbLogger(enabled=True)
+
+    logger.start(
+        evo_config=SimpleNamespace(wandb_config="invalid"),
+        db_config=SimpleNamespace(),
+        job_config=SimpleNamespace(),
+        results_dir=tmp_path,
+    )
+
+    assert logger.active is False
+    assert "Failed to initialize W&B logging" in caplog.text
+
+
+def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
+    db, first, second = _make_db(tmp_path)
+    logged_payloads = []
+    init_kwargs = {}
+
+    class FakeRun:
+        def __init__(self):
+            self.defined = []
+            self.summary = {}
+            self.finished = False
+
+        def define_metric(self, *args, **kwargs):
+            self.defined.append((args, kwargs))
+
+        def log(self, payload):
+            logged_payloads.append(payload)
+
+        def finish(self):
+            self.finished = True
+
+    class FakeTable:
+        def __init__(self, columns, data):
+            self.columns = columns
+            self.data = data
+
+    fake_run = FakeRun()
+    fake_wandb = ModuleType("wandb")
+
+    def fake_init(**kwargs):
+        init_kwargs.update(kwargs)
+        return fake_run
+
+    fake_wandb.init = fake_init
+    fake_wandb.Table = FakeTable
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    evo_config = EvolutionConfig(
+        wandb_project="project",
+        wandb_name="name",
+        wandb_mode="offline",
+    )
+    logger = ShinkaWandbLogger(enabled=True)
+    logger.start(
+        evo_config=evo_config,
+        db_config=SimpleNamespace(),
+        job_config=SimpleNamespace(),
+        results_dir=tmp_path,
+    )
+    logger.log_program(first)
+    logger.log_program(first)
+    logger.log_program(second)
+    logger.log_final(
+        db=db,
+        total_proposals_generated=2,
+        total_api_cost=0.5,
+    )
+    logger.finish()
+
+    assert init_kwargs["project"] == "project"
+    assert init_kwargs["mode"] == "offline"
+    assert init_kwargs["id"]
+    assert init_kwargs["resume"] == "allow"
+    assert (tmp_path / ".wandb_run_id").read_text(encoding="utf-8").strip() == (
+        init_kwargs["id"]
+    )
+    assert init_kwargs["config"]["evolution"]["wandb_run_id"] == init_kwargs["id"]
+    assert fake_run.finished is True
+    assert [payload[INDIVIDUAL_SCORE_METRIC] for payload in logged_payloads[:2]] == [
+        1.0,
+        0.25,
+    ]
+    assert len(logged_payloads) == 3
+    table = logged_payloads[-1][PROGRAM_TABLE_KEY]
+    assert isinstance(table, FakeTable)
+    assert table.columns == PROGRAM_TABLE_COLUMNS
+    assert len(table.data) == 2
+    assert "code" not in table.columns
+    assert "embedding" not in table.columns
+    assert fake_run.summary["run/best_score"] == 1.0
+    score_definition = next(
+        item for item in fake_run.defined if item[0] == (INDIVIDUAL_SCORE_METRIC,)
+    )
+    assert score_definition[1] == {"step_metric": "generation"}
+
+    first_run_id = init_kwargs["id"]
+    resumed_config = EvolutionConfig(
+        wandb_project="project",
+        wandb_mode="offline",
+        wandb_resume="must",
+    )
+    resumed_logger = ShinkaWandbLogger(enabled=True)
+    resumed_logger.start(
+        evo_config=resumed_config,
+        db_config=SimpleNamespace(),
+        job_config=SimpleNamespace(),
+        results_dir=tmp_path,
+    )
+
+    assert init_kwargs["id"] == first_run_id
+    assert init_kwargs["resume"] == "must"
+    assert resumed_config.wandb_run_id == first_run_id
+    resumed_logger.finish()
+
+
+@pytest.mark.requires_secrets
+def test_wandb_online_logging_with_authenticated_sdk(tmp_path, monkeypatch, caplog):
+    import wandb
+
+    db, first, second = _make_db(tmp_path)
+    monkeypatch.delenv("WANDB_MODE", raising=False)
+    wandb.login(verify=True)
+
+    config = EvolutionConfig(
+        enable_wandb_logging=True,
+        wandb_project="shinka-evolve-integration",
+        wandb_name=f"authenticated-smoke-{tmp_path.name}",
+        wandb_mode="online",
+        wandb_tags=["integration-test"],
+    )
+    logger = ShinkaWandbLogger(enabled=True)
+    logger.start(
+        evo_config=config,
+        db_config=DatabaseConfig(db_path=str(tmp_path / "programs.sqlite")),
+        job_config=SimpleNamespace(),
+        results_dir=tmp_path,
+    )
+
+    try:
+        assert logger.active, caplog.text
+        logger.log_program(first)
+        logger.log_program(second)
+        logger.log_final(
+            db=db,
+            total_proposals_generated=2,
+            total_api_cost=0.5,
+        )
+    finally:
+        logger.finish()
+
+    integration_warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "shinka.wandb_logging" and record.levelno >= 30
+    ]
+    assert integration_warnings == []


### PR DESCRIPTION
## Summary

- add optional Weights & Biases logging alongside the existing SQLite and WebUI paths
- log every evaluated individual's score against its generation, plus compact evaluation, timing, and cost metrics

## Why

For researchers who prefer metrics reporting online on Weights & Biases.

## Configuration and behavior

W&B logging is disabled by default and is enabled with `evo.enable_wandb_logging=true`. The integration is best-effort: W&B failures emit warnings without interrupting evolution or replacing existing logging.

Online runs use `wandb login` or `WANDB_API_KEY`. The secret-backed integration workflow installs the optional `wandb` extra and expects the SakanaAI repository to configure a `WANDB_API_KEY` Actions secret.

## Testing

- `uv run ruff check tests --exclude tests/file.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
- `uv run --with pytest-cov pytest -q -m "not requires_secrets" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml` — 724 passed, 1 deselected
- `uv run pytest -q -m "requires_secrets"` — 1 passed, 724 deselected against the authenticated W&B service

## Compatibility

- no changes to SQLite or WebUI logging
- no W&B dependency unless the optional `wandb` extra is installed