### PR TITLE
fix: security hardening from deep review (server, XSS, launch)

### DIFF
--- a/shinka/core/wrap_eval.py
+++ b/shinka/core/wrap_eval.py
@@ -25,7 +25,14 @@ DEFAULT_METRICS_ON_ERROR = {
 
 
 def load_program(program_path: str) -> Any:
-    """Loads a Python module dynamically from a given file path."""
+    """Loads a Python module dynamically from a given file path.
+
+    Security note: ``program_path`` points at LLM-generated code, and importing
+    it executes it in-process with no sandbox. Run evolution only with models
+    and initial programs you trust, or use an isolated eval (Docker/Slurm). The
+    local launcher honours ``SHINKA_STRIP_EVAL_SECRETS=1`` to withhold provider
+    credentials from the eval subprocess (see shinka.launch.local).
+    """
     spec = importlib.util.spec_from_file_location("program", program_path)
     if spec is None:
         raise ImportError(f"Could not load spec for module at {program_path}")

--- a/shinka/env.py
+++ b/shinka/env.py
@@ -23,6 +23,10 @@ def load_shinka_dotenv(
         env_paths.append(launch_env)
 
     for env_path in env_paths:
-        load_dotenv(dotenv_path=env_path, override=True)
+        # The package-dir .env fills gaps only (override=False) so a stray or
+        # shipped .env cannot silently shadow the operator's real environment.
+        # The launch-dir .env keeps its intended precedence (override=True).
+        override = env_path == launch_env
+        load_dotenv(dotenv_path=env_path, override=override)
 
     return tuple(env_paths)

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -10,6 +10,48 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Environment variable name-parts that identify provider credentials. A local
+# evaluation runs LLM-generated program code with no isolation, inheriting the
+# parent environment; when SHINKA_STRIP_EVAL_SECRETS is truthy these are removed
+# so an adversarial/prompt-injected program cannot read the operator's keys.
+_SECRET_NAME_MARKERS = (
+    "API_KEY",
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "OPENAI",
+    "ANTHROPIC",
+    "GEMINI",
+    "DEEPSEEK",
+    "AZURE",
+    "AWS_",
+    "HUGGINGFACE",
+    "WANDB",
+    "XAI",
+    "GROQ",
+    "MISTRAL",
+    "COHERE",
+    "OPENROUTER",
+)
+
+
+def _should_strip_eval_secrets() -> bool:
+    return os.environ.get("SHINKA_STRIP_EVAL_SECRETS", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _strip_provider_secrets(env: Dict[str, str]) -> Dict[str, str]:
+    """Drop provider-credential variables from an environment mapping."""
+    return {
+        key: value
+        for key, value in env.items()
+        if not any(marker in key.upper() for marker in _SECRET_NAME_MARKERS)
+    }
+
 
 class ProcessWithLogging:
     """Wrapper for subprocess.Popen with real-time logging capabilities."""
@@ -113,8 +155,14 @@ def submit(
     stdout_path = log_dir_path / "job_log.out"
     stderr_path = log_dir_path / "job_log.err"
 
-    # Set up environment to force unbuffered output
+    # Set up environment to force unbuffered output. The evaluated program is
+    # LLM-generated and runs unsandboxed here, inheriting this environment; set
+    # SHINKA_STRIP_EVAL_SECRETS=1 to withhold provider credentials from it.
+    # Explicit env_overrides are applied AFTER stripping so an eval that needs a
+    # key (e.g. an LLM judge) can still be given one deliberately.
     env = os.environ.copy()
+    if _should_strip_eval_secrets():
+        env = _strip_provider_secrets(env)
     env["PYTHONUNBUFFERED"] = "1"  # Force Python to be unbuffered
     env["PYTHONIOENCODING"] = "utf-8"  # Ensure proper encoding
     if env_overrides:

--- a/shinka/launch/slurm.py
+++ b/shinka/launch/slurm.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import shlex
 import subprocess
 import tempfile
 import time
@@ -17,14 +18,18 @@ def _render_env_exports(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as newline-joined ``export K=V`` lines for a script."""
     if not eval_env:
         return ""
-    return "\n".join(f"export {k}={v}" for k, v in eval_env.items())
+    # shlex.quote the value so a value containing spaces/;/$(...) cannot inject
+    # extra shell commands when this string is spliced into a bash script.
+    return "\n".join(f"export {k}={shlex.quote(str(v))}" for k, v in eval_env.items())
 
 
 def _render_env_docker_flags(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as space-joined ``-e K=V`` flags for ``docker run``."""
     if not eval_env:
         return ""
-    return " ".join(f"-e {k}={v}" for k, v in eval_env.items())
+    return " ".join(
+        f"-e {shlex.quote(f'{k}={v}')}" for k, v in eval_env.items()
+    )
 
 
 # Configuration for Docker image caching
@@ -480,7 +485,9 @@ def submit_local_conda(
         activate_script=activate_script,
         separator="; ",
     )
-    env_exports = "; ".join(f"export {k}={v}" for k, v in (eval_env or {}).items())
+    env_exports = "; ".join(
+        f"export {k}={shlex.quote(str(v))}" for k, v in (eval_env or {}).items()
+    )
     full_cmd = "; ".join(
         segment
         for segment in [

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -1572,10 +1572,17 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 ) as pdf_file:
                     pdf_file_path = pdf_file.name
 
-                # Try wkhtmltopdf directly
+                # Try wkhtmltopdf directly. Disable JavaScript and local-file /
+                # external access: the HTML is built from LLM-generated meta
+                # content, so a payload like <img src="file:///etc/passwd"> or a
+                # remote fetch could otherwise exfiltrate local files / SSRF via
+                # wkhtmltopdf's WebKit engine.
                 result = subprocess.run(
                     [
                         "wkhtmltopdf",
+                        "--disable-javascript",
+                        "--disable-local-file-access",
+                        "--disable-external-links",
                         "--page-size",
                         "A4",
                         "--margin-top",

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -36,13 +36,23 @@ CACHE_EXPIRATION_SECONDS = 5  # Cache data for 5 seconds
 db_cache: Dict[str, Tuple[float, Any]] = {}
 
 
+class PathValidationError(ValueError):
+    """Raised when a user-supplied path escapes the served search root."""
+
+
 class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, search_root=None, **kwargs):
+    def __init__(self, *args, search_root=None, allowed_hosts=..., **kwargs):
         self.search_root = search_root or os.getcwd()
+        # Attributes must be set before super().__init__, which handles the
+        # request immediately. `...` means "keep the class default allowlist".
+        if allowed_hosts is not ...:
+            self.allowed_hosts = allowed_hosts
         super().__init__(*args, **kwargs)
 
     def end_headers(self):
         """Disable browser caching for local HTML shells to avoid stale embedded JS."""
+        # Prevent MIME sniffing on every response (DB-sourced content is served).
+        self.send_header("X-Content-Type-Options", "nosniff")
         parsed_url = urllib.parse.urlparse(self.path)
         if parsed_url.path in ("/", "/index.html", "/viz_tree.html", "/compare.html"):
             self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
@@ -271,7 +281,35 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         finally:
             conn.close()
 
+    # Host header values allowed when the server is bound to loopback. Overwritten
+    # per-instance via the handler factory when an explicit external host is used.
+    allowed_hosts = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+    def _host_allowed(self) -> bool:
+        """Reject Host headers outside the allowlist (DNS-rebinding defense)."""
+        if self.allowed_hosts is None:
+            return True  # Explicit external bind: operator opted out of the check.
+        host_header = self.headers.get("Host", "")
+        hostname = host_header.rsplit(":", 1)[0] if host_header else ""
+        return hostname in self.allowed_hosts
+
     def do_GET(self):
+        if not self._host_allowed():
+            self.send_error(403, "Host not allowed")
+            return None
+        try:
+            return self._dispatch_get()
+        except PathValidationError as exc:
+            print(f"[SERVER] Rejected path-traversal attempt: {exc}")
+            self.send_error(403, "Access denied")
+            return None
+
+    def list_directory(self, path):
+        """Never serve auto-generated directory listings."""
+        self.send_error(403, "Directory listing is disabled")
+        return None
+
+    def _dispatch_get(self):
         print(f"\n[SERVER] Received GET request for: {self.path}")
         parsed_url = urllib.parse.urlparse(self.path)
         path = parsed_url.path
@@ -425,9 +463,33 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.send_json_response(db_files)
         print(f"[SERVER] Served DB list with {len(db_files)} entries, sorted by date.")
 
+    def _resolve_within_root(self, relative_path: str) -> str:
+        """Resolve a user-supplied path under search_root, rejecting escapes.
+
+        Returns the canonical absolute path if it is contained within
+        search_root; raises PathValidationError otherwise. Absolute inputs and
+        ``..`` traversal both fail the containment check, and symlinks are
+        resolved (realpath) before checking so an in-root symlink pointing
+        outside cannot be used to escape.
+        """
+        root = os.path.realpath(self.search_root)
+        candidate = os.path.realpath(os.path.join(root, relative_path))
+        try:
+            contained = os.path.commonpath([root, candidate]) == root
+        except ValueError:
+            # Different drives / mixed absolute-relative: treat as an escape.
+            contained = False
+        if not contained:
+            raise PathValidationError(f"Path escapes search root: {relative_path!r}")
+        return candidate
+
     def _get_actual_db_path(self, db_path: str) -> str:
-        """Convert db_path to the actual file path (now a no-op since path is not modified)."""
-        return db_path
+        """Validate db_path stays within search_root; return its absolute path.
+
+        Handlers pass the result to ``os.path.join(self.search_root, ...)``,
+        which is a no-op on the absolute path returned here.
+        """
+        return self._resolve_within_root(db_path)
 
     def handle_get_programs(self, db_path: str):
         """Fetch all programs from a given database file."""
@@ -984,29 +1046,33 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         parsed_url = urllib.parse.urlparse(self.path)
         rel_path = urllib.parse.unquote(parsed_url.path[11:])  # Remove /plot_file/
 
-        abs_path = os.path.join(self.search_root, rel_path)
-        print(f"[SERVER] Serving plot file: {abs_path}")
-
-        if not os.path.exists(abs_path):
-            self.send_error(404, f"Plot file not found: {rel_path}")
-            return
-
-        # Security check: ensure the path is within search_root
-        abs_path = os.path.abspath(abs_path)
-        abs_search_root = os.path.abspath(self.search_root)
-        if not abs_path.startswith(abs_search_root):
-            self.send_error(403, "Access denied")
-            return
-
-        # Determine content type
-        ext = os.path.splitext(abs_path)[1].lower()
+        # Restrict to image files, and containment-check BEFORE touching disk so
+        # out-of-root paths can't be probed for existence (403 vs 404 leak) and
+        # symlinks pointing outside the root are rejected (realpath + commonpath).
         content_types = {
             ".png": "image/png",
             ".gif": "image/gif",
             ".jpg": "image/jpeg",
             ".jpeg": "image/jpeg",
         }
-        content_type = content_types.get(ext, "application/octet-stream")
+        ext = os.path.splitext(rel_path)[1].lower()
+        if ext not in content_types:
+            self.send_error(403, "Access denied")
+            return
+        content_type = content_types[ext]
+
+        try:
+            abs_path = self._resolve_within_root(rel_path)
+        except PathValidationError as exc:
+            print(f"[SERVER] Rejected plot-file traversal: {exc}")
+            self.send_error(403, "Access denied")
+            return
+
+        print(f"[SERVER] Serving plot file: {abs_path}")
+
+        if not os.path.isfile(abs_path):
+            self.send_error(404, f"Plot file not found: {rel_path}")
+            return
 
         try:
             with open(abs_path, "rb") as f:
@@ -1678,7 +1744,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         payload = json.dumps(clean_data, default=self._json_encoder).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        # No "Access-Control-Allow-Origin: *": the UI is served same-origin, and
+        # a wildcard would let any site the operator visits read the full DB.
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
@@ -1708,17 +1775,36 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
-def create_handler_factory(search_root):
+def create_handler_factory(search_root, allowed_hosts=...):
     """Create a handler factory that passes the search root to handler."""
 
     def handler_factory(*args, **kwargs):
-        return DatabaseRequestHandler(*args, search_root=search_root, **kwargs)
+        return DatabaseRequestHandler(
+            *args,
+            search_root=search_root,
+            allowed_hosts=allowed_hosts,
+            **kwargs,
+        )
 
     return handler_factory
 
 
-def start_server(port: int, search_root: str, db_path: Optional[str] = None):
-    """Start the HTTP server."""
+def _is_loopback_host(host: str) -> bool:
+    return host in ("127.0.0.1", "localhost", "::1", "")
+
+
+def start_server(
+    port: int,
+    search_root: str,
+    db_path: Optional[str] = None,
+    host: str = "127.0.0.1",
+):
+    """Start the HTTP server.
+
+    Binds to 127.0.0.1 by default so the evolution database is not exposed to
+    the local network. Pass an explicit ``host`` (e.g. "0.0.0.0") to expose it,
+    which also relaxes the DNS-rebinding Host-header check.
+    """
     # Change to the webui directory inside the shinka package to serve static files
     webui_dir = os.path.dirname(__file__)
     webui_dir = os.path.abspath(webui_dir)
@@ -1730,15 +1816,24 @@ def start_server(port: int, search_root: str, db_path: Optional[str] = None):
     print(f"[DEBUG] Server root directory: {webui_dir}")
     print(f"[DEBUG] Search root directory: {search_root}")
 
-    # Create handler factory with search root
-    handler_factory = create_handler_factory(search_root)
+    # On a loopback bind, enforce the Host-header allowlist (anti DNS-rebinding).
+    # On an explicit external bind the operator has opted in, so disable it.
+    allowed_hosts = ... if _is_loopback_host(host) else None
+    handler_factory = create_handler_factory(search_root, allowed_hosts=allowed_hosts)
 
-    # Reuse the socket so you can restart quickly
-    class ReusableTCPServer(socketserver.TCPServer):
+    # Reuse the socket so you can restart quickly; threaded so one slow request
+    # (e.g. PDF export) doesn't freeze the whole UI.
+    class ReusableTCPServer(socketserver.ThreadingTCPServer):
         allow_reuse_address = True
+        daemon_threads = True
 
-    with ReusableTCPServer(("", port), handler_factory) as httpd:
-        msg = f"\n[*] Serving http://0.0.0.0:{port}  (Ctrl+C to stop)"
+    with ReusableTCPServer((host, port), handler_factory) as httpd:
+        msg = f"\n[*] Serving http://{host}:{port}  (Ctrl+C to stop)"
+        if not _is_loopback_host(host):
+            msg += (
+                "\n[!] Bound to a non-loopback address: the evolution database "
+                "is reachable from the network with no authentication."
+            )
         print(msg)
         httpd.serve_forever()
 
@@ -1775,6 +1870,15 @@ def main():
         default=None,
         help="Path to a specific database file to serve.",
     )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Address to bind (default: 127.0.0.1, local only). Use 0.0.0.0 to "
+            "expose on the network — this serves the database with no auth."
+        ),
+    )
     args = parser.parse_args()
 
     # Resolve the root directory to an absolute path
@@ -1789,7 +1893,7 @@ def main():
     # Kick off the HTTP server in a daemon thread.
     server_thread = threading.Thread(
         target=start_server,
-        args=(args.port, search_root, args.db),
+        args=(args.port, search_root, args.db, args.host),
         daemon=True,
     )
     server_thread.start()

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -2071,17 +2071,22 @@
                 </div>
             </div>
             
-    <!-- Place all external script tags here, before the main inline script -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
-    <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/diff@5.1.0/dist/diff.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/languages/python.min.js"></script>
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <!-- Place all external script tags here, before the main inline script.
+         All are pinned to exact versions with Subresource Integrity (SRI)
+         hashes and crossorigin=anonymous, so a CDN compromise or a silent
+         version bump cannot inject arbitrary JS into the page (which handles
+         the local evolution database). DOMPurify sanitizes rendered markdown. -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js" integrity="sha384-9MhbyIRcBVQiiC7FSd7T38oJNj2Zh+EfxS7/vjhBi4OOT78NlHSnzM31EZRWR1LZ" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7.8.5/dist/d3.min.js" integrity="sha384-su5kReKyYlIFrI62mbQRKXHzFobMa7BHp1cK6julLPbnYcCW9NIZKJiTODjLPeDh" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js" integrity="sha384-zbcZAIxlvJtNE3Dp5nxLXdXtXyxwOdnILY1TDPVmKFhl4r4nSUG1r8bcFXGVa4Te" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js" integrity="sha384-vdScihEZCfbPnBQf+lc7LgXUdJVYyhC3yWHUW5C5P5GpHRqVnaM6HJELJxT6IqwM" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2pdf.js@0.10.1/dist/html2pdf.bundle.min.js" integrity="sha384-Yv5O+t3uE3hunW8uyrbpPW3iw6/5/Y7HitWJBLgqfMoA36NogMmy+8wWZMpn3HWc" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js" integrity="sha384-JcnsjUPPylna1s1fvi1u12X5qjY5OL56iySh75FdtrwhO/SWXgMjoVqcKyIIWOLk" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.8.0/highlight.min.js" integrity="sha384-g4mRvs7AO0/Ol5LxcGyz4Doe21pVhGNnC3EQw5shw+z+aXDN86HqUdwXWO+Gz2zI" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/diff@5.1.0/dist/diff.min.js" integrity="sha384-kfJm1UHujU89hXr0VHT0u0t4lqavqaoomP6wix8D9fhzTeFvC9DYyaT36//Qd144" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets@11.8.0/languages/python.min.js" integrity="sha384-0EkvOvPJDe7t47eSkiz1pp/B1WWuqLqcrGPJKePN+rZ3d50pFtcIqsBUgCMLUoMu" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/plotly.js@2.27.1/dist/plotly.min.js" integrity="sha384-CfdUumYc8S2dvFy54M+E85yISHkahaJKY7Z8fFtHiyO/mLGSmDaGwiA4VfQufhNR" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js" integrity="sha384-+mbV2IY1Zk/X1p/nWllGySJSUN8uMs+gUAN10Or95UBH0fpj6GfKgPmgC5EXieXG" crossorigin="anonymous"></script>
 
     <!-- Add our script after all external dependencies -->
     <script>
@@ -2865,11 +2870,11 @@ ${'='.repeat(80)}
                     if (!inSection) {
                         // Content before first section - treat as introduction
                         html += `<div style="margin-bottom: 20px; padding: 15px; background-color: #f9f9f9; border-radius: 5px;">`;
-                        html += marked.parse(section);
+                        html += renderMarkdown(section);
                         html += `</div>`;
                     } else {
                         // Content within a section - just use regular markdown parsing
-                        html += marked.parse(section);
+                        html += renderMarkdown(section);
                     }
                 }
             }
@@ -3070,10 +3075,10 @@ ${'='.repeat(80)}
                     sections.individualPrograms = formatProgramSummaries(sectionContent.trim());
                 } else if (sectionTitle === 'GLOBAL INSIGHTS SCRATCHPAD') {
                     rawSections.globalInsights = sectionContent.trim();
-                    sections.globalInsights = marked.parse(sectionContent.trim());
+                    sections.globalInsights = renderMarkdown(sectionContent.trim());
                 } else if (sectionTitle === 'META RECOMMENDATIONS') {
                     rawSections.metaRecommendations = sectionContent.trim();
-                    sections.metaRecommendations = marked.parse(sectionContent.trim());
+                    sections.metaRecommendations = renderMarkdown(sectionContent.trim());
                 }
             }
             
@@ -3131,7 +3136,7 @@ ${'='.repeat(80)}
         function generateSimpleDiffHTML(oldText, newText) {
             if (typeof Diff === 'undefined') {
                 console.warn("[WARN] Diff library not loaded, showing markdown");
-                return marked.parse(newText);
+                return renderMarkdown(newText);
             }
             
             try {
@@ -3145,11 +3150,11 @@ ${'='.repeat(80)}
                         if (line.trim() === '' && index === lines.length - 1) return; // Skip final empty line
                         
                         if (part.added) {
-                            result += `<div class="diff-added" style="display: block; margin: 2px 0;">${marked.parseInline(line)}</div>\n`;
+                            result += `<div class="diff-added" style="display: block; margin: 2px 0;">${renderMarkdownInline(line)}</div>\n`;
                         } else if (part.removed) {
-                            result += `<div class="diff-removed" style="display: block; margin: 2px 0;">${marked.parseInline(line)}</div>\n`;
+                            result += `<div class="diff-removed" style="display: block; margin: 2px 0;">${renderMarkdownInline(line)}</div>\n`;
                         } else {
-                            result += `${marked.parseInline(line)}<br>\n`;
+                            result += `${renderMarkdownInline(line)}<br>\n`;
                         }
                     });
                 });
@@ -3157,7 +3162,7 @@ ${'='.repeat(80)}
                 return result;
             } catch (e) {
                 console.error("[ERROR] Failed to generate simple diff:", e);
-                return marked.parse(newText);
+                return renderMarkdown(newText);
             }
         }
         
@@ -3202,11 +3207,36 @@ ${'='.repeat(80)}
         
         // Helper function to escape HTML
         function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            if (text === null || text === undefined) return '';
+            return String(text)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
         }
-        
+
+        // Render LLM/DB-sourced markdown safely. The content is attacker-
+        // influenced (program code, thoughts, meta text come from model output),
+        // so marked's HTML output is passed through DOMPurify before it reaches
+        // innerHTML. If DOMPurify failed to load, fall back to escaped plain
+        // text rather than emitting unsanitized HTML.
+        function renderMarkdown(text) {
+            const src = (text === null || text === undefined) ? '' : String(text);
+            if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+                return escapeHtml(src);
+            }
+            return DOMPurify.sanitize(marked.parse(src));
+        }
+
+        function renderMarkdownInline(text) {
+            const src = (text === null || text === undefined) ? '' : String(text);
+            if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+                return escapeHtml(src);
+            }
+            return DOMPurify.sanitize(marked.parseInline(src));
+        }
+
         // Helper function to show meta error message
         function showMetaError(message) {
             const metaContent = document.getElementById('meta-content');
@@ -4768,7 +4798,7 @@ console.error("[DEBUG] Error in processData:", error);
                         
                         if (d.data.isUnifiedRoot) {
                             tooltip.html(`
-                                <strong style="color: #9b59b6; font-size: 13px;">⭐ ${patchName}</strong><br>
+                                <strong style="color: #9b59b6; font-size: 13px;">⭐ ${escapeHtml(patchName)}</strong><br>
                                 <strong>Type:</strong> Unified Root<br>
                                 <strong>Score:</strong> ${score}<br>
                                 <em>Common origin for all islands</em>
@@ -4776,14 +4806,14 @@ console.error("[DEBUG] Error in processData:", error);
                         } else {
                             if (isFailedProposalNode(d.data)) {
                                 tooltip.html(`
-                                    <strong style="color: #ffb3b3; font-size: 13px;">${patchName}</strong><br>
+                                    <strong style="color: #ffb3b3; font-size: 13px;">${escapeHtml(patchName)}</strong><br>
                                     <strong>Status:</strong> Failed Proposal<br>
                                     <strong>Failure:</strong> ${escapeHtml(d.data.metadata.failure_class || d.data.metadata.failure_stage || 'failed_proposal')}<br>
                                     <strong>Reason:</strong> ${escapeHtml(d.data.metadata.failure_reason || d.data.text_feedback || 'N/A')}
                                 `);
                             } else {
                             tooltip.html(`
-                                <strong style="color: #58a6ff; font-size: 13px;">${patchName}</strong><br>
+                                <strong style="color: #58a6ff; font-size: 13px;">${escapeHtml(patchName)}</strong><br>
                                 <strong>Score:</strong> ${score}<br>
                                 <strong>Type:</strong> ${patchType}<br>
                                 <strong>Island:</strong> ${islandIdx}<br>
@@ -5688,13 +5718,14 @@ console.error("[DEBUG] Error in processData:", error);
             const agentName = data.metadata.patch_name || data.agent_name || "unnamed_agent";
             const score = data.combined_score;
             
-            // Update node summary
+            // Update node summary. agentName/id/parent_id/error are DB-sourced
+            // (patch names come from LLM output), so escape before innerHTML.
             document.getElementById("node-summary").innerHTML = `
-                <h3>${agentName} (Gen ${data.generation})</h3>
-                <p><strong>ID:</strong> <span style="font-family: monospace;">${data.id}</span></p>
-                <p><strong>Parent ID:</strong> <span style="font-family: monospace;">${data.parent_id || 'None'}</span></p>
+                <h3>${escapeHtml(agentName)} (Gen ${escapeHtml(data.generation)})</h3>
+                <p><strong>ID:</strong> <span style="font-family: monospace;">${escapeHtml(data.id)}</span></p>
+                <p><strong>Parent ID:</strong> <span style="font-family: monospace;">${escapeHtml(data.parent_id || 'None')}</span></p>
                 <p><strong>Score:</strong> <span class="${getScoreClass(score)}">${formatScore(score)}</span></p>
-                ${data.error ? `<p><strong>Error:</strong> <span class="metric-bad">${data.error}</span></p>` : ''}
+                ${data.error ? `<p><strong>Error:</strong> <span class="metric-bad">${escapeHtml(data.error)}</span></p>` : ''}
             `;
             
 
@@ -5949,8 +5980,8 @@ console.error("[DEBUG] Error in processData:", error);
                     <div class="details-section">
                         <h5>Patch Information</h5>
                         <div class="details-section-content">
-                        <p><strong>Patch Type:</strong> ${patchType}</p>
-                        <p><strong>Patch Name:</strong> ${patchName}</p>
+                        <p><strong>Patch Type:</strong> ${escapeHtml(patchType)}</p>
+                        <p><strong>Patch Name:</strong> ${escapeHtml(patchName)}</p>
                             ${patchDescriptionHtml}
                         </div>
                     </div>
@@ -6006,7 +6037,7 @@ console.error("[DEBUG] Error in processData:", error);
                 longContentHtml += `
                     <div class="details-section" style="margin-top: 15px;">
                         <h5>Thought Process</h5>
-                        <div class="markdown">${marked.parse(data.metadata.thought)}</div>
+                        <div class="markdown">${renderMarkdown(data.metadata.thought)}</div>
                     </div>
                 `;
             }
@@ -6192,8 +6223,8 @@ console.error("[DEBUG] Error in processData:", error);
 
         // Helper function to escape HTML content to prevent XSS and formatting issues
         function escapeHtml(text) {
-            if (!text) return '';
-            return text
+            if (text === null || text === undefined) return '';
+            return String(text)
                 .replace(/&/g, "&amp;")
                 .replace(/</g, "&lt;")
                 .replace(/>/g, "&gt;")
@@ -8174,8 +8205,8 @@ console.error("[DEBUG] Error in processData:", error);
                     <td>${prog.generation}</td>
                     <td style="text-align: center; color: ${prog.in_archive ? '#28a745' : '#6c757d'}; font-weight: bold;">${archiveStatus}</td>
                     <td>${escapeHtml(statusLabel)}</td>
-                    <td>${patchName}</td>
-                    <td>${prog.metadata?.patch_type || 'N/A'}</td>
+                    <td>${escapeHtml(patchName)}</td>
+                    <td>${escapeHtml(prog.metadata?.patch_type || 'N/A')}</td>
                     <td>${islandIdx}</td>
                     <td>${scoreDisplay}</td>
                     <td>${apiCost}</td>
@@ -8183,7 +8214,7 @@ console.error("[DEBUG] Error in processData:", error);
                     <td>${noveltyAttempt}</td>
                     <td>${resampleAttempt}</td>
                     <td>${patchAttempt}</td>
-                    <td>${model}</td>
+                    <td>${escapeHtml(model)}</td>
                 `;
                 tableBody.appendChild(row);
             });
@@ -10404,14 +10435,14 @@ console.error("[DEBUG] Error in processData:", error);
                     
                     if (isFailedProposalNode(d.data)) {
                         tooltip.html(`
-                            <strong style="color: #ffb3b3; font-size: 13px;">${patchName}</strong><br>
+                            <strong style="color: #ffb3b3; font-size: 13px;">${escapeHtml(patchName)}</strong><br>
                             <strong>Status:</strong> Failed Proposal<br>
                             <strong>Failure:</strong> ${escapeHtml(d.data.metadata.failure_class || d.data.metadata.failure_stage || 'failed_proposal')}<br>
                             <strong>Reason:</strong> ${escapeHtml(d.data.metadata.failure_reason || d.data.text_feedback || 'N/A')}
                         `);
                     } else {
                         tooltip.html(`
-                            <strong style="color: #58a6ff; font-size: 13px;">${patchName}</strong><br>
+                            <strong style="color: #58a6ff; font-size: 13px;">${escapeHtml(patchName)}</strong><br>
                             <strong>Score:</strong> ${score}<br>
                             <strong>Type:</strong> ${patchType}<br>
                             <strong>Island:</strong> ${islandIdx}
@@ -17653,11 +17684,11 @@ console.error("[DEBUG] Error in processData:", error);
                         <div style="font-size: 10px; color: #888; font-family: monospace;">
                             ID: ${promptData.id.substring(0, 24)}...
                         </div>
-                        ${promptData.name ? `<div style="font-size: 13px; font-weight: 600; color: #333; margin-top: 8px;">${promptData.name}</div>` : ''}
+                        ${promptData.name ? `<div style="font-size: 13px; font-weight: 600; color: #333; margin-top: 8px;">${escapeHtml(promptData.name)}</div>` : ''}
                         ${promptData.description ? `
                             <div id="prompt-description-box" style="margin-top: 8px; background: #f8f9fa; border: 1px solid #e0e0e0; border-radius: 4px; overflow: hidden;">
                                 <div id="prompt-description-content" style="font-size: 11px; color: #666; line-height: 1.4; padding: 8px; max-height: 80px; overflow: hidden; transition: max-height 0.3s ease;">
-                                    ${promptData.description}
+                                    ${escapeHtml(promptData.description)}
                                 </div>
                                 <div id="prompt-description-toggle" onclick="togglePromptDescription()" style="display: none; font-size: 10px; color: #8e44ad; padding: 4px 8px; cursor: pointer; text-align: center; border-top: 1px solid #e0e0e0; background: #f0f0f0; user-select: none;">
                                     ▼ Show more
@@ -18004,9 +18035,13 @@ console.error("[DEBUG] Error in processData:", error);
         }
 
         function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            if (text === null || text === undefined) return '';
+            return String(text)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
         }
 
     </script>

--- a/tests/test_dotenv_loading.py
+++ b/tests/test_dotenv_loading.py
@@ -61,3 +61,23 @@ def test_load_shinka_dotenv_prefers_launch_directory_over_package_env(
     load_shinka_dotenv(package_root=package_root, cwd=launch_dir)
 
     assert os.getenv(env_key) == "from-launch-dir"
+
+
+def test_package_env_does_not_shadow_real_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A package-dir .env must not override a variable set in the real env."""
+    from shinka.env import load_shinka_dotenv
+
+    env_key = "SHINKA_TEST_SHELL_PRECEDENCE_KEY"
+    package_root = tmp_path / "package-root"
+    launch_dir = tmp_path / "launch-dir"
+    package_root.mkdir()
+    launch_dir.mkdir()
+    (package_root / ".env").write_text(f"{env_key}=from-package\n", encoding="utf-8")
+    # No launch-dir .env; the real environment already sets the key.
+    monkeypatch.setenv(env_key, "from-shell")
+
+    load_shinka_dotenv(package_root=package_root, cwd=launch_dir)
+
+    assert os.getenv(env_key) == "from-shell"

--- a/tests/test_launch_job_status.py
+++ b/tests/test_launch_job_status.py
@@ -105,3 +105,39 @@ def test_kill_terminates_child_process_group(tmp_path):
         time.sleep(0.05)
     else:
         pytest.fail("grandchild survived process-group kill")
+
+
+def test_env_exports_shell_quote_injection():
+    """A malicious eval_env value must be shell-quoted, not spliced as commands."""
+    from shinka.launch.slurm import _render_env_exports, _render_env_docker_flags
+
+    exports = _render_env_exports({"FOO": "a; rm -rf /tmp/x"})
+    # The dangerous ';' is inside a single-quoted value, not a command separator.
+    assert exports == "export FOO='a; rm -rf /tmp/x'"
+
+    flags = _render_env_docker_flags({"BAR": "b $(whoami)"})
+    assert flags == "-e 'BAR=b $(whoami)'"
+
+
+def test_strip_provider_secrets_opt_in(monkeypatch):
+    """SHINKA_STRIP_EVAL_SECRETS removes provider credentials from eval env."""
+    from shinka.launch.local import (
+        _strip_provider_secrets,
+        _should_strip_eval_secrets,
+    )
+
+    env = {
+        "PATH": "/usr/bin",
+        "OPENAI_API_KEY": "sk-secret",
+        "ANTHROPIC_API_KEY": "sk-ant",
+        "AWS_SECRET_ACCESS_KEY": "aws",
+        "HF_TOKEN": "hf",
+        "CUDA_VISIBLE_DEVICES": "0",
+    }
+    stripped = _strip_provider_secrets(env)
+    assert stripped == {"PATH": "/usr/bin", "CUDA_VISIBLE_DEVICES": "0"}
+
+    monkeypatch.delenv("SHINKA_STRIP_EVAL_SECRETS", raising=False)
+    assert _should_strip_eval_secrets() is False
+    monkeypatch.setenv("SHINKA_STRIP_EVAL_SECRETS", "1")
+    assert _should_strip_eval_secrets() is True

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -1,0 +1,138 @@
+"""Security regression tests for the visualization server.
+
+Covers the path-traversal containment that gates every db_path/meta/plot handler,
+plus the DNS-rebinding Host check, absent CORS wildcard, nosniff, and disabled
+directory listing.
+"""
+
+import http.client
+import os
+import socketserver
+import threading
+
+import pytest
+
+from shinka.webui.visualization import (
+    DatabaseRequestHandler,
+    PathValidationError,
+    create_handler_factory,
+)
+
+
+def _handler(root):
+    # Build a handler without running the socket-bound __init__.
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.search_root = str(root)
+    return handler
+
+
+def test_resolve_accepts_path_within_root(tmp_path):
+    (tmp_path / "run").mkdir()
+    db = tmp_path / "run" / "programs.sqlite"
+    db.write_text("x")
+    handler = _handler(tmp_path)
+    assert handler._resolve_within_root("run/programs.sqlite") == os.path.realpath(
+        str(db)
+    )
+
+
+def test_resolve_rejects_absolute_path(tmp_path):
+    handler = _handler(tmp_path)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("/etc/passwd")
+
+
+def test_resolve_rejects_parent_traversal(tmp_path):
+    served = tmp_path / "served"
+    served.mkdir()
+    (tmp_path / "secret.db").write_text("secret")
+    handler = _handler(served)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("../secret.db")
+
+
+def test_resolve_rejects_symlink_escape(tmp_path):
+    served = tmp_path / "served"
+    served.mkdir()
+    outside = tmp_path / "outside.db"
+    outside.write_text("outside")
+    os.symlink(outside, served / "link.db")
+    handler = _handler(served)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("link.db")
+
+
+def test_resolve_rejects_sibling_prefix_dir(tmp_path):
+    # Root "<x>/served" must not allow reaching a sibling "<x>/served_bak".
+    served = tmp_path / "served"
+    served.mkdir()
+    sibling = tmp_path / "served_bak"
+    sibling.mkdir()
+    (sibling / "leak.db").write_text("leak")
+    handler = _handler(served)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("../served_bak/leak.db")
+
+
+class _Server:
+    """Direct ThreadingTCPServer for the handler (no start_server chdir)."""
+
+    def __init__(self, search_root):
+        self.httpd = socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0), create_handler_factory(str(search_root))
+        )
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def get(self, path, host=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        headers = {"Host": host} if host else {}
+        conn.request("GET", path, headers=headers)
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        return resp, body
+
+    def close(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture
+def server(tmp_path):
+    (tmp_path / "run").mkdir()
+    (tmp_path / "run" / "programs.sqlite").write_text("db")
+    srv = _Server(tmp_path)
+    yield srv
+    srv.close()
+
+
+def test_http_rejects_absolute_db_path(server):
+    resp, _ = server.get(
+        "/get_programs?db_path=/etc/passwd", host=f"127.0.0.1:{server.port}"
+    )
+    assert resp.status == 403
+
+
+def test_http_rejects_foreign_host_header(server):
+    # DNS-rebinding: a request whose Host is an attacker domain is refused.
+    resp, _ = server.get("/list_databases", host="evil.example.com")
+    assert resp.status == 403
+
+
+def test_http_json_has_no_cors_wildcard_and_sets_nosniff(server):
+    resp, _ = server.get("/list_databases", host=f"127.0.0.1:{server.port}")
+    assert resp.status == 200
+    assert resp.getheader("Access-Control-Allow-Origin") is None
+    assert resp.getheader("X-Content-Type-Options") == "nosniff"
+
+
+def test_list_directory_override_forbids(tmp_path):
+    # The override must refuse to render an auto-generated index unconditionally.
+    handler = object.__new__(DatabaseRequestHandler)
+    sent = {}
+    handler.send_error = lambda code, msg=None: sent.update(code=code, msg=msg)
+    result = handler.list_directory(str(tmp_path))
+    assert result is None
+    assert sent["code"] == 403


### PR DESCRIPTION
## Security hardening from deep review

Fixes the High/Medium security findings from the deep review (`docs/deepreview.md` §1), concentrated in the visualization server and web UI. New regression tests; full suite green; ruff/mypy pass.

**Stacked on `fix/correctness-concurrency`** (base branch of this PR) — review/merge that first.

### Visualization server (`shinka/webui/visualization.py`)
- **Bind 127.0.0.1 by default** (was `0.0.0.0`, network-reachable with no auth). External exposure is now an explicit `--host` opt-in that prints a no-auth warning. Threaded server so one slow request (PDF export) can't freeze the UI.
- **Path traversal** — every user-supplied `db_path`/meta/plot path is now validated against the search root with `realpath` + `commonpath` (rejecting absolute paths, `..`, and in-root symlinks that escape). Previously `_get_actual_db_path` was a no-op, so `?db_path=/abs/x.db` opened any SQLite DB or file on the host.
- **/plot_file/** containment-checks before touching disk (no 403-vs-404 existence leak) and restricts to image extensions.
- **CORS** — dropped the `Access-Control-Allow-Origin: *` wildcard (UI is same-origin) and added a **Host-header allowlist** so a DNS-rebinding page can't read the DB. `X-Content-Type-Options: nosniff` on all responses; directory listings disabled.
- **PDF export** — pass `--disable-javascript --disable-local-file-access --disable-external-links` to wkhtmltopdf, which renders LLM-generated meta HTML and would otherwise run JS / load `file://` (local-file exfiltration / SSRF).

### Web UI XSS + supply chain (`shinka/webui/viz_tree.html`)
- **Stored XSS** — DB content (patch names, thoughts, meta text, prompt descriptions) is attacker-influenced (LLM output). Consolidated the three divergent `escapeHtml` definitions into one that also escapes quotes (the live copy didn't), routed all markdown through `DOMPurify.sanitize(marked.parse(...))` with an escaped-plain-text fallback, and escaped the remaining raw DB-field `innerHTML`/d3-`.html()` interpolations.
- **SRI** — pinned every CDN script to an exact version with a Subresource Integrity hash + `crossorigin` (marked and plotly were unpinned), and added DOMPurify. Verified: the extracted inline script passes `node --check`.

### Launch (`shinka/launch/`)
- `shlex.quote` env values spliced into Slurm/conda/docker shell scripts (an `eval_env` value with shell metacharacters could otherwise inject commands).
- **Opt-in eval-secret stripping** — `SHINKA_STRIP_EVAL_SECRETS=1` (default off) withholds provider credentials from the local eval subprocess, which runs LLM-generated code unsandboxed and inherits the parent environment. Explicit `env_overrides` are applied after stripping. The code-execution trust boundary is now documented on `load_program`.

### Config (`shinka/env.py`)
- The package-dir `.env` is loaded with `override=False` so a stray/shipped `.env` can't silently shadow the operator's real environment; the launch-dir `.env` keeps its intended precedence.

### Not changed (documented recommendations)
- **S3 full sandboxing** — local eval remains unsandboxed by design (the framework runs evolved code). Beyond the opt-in secret stripping and docs added here, running untrusted models should use the Docker/Slurm eval path; a full sandbox is out of scope for this PR.
- **`.github/workflows/claude.yml`** triggers `claude-code-action` on `@claude` from any GitHub user (prompt-injection / billing-DoS surface). Its permissions are read-only, limiting blast radius; restricting the trigger to members/authors is a repo-policy decision left to maintainers.

### Testing
New `tests/test_webui_security.py` (path-traversal unit + HTTP integration: absolute/`..`/symlink/sibling rejection, DNS-rebinding Host check, no CORS wildcard, nosniff, disabled listing) and launch/env tests (shell-quoting, secret stripping, package-.env shell precedence). Full suite green; ruff + mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
