### PR TITLE
perf: performance fixes from deep review (indexes, N+1, caching)

### DIFF
--- a/shinka/core/async_novelty_judge.py
+++ b/shinka/core/async_novelty_judge.py
@@ -91,9 +91,11 @@ class AsyncNoveltyJudge:
                 return True, novelty_metadata
 
             loop = asyncio.get_event_loop()
-            similarity_scores = await loop.run_in_executor(
+            # One thread-safe scan returns both the scores and the most similar
+            # program, replacing two full island scans per candidate.
+            similarity_scores, most_similar_program = await loop.run_in_executor(
                 None,
-                db.compute_similarity_thread_safe,
+                db.compute_similarity_details_thread_safe,
                 code_embedding,
                 parent_program.island_idx,
             )
@@ -127,15 +129,7 @@ class AsyncNoveltyJudge:
             novelty_cost = 0.0
 
             if self.async_llm_client is not None:
-                # Get the most similar program for LLM comparison (thread-safe)
-                loop = asyncio.get_event_loop()
-                most_similar_program = await loop.run_in_executor(
-                    None,
-                    db.get_most_similar_program_thread_safe,
-                    code_embedding,
-                    parent_program.island_idx,
-                )
-
+                # most_similar_program already fetched in the single scan above.
                 if most_similar_program:
                     try:
                         # Read the current proposed code

--- a/shinka/core/novelty_judge.py
+++ b/shinka/core/novelty_judge.py
@@ -85,9 +85,12 @@ class NoveltyJudge:
         }
 
         for attempt in range(self.max_novelty_attempts):
-            # Compute similarities with programs in island
-            similarity_scores = database.compute_similarity(
-                code_embedding, parent_program.island_idx
+            # One island scan yields both the similarity scores and the most
+            # similar program (used below), instead of scanning the island twice.
+            similarity_scores, most_similar_program = (
+                database.compute_similarity_details(
+                    code_embedding, parent_program.island_idx
+                )
             )
 
             if not similarity_scores:
@@ -120,11 +123,7 @@ class NoveltyJudge:
             novelty_cost = 0.0
 
             if self.novelty_llm_client is not None:
-                # Get the most similar program for LLM comparison
-                most_similar_program = database.get_most_similar_program(
-                    code_embedding, parent_program.island_idx
-                )
-
+                # most_similar_program already fetched in the single scan above.
                 if most_similar_program:
                     try:
                         # Read the current proposed code

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -463,6 +463,14 @@ class ProgramDatabase:
             "programs(island_idx)",
             "CREATE INDEX IF NOT EXISTS idx_programs_system_prompt_id ON "
             "programs(system_prompt_id)",
+            # combined_score and correct are the two most-filtered/sorted columns
+            # (top-N, elites, island aggregates). These composite indexes turn
+            # the per-generation "WHERE correct=1 ORDER BY combined_score" scans
+            # into index range scans and cover the island-sampler aggregates.
+            "CREATE INDEX IF NOT EXISTS idx_programs_correct_score ON "
+            "programs(correct, combined_score)",
+            "CREATE INDEX IF NOT EXISTS idx_programs_island_correct_score ON "
+            "programs(island_idx, correct, combined_score)",
         ]
         for cmd in idx_cmds:
             self.cursor.execute(cmd)

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -2514,6 +2514,85 @@ class ProgramDatabase:
         similarity = np.dot(arr1, arr2) / (norm_a * norm_b)
         return float(similarity)
 
+    def _scan_island_similarities(
+        self, cursor, code_embedding: List[float], island_idx: int
+    ) -> Tuple[List[float], Optional[str]]:
+        """Single scan over an island: return (scores, id_of_most_similar).
+
+        Combines what compute_similarity and get_most_similar_program each did
+        with a full independent scan, so the novelty check no longer walks the
+        whole island twice (and re-parses every embedding twice) per candidate.
+        """
+        cursor.execute(
+            "SELECT id, embedding FROM programs WHERE island_idx = ? "
+            "AND embedding IS NOT NULL AND embedding != '[]'",
+            (island_idx,),
+        )
+        rows = cursor.fetchall()
+        scores: List[float] = []
+        best_sim = -1.0
+        best_id: Optional[str] = None
+        for row in rows:
+            rid = row["id"]
+            try:
+                embedding = json.loads(row["embedding"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(f"Could not decode embedding for program {rid}")
+                scores.append(0.0)
+                continue
+            sim = self._cosine_similarity(code_embedding, embedding) if embedding else 0.0
+            scores.append(sim)
+            if sim > best_sim:
+                best_sim = sim
+                best_id = rid
+        return scores, best_id
+
+    def compute_similarity_details(
+        self, code_embedding: List[float], island_idx: int
+    ) -> Tuple[List[float], Optional["Program"]]:
+        """Return (similarity_scores, most_similar_program) in one island scan."""
+        if not self.cursor:
+            raise ConnectionError("DB not connected.")
+        if not code_embedding:
+            return [], None
+        scores, best_id = self._scan_island_similarities(
+            self.cursor, code_embedding, island_idx
+        )
+        program = self.get(best_id) if best_id is not None else None
+        return scores, program
+
+    @db_retry()
+    def compute_similarity_details_thread_safe(
+        self, code_embedding: List[float], island_idx: int
+    ) -> Tuple[List[float], Optional["Program"]]:
+        """Thread-safe single-scan returning (scores, most_similar_program).
+
+        Uses one connection for both the island scan and the single-row fetch of
+        the winner, so the async novelty path no longer scans the island twice.
+        """
+        if not code_embedding:
+            return [], None
+        conn = None
+        try:
+            conn = sqlite3.connect(
+                self.config.db_path, check_same_thread=False, timeout=60.0
+            )
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            scores, best_id = self._scan_island_similarities(
+                cursor, code_embedding, island_idx
+            )
+            program = None
+            if best_id is not None:
+                cursor.execute("SELECT * FROM programs WHERE id = ?", (best_id,))
+                row = cursor.fetchone()
+                if row:
+                    program = self._program_from_row(row)
+            return scores, program
+        finally:
+            if conn:
+                conn.close()
+
     @db_retry()
     def compute_similarity_thread_safe(
         self, vec: List[float], island_idx: int

--- a/shinka/database/inspirations.py
+++ b/shinka/database/inspirations.py
@@ -36,6 +36,15 @@ class ContextSelectorStrategy(ABC):
 class ArchiveInspirationSelector(ContextSelectorStrategy):
     """Strategy for selecting archive inspirations."""
 
+    def _row_to_program(self, row: sqlite3.Row) -> Any:
+        """Build a Program from a full row, avoiding a per-id follow-up query.
+
+        Falls back to get_program() only if no row converter was provided.
+        """
+        if self.program_from_row is not None:
+            return self.program_from_row(row)
+        return self.get_program(row["id"])
+
     def sample_context(self, parent: Any, n: int) -> List[Any]:
         """Sample archive inspirations based on elites, best program, and random selection."""
         if n <= 0:
@@ -71,7 +80,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
         if num_elites > 0 and len(inspirations) < n and parent_island_idx is not None:
             self.cursor.execute(
                 """
-                SELECT p.id FROM programs p
+                SELECT p.* FROM programs p
                 JOIN archive a ON p.id = a.program_id
                 WHERE p.island_idx = ? AND p.correct = 1
                 ORDER BY p.combined_score DESC
@@ -82,7 +91,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
             for row in self.cursor.fetchall():
                 if len(inspirations) >= n:
                     break
-                prog = self.get_program(row["id"])
+                prog = self._row_to_program(row)
                 if prog and prog.id not in insp_ids:
                     inspirations.append(prog)
                     insp_ids.add(prog.id)
@@ -93,7 +102,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
             if needed > 0:
                 placeholders_rand = ",".join("?" * len(insp_ids))
                 sql_rand = f"""
-                    SELECT p.id FROM programs p
+                    SELECT p.* FROM programs p
                     JOIN archive a ON p.id = a.program_id
                     WHERE p.island_idx = ? AND p.correct = 1
                     AND p.id NOT IN ({placeholders_rand})
@@ -103,7 +112,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
 
                 self.cursor.execute(sql_rand, params_rand)
                 for row in self.cursor.fetchall():
-                    prog = self.get_program(row["id"])
+                    prog = self._row_to_program(row)
                     if prog:  # id is already not in insp_ids from query
                         inspirations.append(prog)
 
@@ -113,7 +122,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
             needed = n - len(inspirations)
             if needed > 0:
                 placeholders_rand = ",".join("?" * len(insp_ids))
-                sql_rand = f"""SELECT p.id FROM programs p
+                sql_rand = f"""SELECT p.* FROM programs p
                                  JOIN archive a ON p.id = a.program_id
                                  WHERE p.correct = 1
                                  AND p.id NOT IN ({placeholders_rand})
@@ -122,7 +131,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
                 params_rand = list(insp_ids) + [needed]
                 self.cursor.execute(sql_rand, params_rand)
                 for row in self.cursor.fetchall():
-                    prog = self.get_program(row["id"])
+                    prog = self._row_to_program(row)
                     if prog:
                         inspirations.append(prog)
 

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -432,7 +432,26 @@ class JobScheduler:
         )
 
     async def batch_check_status_async(self, jobs: List) -> List[bool]:
-        """Check status of multiple jobs concurrently."""
+        """Check status of multiple jobs.
+
+        For Slurm, resolve all jobs with ONE ``squeue`` call per tick instead of
+        spawning a squeue subprocess per job; fall back to per-job checks if the
+        batched query is unavailable.
+        """
+        if self.job_type in ("slurm_docker", "slurm_conda"):
+            from .slurm import get_active_job_ids
+
+            loop = asyncio.get_event_loop()
+            job_ids = [job.job_id for job in jobs if isinstance(job.job_id, str)]
+            active = await loop.run_in_executor(
+                self.executor, get_active_job_ids, job_ids
+            )
+            if active is not None:
+                return [
+                    isinstance(job.job_id, str) and job.job_id in active
+                    for job in jobs
+                ]
+
         tasks = [self.check_job_status_async(job) for job in jobs]
         return await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/shinka/launch/slurm.py
+++ b/shinka/launch/slurm.py
@@ -584,6 +584,37 @@ def get_job_status(job_id: str) -> Optional[str]:
         return None
 
 
+def get_active_job_ids(job_ids) -> Optional[set]:
+    """Return the subset of Slurm job ids still active, via a single squeue call.
+
+    Batches what would otherwise be one ``squeue`` subprocess per job per poll
+    tick. Returns None to signal the caller to fall back to per-job checks when
+    squeue is unavailable or returns nothing useful. Job ids listed by squeue
+    are active; any queried id not listed has left the queue (finished).
+    """
+    ids = [str(j) for j in job_ids if not str(j).startswith("local-")]
+    if not ids:
+        return set()
+    try:
+        result = subprocess.run(
+            ["squeue", "--jobs=" + ",".join(ids), "--noheader", "--format=%i"],
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if result.returncode != 0 and not lines:
+        # squeue failed entirely (e.g. controller unreachable): let the caller
+        # fall back to the per-job path, which disambiguates via sacct.
+        return None
+    active = set()
+    for line in lines:
+        token = line.split()[0]
+        active.add(token.split(".")[0])  # strip any array/step suffix
+    return active
+
+
 def monitor(job_id, results_dir=None, poll_interval=10, verbose: bool = False):
     """
     Monitor a Slurm job until completion and load its results.

--- a/shinka/llm/client.py
+++ b/shinka/llm/client.py
@@ -1,5 +1,8 @@
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
+import asyncio
+import hashlib
 import os
+import weakref
 import anthropic
 import openai
 import instructor
@@ -8,29 +11,156 @@ from shinka.env import load_shinka_dotenv
 from shinka.google_genai import _google_genai_timeout_ms, build_google_genai_client
 from shinka.local_openai_config import resolve_local_openai_api_key
 from .constants import OPENAI_MAX_RETRIES, TIMEOUT
-from .providers.model_resolver import resolve_model_backend
+from .providers.model_resolver import ResolvedModel, resolve_model_backend
 
 load_shinka_dotenv()
 
 
-def get_client_llm(
-    model_name: str, structured_output: bool = False
-) -> Tuple[Any, str, str]:
-    """Get the client and model for the given model name.
+# Constructing an SDK client (anthropic.Anthropic, openai.OpenAI, ...) spins up
+# a fresh httpx connection pool and pays TLS + pool setup on first use. Building
+# a brand-new client on every query — and every retry — throws that pool away
+# immediately, so sequential queries never share HTTP keep-alive. We memoize the
+# constructed clients so repeated queries with identical parameters reuse one
+# client (and its pool).
+#
+# Sync clients live in a plain dict. Async clients (httpx.AsyncClient) bind to
+# the event loop that first drives them, so they are cached per running loop in
+# a WeakKeyDictionary keyed on the loop object: when a loop is garbage-collected
+# its cached clients are dropped and never handed to a different loop.
+_SYNC_CLIENT_CACHE: dict = {}
+_ASYNC_CLIENT_CACHE: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
 
-    Args:
-        model_name (str): The name of the model to get the client.
 
-    Raises:
-        ValueError: If the model is not supported.
+class _NoRunningLoop:
+    """Weak-referenceable sentinel bucket for calls made outside a loop."""
 
-    Returns:
-        Tuple[Any, str, str]: (client, API model name, resolved provider).
+
+_NO_RUNNING_LOOP = _NoRunningLoop()
+
+
+def _fingerprint(secret: Optional[str]) -> Optional[str]:
+    """Stable, non-reversible fingerprint of a secret for use in a cache key.
+
+    Different secrets map to different fingerprints (so two callers with
+    distinct keys never share a client), while the raw secret never enters the
+    key itself.
     """
-    resolved = resolve_model_backend(model_name)
-    provider = resolved.provider
-    api_model_name = resolved.api_model_name
+    if not secret:
+        return None
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()[:16]
 
+
+def _client_identity_extras(provider: str, resolved: ResolvedModel) -> Tuple:
+    """Dynamic, env-derived config that changes which client gets built.
+
+    Everything here is beyond (provider, api_model_name, structured_output):
+    the base URL and API key(s) a provider reads at construction time. Secrets
+    are fingerprinted, not stored raw. Two calls that would build clients
+    talking to different endpoints or authenticating with different keys land
+    on different cache entries.
+    """
+    if provider == "anthropic":
+        return (_fingerprint(os.getenv("ANTHROPIC_API_KEY")),)
+    if provider == "bedrock":
+        return (
+            _fingerprint(os.getenv("AWS_ACCESS_KEY_ID")),
+            _fingerprint(os.getenv("AWS_SECRET_ACCESS_KEY")),
+            os.getenv("AWS_REGION_NAME"),
+        )
+    if provider == "openai":
+        return (_fingerprint(os.getenv("OPENAI_API_KEY")),)
+    if provider == "azure_openai":
+        # Azure endpoint + key come from the environment, not from `resolved`.
+        return (azure_v1_base_url(), _fingerprint(azure_openai_api_key()))
+    if provider == "deepseek":
+        return (_fingerprint(os.getenv("DEEPSEEK_API_KEY")),)
+    if provider == "google":
+        return (
+            _fingerprint(os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")),
+        )
+    if provider == "openrouter":
+        return (_fingerprint(os.getenv("OPENROUTER_API_KEY")),)
+    if provider == "local_openai":
+        return (
+            resolved.base_url,
+            resolved.api_key_env_name,
+            _fingerprint(resolve_local_openai_api_key(resolved.api_key_env_name)),
+        )
+    return ()
+
+
+def _sync_client_builder(provider: str) -> Any:
+    """The constructor a sync client is built from, resolved at call time.
+
+    Read live from the module globals so a monkeypatched constructor (e.g. a
+    test swapping ``openai.OpenAI``) is a different object and never collides in
+    the cache with the real one.
+    """
+    return {
+        "anthropic": anthropic.Anthropic,
+        "bedrock": anthropic.AnthropicBedrock,
+        "openai": openai.OpenAI,
+        "azure_openai": openai.OpenAI,
+        "deepseek": openai.OpenAI,
+        "openrouter": openai.OpenAI,
+        "local_openai": openai.OpenAI,
+        "google": build_google_genai_client,
+    }.get(provider)
+
+
+def _async_client_builder(provider: str) -> Any:
+    """The constructor an async client is built from, resolved at call time."""
+    return {
+        "anthropic": anthropic.AsyncAnthropic,
+        "bedrock": anthropic.AsyncAnthropicBedrock,
+        "openai": openai.AsyncOpenAI,
+        "azure_openai": openai.AsyncOpenAI,
+        "deepseek": openai.AsyncOpenAI,
+        "openrouter": openai.AsyncOpenAI,
+        "local_openai": openai.AsyncOpenAI,
+        "google": build_google_genai_client,
+    }.get(provider)
+
+
+def _client_cache_key(
+    provider: str,
+    structured_output: bool,
+    resolved: ResolvedModel,
+    builder: Any,
+) -> Tuple:
+    """Key that uniquely identifies a client's construction parameters.
+
+    Distinct clients are forced apart by: provider (openai vs azure share a
+    constructor but hit different endpoints), api_model_name, the
+    structured_output flag (instructor-wrapped clients must never be handed to
+    plain callers), the actual constructor object (guards against monkeypatched
+    builders), and the env-derived base URL / key fingerprints.
+    """
+    return (
+        provider,
+        resolved.api_model_name,
+        bool(structured_output),
+        builder,
+        _client_identity_extras(provider, resolved),
+    )
+
+
+def _running_loop_key() -> Any:
+    """The event loop bucket for async client caching.
+
+    Returns the running loop when one exists, else a shared sentinel for calls
+    made outside any loop (e.g. constructing a client eagerly in sync code).
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return _NO_RUNNING_LOOP
+
+
+def _build_sync_client(
+    provider: str, structured_output: bool, resolved: ResolvedModel
+) -> Any:
+    """Construct a fresh sync client for the resolved provider."""
     if provider == "anthropic":
         client = anthropic.Anthropic(timeout=TIMEOUT)
         if structured_output:
@@ -96,29 +226,15 @@ def get_client_llm(
     elif provider == "headless":
         client = None
     else:
-        raise ValueError(f"Model {model_name} not supported.")
+        raise ValueError(f"Model {resolved.original_model_name} not supported.")
 
-    return client, api_model_name, provider
+    return client
 
 
-def get_async_client_llm(
-    model_name: str, structured_output: bool = False
-) -> Tuple[Any, str, str]:
-    """Get the async client and model for the given model name.
-
-    Args:
-        model_name (str): The name of the model to get the client.
-
-    Raises:
-        ValueError: If the model is not supported.
-
-    Returns:
-        Tuple[Any, str, str]: (async client, API model name, resolved provider).
-    """
-    resolved = resolve_model_backend(model_name)
-    provider = resolved.provider
-    api_model_name = resolved.api_model_name
-
+def _build_async_client(
+    provider: str, structured_output: bool, resolved: ResolvedModel
+) -> Any:
+    """Construct a fresh async client for the resolved provider."""
     if provider == "anthropic":
         client = anthropic.AsyncAnthropic(timeout=TIMEOUT)
         if structured_output:
@@ -181,6 +297,68 @@ def get_async_client_llm(
     elif provider == "headless":
         client = None
     else:
-        raise ValueError(f"Model {model_name} not supported.")
+        raise ValueError(f"Model {resolved.original_model_name} not supported.")
 
-    return client, api_model_name, provider
+    return client
+
+
+def get_client_llm(
+    model_name: str, structured_output: bool = False
+) -> Tuple[Any, str, str]:
+    """Get the client and model for the given model name.
+
+    Clients are memoized: repeated calls with identical parameters reuse one
+    client (and its connection pool) instead of rebuilding it per query.
+
+    Args:
+        model_name (str): The name of the model to get the client.
+
+    Raises:
+        ValueError: If the model is not supported.
+
+    Returns:
+        Tuple[Any, str, str]: (client, API model name, resolved provider).
+    """
+    resolved = resolve_model_backend(model_name)
+    provider = resolved.provider
+    builder = _sync_client_builder(provider)
+    cache_key = _client_cache_key(provider, structured_output, resolved, builder)
+    if cache_key not in _SYNC_CLIENT_CACHE:
+        _SYNC_CLIENT_CACHE[cache_key] = _build_sync_client(
+            provider, structured_output, resolved
+        )
+    return _SYNC_CLIENT_CACHE[cache_key], resolved.api_model_name, provider
+
+
+def get_async_client_llm(
+    model_name: str, structured_output: bool = False
+) -> Tuple[Any, str, str]:
+    """Get the async client and model for the given model name.
+
+    Async clients are memoized per running event loop, so repeated queries on
+    the same loop reuse one client (and its connection pool), while a client is
+    never shared across event loops.
+
+    Args:
+        model_name (str): The name of the model to get the client.
+
+    Raises:
+        ValueError: If the model is not supported.
+
+    Returns:
+        Tuple[Any, str, str]: (async client, API model name, resolved provider).
+    """
+    resolved = resolve_model_backend(model_name)
+    provider = resolved.provider
+    builder = _async_client_builder(provider)
+    cache_key = _client_cache_key(provider, structured_output, resolved, builder)
+    loop_key = _running_loop_key()
+    per_loop = _ASYNC_CLIENT_CACHE.get(loop_key)
+    if per_loop is None:
+        per_loop = {}
+        _ASYNC_CLIENT_CACHE[loop_key] = per_loop
+    if cache_key not in per_loop:
+        per_loop[cache_key] = _build_async_client(
+            provider, structured_output, resolved
+        )
+    return per_loop[cache_key], resolved.api_model_name, provider

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -281,6 +281,39 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         finally:
             conn.close()
 
+    def _failed_proposal_count_and_timestamp(
+        self, cursor
+    ) -> Tuple[int, Optional[float]]:
+        """Aggregate failed-proposal stats for lightweight change detection.
+
+        Returns ``(count, max_timestamp)`` where ``count`` is the number of
+        distinct generations that recorded a failed proposal (mirroring the
+        per-generation dedup in ``_load_failed_proposal_nodes``) and
+        ``max_timestamp`` is the newest ``created_at`` among them. Uses a single
+        aggregate query and never opens failure JSON files from disk, so it is
+        cheap enough for the frequent change-detection poll. A missing
+        ``attempt_log`` table yields ``(0, None)`` instead of an error.
+        """
+        try:
+            cursor.execute(
+                """
+                SELECT COUNT(DISTINCT generation) AS count,
+                       MAX(created_at) AS max_timestamp
+                FROM attempt_log
+                WHERE status = 'failed'
+                  AND json_valid(details)
+                  AND json_extract(details, '$.node_kind') = 'failed_proposal'
+                """
+            )
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return 0, None
+            raise
+        row = cursor.fetchone()
+        if not row:
+            return 0, None
+        return int(row["count"] or 0), row["max_timestamp"]
+
     # Host header values allowed when the server is bound to loopback. Overwritten
     # per-instance via the handler factory when an explicit external host is used.
     allowed_hosts = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
@@ -320,7 +353,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if path == "/get_programs" and "db_path" in query:
             db_path = query["db_path"][0]
-            return self.handle_get_programs(db_path)
+            return self.handle_get_programs(
+                db_path,
+                limit=self._parse_int_param(query, "limit"),
+                offset=self._parse_int_param(query, "offset"),
+                include_code=self._parse_bool_param(query, "include_code", True),
+            )
 
         if path == "/get_programs_summary" and "db_path" in query:
             db_path = query["db_path"][0]
@@ -491,20 +529,91 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         """
         return self._resolve_within_root(db_path)
 
-    def handle_get_programs(self, db_path: str):
-        """Fetch all programs from a given database file."""
+    @staticmethod
+    def _parse_int_param(query: Dict[str, Any], name: str) -> Optional[int]:
+        """Parse an optional integer query param; None if absent or invalid.
+
+        Returning None on absence/parse-failure keeps the default (unpaginated)
+        response behavior unchanged for callers that omit the param.
+        """
+        values = query.get(name)
+        if not values:
+            return None
+        try:
+            return int(values[0])
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_bool_param(query: Dict[str, Any], name: str, default: bool) -> bool:
+        """Parse an optional boolean query param.
+
+        Only explicit false-ish values ('false', '0', 'no', 'off') disable;
+        anything else (including an absent param) keeps ``default``.
+        """
+        values = query.get(name)
+        if not values:
+            return default
+        return values[0].strip().lower() not in ("false", "0", "no", "off")
+
+    @staticmethod
+    def _project_programs(
+        programs: list,
+        limit: Optional[int],
+        offset: Optional[int],
+        include_code: bool,
+    ) -> list:
+        """Apply opt-in pagination/projection to a full programs list.
+
+        With the defaults (no offset, no limit, include_code=True) the input
+        list is returned unchanged, so the default response stays byte-for-byte
+        identical to the pre-pagination behavior. Narrowing produces a new list
+        and never mutates the cached programs.
+        """
+        if offset is None and limit is None and include_code:
+            return programs
+        result = programs
+        if offset is not None or limit is not None:
+            start = max(offset or 0, 0)
+            if limit is None:
+                result = result[start:]
+            else:
+                result = result[start : start + max(limit, 0)]
+        if not include_code:
+            result = [{**program, "code": None} for program in result]
+        return result
+
+    def handle_get_programs(
+        self,
+        db_path: str,
+        *,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include_code: bool = True,
+    ):
+        """Fetch all programs from a given database file.
+
+        The full programs list is always built and cached; ``limit``/``offset``/
+        ``include_code`` only narrow the *response* (opt-in), never the cache.
+        """
         print(f"[SERVER] Fetching programs from DB: {db_path}")
 
         # Handle the case where db_path might have the task name prepended
         # Extract the actual path by removing the task name prefix if present
         actual_db_path = self._get_actual_db_path(db_path)
 
+        # Key the cache on the resolved absolute path (like the summary handler)
+        # so two servers/search-roots sharing a relative db_path can't collide.
+        programs_cache_key = f"programs::{actual_db_path}"
+
         # Check cache first
-        if db_path in db_cache:
-            last_fetch_time, cached_data = db_cache[db_path]
+        if programs_cache_key in db_cache:
+            last_fetch_time, cached_data = db_cache[programs_cache_key]
             if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
                 print(f"[SERVER] Serving from cache for DB: {db_path}")
-                self.send_json_response(cached_data)
+                self.send_json_response(
+                    self._project_programs(cached_data, limit, offset, include_code)
+                )
                 return
 
         # Construct absolute path to the database from search root using actual path
@@ -542,10 +651,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     self._load_failed_proposal_nodes(abs_db_path, include_code=False)
                 )
 
-                # Update cache
-                db_cache[db_path] = (time.time(), programs_dict)
+                # Update cache with the full list; narrowing is applied only to
+                # the response so the cached payload stays complete.
+                db_cache[programs_cache_key] = (time.time(), programs_dict)
 
-                self.send_json_response(programs_dict)
+                self.send_json_response(
+                    self._project_programs(
+                        programs_dict, limit, offset, include_code
+                    )
+                )
                 success_msg = (
                     f"[SERVER] Successfully served {len(programs)} "
                     f"programs from {db_path} (attempt {i + 1})"
@@ -605,6 +719,18 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         print(f"[SERVER] Fetching program summaries from DB: {db_path}")
 
         actual_db_path = self._get_actual_db_path(db_path)
+
+        # Same TTL cache as handle_get_programs, but under a distinct namespaced
+        # key so the summary payload never collides with the full-programs entry
+        # cached under the bare db_path.
+        summary_cache_key = f"summary::{actual_db_path}"
+        if summary_cache_key in db_cache:
+            last_fetch_time, cached_data = db_cache[summary_cache_key]
+            if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
+                print(f"[SERVER] Serving summaries from cache for DB: {db_path}")
+                self.send_json_response(cached_data)
+                return
+
         abs_db_path = os.path.join(self.search_root, actual_db_path)
 
         if not os.path.exists(abs_db_path):
@@ -630,6 +756,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 summaries.extend(
                     self._load_failed_proposal_nodes(abs_db_path, include_code=False)
                 )
+                db_cache[summary_cache_key] = (time.time(), summaries)
                 self.send_json_response(summaries)
                 print(
                     f"[SERVER] Successfully served {len(summaries)} "
@@ -697,21 +824,20 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                         pass
 
                 result = db.get_program_count_and_timestamp()
-                failed_nodes = self._load_failed_proposal_nodes(
-                    abs_db_path, include_code=False
+                # Change-detection only: fold in the failed-proposal generations
+                # via a cheap aggregate. Do NOT materialize nodes or read any
+                # failure JSON from disk here — this endpoint is polled every
+                # few seconds, so it must stay lightweight.
+                failed_count, failed_max_ts = (
+                    self._failed_proposal_count_and_timestamp(db.cursor)
                 )
-                if failed_nodes:
-                    result["count"] += len(failed_nodes)
-                    max_failure_timestamp = max(
-                        node["timestamp"]
-                        for node in failed_nodes
-                        if node.get("timestamp") is not None
-                    )
-                    if (
-                        result.get("max_timestamp") is None
-                        or max_failure_timestamp > result["max_timestamp"]
-                    ):
-                        result["max_timestamp"] = max_failure_timestamp
+                if failed_count:
+                    result["count"] += failed_count
+                if failed_max_ts is not None and (
+                    result.get("max_timestamp") is None
+                    or failed_max_ts > result["max_timestamp"]
+                ):
+                    result["max_timestamp"] = failed_max_ts
                 self.send_json_response(result)
                 return
 

--- a/tests/test_db_indexes.py
+++ b/tests/test_db_indexes.py
@@ -1,0 +1,55 @@
+"""Regression tests for the performance indexes on the programs table."""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(pid: str, score: float, correct: bool = True) -> Program:
+    return Program(
+        id=pid,
+        code="def f():\n    return 1\n",
+        correct=correct,
+        combined_score=score,
+        generation=0,
+        island_idx=0,
+    )
+
+
+def test_score_indexes_exist():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "idx.db"
+        ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+
+        conn = sqlite3.connect(str(db_path))
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        conn.close()
+        assert "idx_programs_correct_score" in names
+        assert "idx_programs_island_correct_score" in names
+
+
+def test_top_programs_query_uses_score_index():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "plan.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        for i in range(5):
+            db.add(_program(f"p{i}", float(i)))
+
+        conn = sqlite3.connect(str(db_path))
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN SELECT id FROM programs "
+            "WHERE combined_score IS NOT NULL AND correct = 1 "
+            "ORDER BY combined_score DESC LIMIT 3"
+        ).fetchall()
+        conn.close()
+        plan_text = " ".join(str(row) for row in plan)
+        # The planner should use an index rather than scanning + sorting.
+        assert "idx_programs_correct_score" in plan_text
+        assert "SCAN programs" not in plan_text

--- a/tests/test_inspiration_nplus1.py
+++ b/tests/test_inspiration_nplus1.py
@@ -1,0 +1,48 @@
+"""Functional test for the single-query archive-inspiration sampling.
+
+The archive/random inspiration loops now fetch full rows (SELECT p.*) and build
+Program objects directly instead of issuing a per-id follow-up query. This
+verifies the sampled inspirations still come back as fully-populated programs.
+"""
+
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(pid: str, score: float, island: int = 0) -> Program:
+    return Program(
+        id=pid,
+        code=f"# code for {pid}\ndef f():\n    return {score}\n",
+        correct=True,
+        combined_score=score,
+        generation=int(score),
+        island_idx=island,
+        embedding=[score, score + 1.0],
+    )
+
+
+def test_sample_returns_fully_populated_inspirations():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "insp.db"
+        config = DatabaseConfig(
+            db_path=str(db_path),
+            num_islands=1,
+            num_archive_inspirations=2,
+            num_top_k_inspirations=1,
+            elite_selection_ratio=0.5,
+            enforce_island_separation=False,
+        )
+        db = ProgramDatabase(config=config)
+        for i in range(6):
+            db.add(_program(f"p{i}", float(i)))
+
+        parent, archive_insp, topk_insp = db.sample()
+
+        # Inspirations must be real, fully-hydrated Program objects (code + id),
+        # proving the SELECT p.* + program_from_row path works end to end.
+        for prog in archive_insp + topk_insp:
+            assert isinstance(prog, Program)
+            assert prog.id
+            assert prog.code and prog.code.startswith("# code for")

--- a/tests/test_launch_job_status.py
+++ b/tests/test_launch_job_status.py
@@ -141,3 +141,41 @@ def test_strip_provider_secrets_opt_in(monkeypatch):
     assert _should_strip_eval_secrets() is False
     monkeypatch.setenv("SHINKA_STRIP_EVAL_SECRETS", "1")
     assert _should_strip_eval_secrets() is True
+
+
+def test_get_active_job_ids_batches_squeue(monkeypatch):
+    """One squeue call resolves many jobs; unlisted ids are treated as finished."""
+    from shinka.launch import slurm as slurm_mod
+
+    calls = {"n": 0}
+
+    class _R:
+        def __init__(self, stdout, rc=0):
+            self.stdout = stdout
+            self.returncode = rc
+
+    def fake_run(cmd, *a, **k):
+        calls["n"] += 1
+        assert cmd[0] == "squeue"
+        # "101" and "103" are still active; "102" has left the queue.
+        return _R("101\n103\n")
+
+    monkeypatch.setattr(slurm_mod.subprocess, "run", fake_run)
+    active = slurm_mod.get_active_job_ids(["101", "102", "103", "local-x"])
+    assert active == {"101", "103"}
+    assert calls["n"] == 1  # a single batched squeue, not one per job
+
+
+def test_get_active_job_ids_empty_and_failure(monkeypatch):
+    from shinka.launch import slurm as slurm_mod
+
+    assert slurm_mod.get_active_job_ids([]) == set()
+    assert slurm_mod.get_active_job_ids(["local-only"]) == set()
+
+    class _R:
+        stdout = ""
+        returncode = 1
+
+    monkeypatch.setattr(slurm_mod.subprocess, "run", lambda *a, **k: _R())
+    # Total squeue failure -> None so caller falls back to per-job checks.
+    assert slurm_mod.get_active_job_ids(["999"]) is None

--- a/tests/test_llm_client_cache.py
+++ b/tests/test_llm_client_cache.py
@@ -1,0 +1,149 @@
+"""Client memoization tests for shinka.llm.client.
+
+Constructing an SDK client builds a fresh httpx connection pool, so rebuilding
+one per query defeats HTTP keep-alive. These tests pin the memoization contract:
+identical parameters reuse one client, differing parameters do not, async
+clients are scoped to their event loop, and no real network is touched (API keys
+come from monkeypatched env).
+"""
+
+import asyncio
+
+import pytest
+
+import shinka.llm.client as llm_client
+from shinka.llm.client import get_async_client_llm, get_client_llm
+
+
+@pytest.fixture(autouse=True)
+def _isolate_client_caches():
+    """Start every test from an empty cache so identity assertions are exact."""
+    llm_client._SYNC_CLIENT_CACHE.clear()
+    llm_client._ASYNC_CLIENT_CACHE.clear()
+    yield
+    llm_client._SYNC_CLIENT_CACHE.clear()
+    llm_client._ASYNC_CLIENT_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_keys(monkeypatch):
+    """Fake keys so clients construct offline without hitting any provider."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+
+
+# --- sync -----------------------------------------------------------------
+
+
+def test_sync_identical_params_reuse_same_client():
+    first, _, _ = get_client_llm("gpt-5-mini")
+    second, _, _ = get_client_llm("gpt-5-mini")
+
+    assert first is second
+
+
+def test_sync_different_provider_returns_distinct_clients():
+    openai_client, _, openai_provider = get_client_llm("gpt-5-mini")
+    anthropic_client, _, anthropic_provider = get_client_llm(
+        "claude-3-5-haiku-20241022"
+    )
+
+    assert openai_provider == "openai"
+    assert anthropic_provider == "anthropic"
+    assert openai_client is not anthropic_client
+
+
+def test_sync_different_model_returns_distinct_clients():
+    mini, _, _ = get_client_llm("gpt-5-mini")
+    other, _, _ = get_client_llm("gpt-5.4-mini")
+
+    assert mini is not other
+
+
+def test_sync_structured_output_not_shared_with_plain_callers():
+    plain, _, _ = get_client_llm("gpt-5-mini", structured_output=False)
+    structured, _, _ = get_client_llm("gpt-5-mini", structured_output=True)
+
+    # An instructor-wrapped client must never be handed to a plain caller.
+    assert plain is not structured
+    # ...but structured callers still memoize among themselves.
+    structured_again, _, _ = get_client_llm("gpt-5-mini", structured_output=True)
+    assert structured is structured_again
+
+
+def test_sync_distinct_endpoints_are_not_shared(monkeypatch):
+    monkeypatch.setenv("LOCAL_OPENAI_API_KEY", "test-local-key")
+
+    first, _, _ = get_client_llm("local/m@http://localhost:9001/v1")
+    second, _, _ = get_client_llm("local/m@http://localhost:9002/v1")
+
+    assert first is not second
+    assert str(first.base_url).startswith("http://localhost:9001")
+    assert str(second.base_url).startswith("http://localhost:9002")
+
+
+def test_sync_distinct_api_key_sources_are_not_shared(monkeypatch):
+    monkeypatch.setenv("KEY_A", "secret-a")
+    monkeypatch.setenv("KEY_B", "secret-b")
+    url = "http://localhost:9100/v1"
+
+    client_a, _, _ = get_client_llm(f"local/m@{url}?api_key_env=KEY_A")
+    client_b, _, _ = get_client_llm(f"local/m@{url}?api_key_env=KEY_B")
+
+    assert client_a is not client_b
+    # Same key source is still reused.
+    client_a_again, _, _ = get_client_llm(f"local/m@{url}?api_key_env=KEY_A")
+    assert client_a is client_a_again
+
+
+# --- async ----------------------------------------------------------------
+
+
+def test_async_reuses_client_outside_event_loop():
+    first, _, _ = get_async_client_llm("gpt-5-mini")
+    second, _, _ = get_async_client_llm("gpt-5-mini")
+
+    assert first is second
+
+
+def test_async_reuses_client_within_same_event_loop():
+    async def scenario():
+        first, _, _ = get_async_client_llm("gpt-5-mini")
+        second, _, _ = get_async_client_llm("gpt-5-mini")
+        return first is second
+
+    assert asyncio.run(scenario())
+
+
+def test_async_does_not_share_client_across_event_loops():
+    async def scenario():
+        client, _, _ = get_async_client_llm("gpt-5-mini")
+        return client
+
+    first = asyncio.run(scenario())
+    second = asyncio.run(scenario())
+
+    assert first is not second
+
+
+def test_async_different_provider_returns_distinct_clients():
+    async def scenario():
+        openai_client, _, _ = get_async_client_llm("gpt-5-mini")
+        anthropic_client, _, _ = get_async_client_llm("claude-3-5-haiku-20241022")
+        return openai_client, anthropic_client
+
+    openai_client, anthropic_client = asyncio.run(scenario())
+
+    assert openai_client is not anthropic_client
+
+
+def test_async_structured_output_not_shared_with_plain_callers():
+    async def scenario():
+        plain, _, _ = get_async_client_llm("gpt-5-mini", structured_output=False)
+        structured, _, _ = get_async_client_llm("gpt-5-mini", structured_output=True)
+        return plain, structured
+
+    plain, structured = asyncio.run(scenario())
+
+    assert plain is not structured

--- a/tests/test_novelty_judge.py
+++ b/tests/test_novelty_judge.py
@@ -58,6 +58,11 @@ class DummyDatabase:
             return self._similarity_sequences[0]
         return self._similarity_sequences.pop(0)
 
+    def compute_similarity_details(self, code_embedding, island_idx):
+        return self.compute_similarity(code_embedding, island_idx), (
+            self.most_similar_program
+        )
+
     def get_most_similar_program(self, code_embedding, island_idx):
         return self.most_similar_program
 

--- a/tests/test_similarity_single_scan.py
+++ b/tests/test_similarity_single_scan.py
@@ -1,0 +1,63 @@
+"""The single-pass similarity scan must match the old two-method behavior."""
+
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(pid: str, emb, island: int = 0) -> Program:
+    return Program(
+        id=pid,
+        code=f"# {pid}\n",
+        correct=True,
+        combined_score=1.0,
+        generation=0,
+        island_idx=island,
+        embedding=emb,
+    )
+
+
+def test_details_match_legacy_methods():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "sim.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        db.add(_program("a", [1.0, 0.0, 0.0]))
+        db.add(_program("b", [0.9, 0.1, 0.0]))
+        db.add(_program("c", [0.0, 1.0, 0.0]))
+
+        query = [1.0, 0.05, 0.0]
+
+        legacy_scores = db.compute_similarity(query, 0)
+        legacy_best = db.get_most_similar_program(query, 0)
+
+        scores, best = db.compute_similarity_details(query, 0)
+
+        assert scores == legacy_scores
+        assert best is not None and legacy_best is not None
+        assert best.id == legacy_best.id
+        # "a" (unit x-axis) is closest to the query.
+        assert best.id == "a"
+
+
+def test_details_thread_safe_matches():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "sim_ts.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        db.add(_program("a", [1.0, 0.0]))
+        db.add(_program("b", [0.0, 1.0]))
+
+        query = [0.1, 1.0]
+        scores, best = db.compute_similarity_details_thread_safe(query, 0)
+        assert len(scores) == 2
+        assert best is not None and best.id == "b"
+
+
+def test_details_empty_embedding_returns_empty():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "sim_empty.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        db.add(_program("a", [1.0, 0.0]))
+        scores, best = db.compute_similarity_details([], 0)
+        assert scores == []
+        assert best is None

--- a/tests/test_webui_perf.py
+++ b/tests/test_webui_perf.py
@@ -1,0 +1,260 @@
+"""Performance regression tests for the visualization server.
+
+Covers three fixes on the fix/performance branch:
+
+* P9  – /get_program_count is a *lightweight* change detector: it must fold in
+        the failed-proposal generations via a cheap aggregate and must NOT
+        materialize failed nodes or read any failure JSON from disk.
+* P10 – /get_programs_summary is TTL-cached like /get_programs, under a
+        namespaced key that does not collide with the full-programs payload.
+* P11 – /get_programs supports opt-in ``limit`` / ``offset`` / ``include_code``
+        narrowing while the default (no params) response is unchanged.
+
+The server harness mirrors tests/test_webui_security.py: a ThreadingTCPServer
+built from create_handler_factory(root), driven with real http.client requests
+that carry a valid loopback Host header.
+"""
+
+import http.client
+import json
+import socketserver
+import threading
+import urllib.parse
+
+import pytest
+
+from shinka.database import DatabaseConfig, ProgramDatabase
+from shinka.webui import visualization
+from shinka.webui.visualization import create_handler_factory
+
+
+@pytest.fixture(autouse=True)
+def _clear_db_cache():
+    """The server's db_cache is a module global; isolate it between tests."""
+    visualization.db_cache.clear()
+    yield
+    visualization.db_cache.clear()
+
+
+N_PROGRAMS = 4
+# Failed proposals recorded across these generations; the endpoint counts
+# DISTINCT generations, so the duplicate gen 5 must NOT be double-counted.
+FAILED_GENERATIONS = [5, 6, 5]
+DISTINCT_FAILED_GENERATIONS = 2
+FAILURE_REASON = "boom-marker-should-not-be-served"
+
+
+def _make_db(root, n_programs=N_PROGRAMS, failed_generations=FAILED_GENERATIONS):
+    """Create a real programs.sqlite under ``root/run`` and return its client path.
+
+    Programs are inserted with raw SQL (the schema is created by ProgramDatabase)
+    to keep counts deterministic — the ``add()`` path spawns island copies.
+    Failed proposals go through the production ``record_attempt_event`` helper.
+    """
+    run_dir = root / "run"
+    run_dir.mkdir()
+    db_file = run_dir / "programs.sqlite"
+
+    db = ProgramDatabase(DatabaseConfig(db_path=str(db_file)), read_only=False)
+    try:
+        for i in range(n_programs):
+            db.cursor.execute(
+                "INSERT INTO programs (id, code, language, generation, timestamp, "
+                "combined_score, correct, children_count, complexity, embedding, "
+                "public_metrics, private_metrics, metadata) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    f"p{i}",
+                    f"print({i})\n",
+                    "python",
+                    i,
+                    100.0 + i,
+                    float(i),
+                    1,
+                    0,
+                    1.0,
+                    json.dumps([0.1 * i, 0.2 * i]),
+                    "{}",
+                    "{}",
+                    "{}",
+                ),
+            )
+        db.conn.commit()
+        for gen in failed_generations:
+            db.record_attempt_event(
+                gen,
+                "proposal",
+                "failed",
+                details={
+                    "node_kind": "failed_proposal",
+                    "failure_reason": FAILURE_REASON,
+                    "failure_json_path": "does/not/exist/failure.json",
+                },
+            )
+    finally:
+        db.close()
+
+    return "run/programs.sqlite"
+
+
+class _Server:
+    """Direct ThreadingTCPServer for the handler (no start_server chdir)."""
+
+    def __init__(self, search_root):
+        self.httpd = socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0), create_handler_factory(str(search_root))
+        )
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def get(self, path):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("GET", path, headers={"Host": f"127.0.0.1:{self.port}"})
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        return resp, body
+
+    def get_json(self, path):
+        resp, body = self.get(path)
+        assert resp.status == 200, (path, resp.status, body[:200])
+        return json.loads(body), body
+
+    def close(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture
+def server(tmp_path):
+    db_path = _make_db(tmp_path)
+    srv = _Server(tmp_path)
+    srv.db_path = db_path
+    yield srv
+    srv.close()
+
+
+def _q(db_path):
+    return urllib.parse.quote(db_path)
+
+
+# --------------------------------------------------------------------------- P9
+
+
+def test_program_count_shape_and_counts(server):
+    result, body = server.get_json(f"/get_program_count?db_path={_q(server.db_path)}")
+
+    # Only the two keys the client actually consumes.
+    assert set(result.keys()) == {"count", "max_timestamp"}
+    # Programs + DISTINCT failed-proposal generations (dup gen not double-counted).
+    assert result["count"] == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+    # Failed proposals are stamped with time.time(), newer than program ts 100-103.
+    assert result["max_timestamp"] is not None
+    assert result["max_timestamp"] > 103.0
+
+
+def test_program_count_does_not_materialize_failed_nodes(server):
+    _result, body = server.get_json(f"/get_program_count?db_path={_q(server.db_path)}")
+    text = body.decode("utf-8")
+
+    # No per-node failure payload leaks into this lightweight endpoint: no
+    # failure_reason (would require reading the row/details), no synthetic node
+    # id, and no node-only keys. Proves _read_failure_json / node build skipped.
+    assert FAILURE_REASON not in text
+    assert "failure_reason" not in text
+    assert "failed:proposal:" not in text
+    for node_only_key in ("public_metrics", "text_feedback", "embedding"):
+        assert node_only_key not in text
+
+
+def test_program_count_matches_full_program_list_length(server):
+    """The change-detector count must equal treeData length (get_programs)."""
+    count_result, _ = server.get_json(
+        f"/get_program_count?db_path={_q(server.db_path)}"
+    )
+    programs, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    assert count_result["count"] == len(programs)
+
+
+# -------------------------------------------------------------------------- P10
+
+
+def test_programs_summary_is_ttl_cached(server, tmp_path):
+    path = f"/get_programs_summary?db_path={_q(server.db_path)}"
+    first, _ = server.get_json(path)
+
+    # Mutate the DB after the first fetch; a fresh read would see the new row.
+    db = ProgramDatabase(
+        DatabaseConfig(db_path=str(tmp_path / server.db_path)), read_only=False
+    )
+    try:
+        db.cursor.execute(
+            "INSERT INTO programs (id, code, language, generation, timestamp) "
+            "VALUES ('extra', 'x', 'python', 99, 999.0)"
+        )
+        db.conn.commit()
+    finally:
+        db.close()
+
+    # Within the TTL the cached (stale) payload is returned, proving the cache.
+    second, _ = server.get_json(path)
+    assert second == first
+    assert len(second) == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+
+
+def test_summary_cache_does_not_collide_with_programs_cache(server):
+    """Namespaced key: summary and full-programs payloads stay distinct."""
+    summaries, _ = server.get_json(
+        f"/get_programs_summary?db_path={_q(server.db_path)}"
+    )
+    programs, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+
+    # Summaries never ship source code; full programs do.
+    assert all(not s.get("code") for s in summaries)
+    assert any(p.get("code") for p in programs)
+
+
+# -------------------------------------------------------------------------- P11
+
+
+def test_get_programs_default_ships_full_code(server):
+    programs, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    assert len(programs) == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+    # At least one real program carries its full source (default = unchanged).
+    assert any(p.get("code") for p in programs)
+
+
+def test_get_programs_limit_returns_fewer_rows(server):
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    limited, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&limit=2"
+    )
+    assert len(limited) == 2
+    assert limited == full[:2]
+
+
+def test_get_programs_offset_paginates(server):
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    page, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&limit=2&offset=1"
+    )
+    assert page == full[1:3]
+
+
+def test_get_programs_include_code_false_strips_code(server):
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    stripped, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&include_code=false"
+    )
+    assert len(stripped) == len(full)
+    assert all(item.get("code") is None for item in stripped)
+
+
+def test_get_programs_ignores_garbage_pagination_params(server):
+    """Non-integer limit/offset are ignored, preserving default behavior."""
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    same, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&limit=abc&offset=xyz"
+    )
+    assert same == full


### PR DESCRIPTION
## Performance fixes from deep review

Addresses the High/Medium performance findings from the deep review (`docs/deepreview.md` §3), focused on the per-generation DB hot path and the web-UI server. New regression tests; full suite green; ruff/mypy pass.

**Stacked on `fix/security-hardening`** (base branch of this PR).

### Database
- **Index the two hottest columns** — added composite indexes `(correct, combined_score)` and `(island_idx, correct, combined_score)`. The per-generation top-N / elite / island-aggregate queries filter on `correct` and sort by `combined_score`, previously forcing a full scan + filesort every generation. `EXPLAIN QUERY PLAN` now shows an index range scan. `IF NOT EXISTS`, so existing DBs pick them up on open.
- **N+1 in archive inspiration sampling** — `ArchiveInspirationSelector` fetched candidate ids then issued a `get_program()` per id every generation (each re-parsing code + embeddings). Now one `SELECT p.*` per category, building programs via the already-wired `program_from_row` converter (the pattern top-k sampling already used).
- **Novelty check scanned each island twice** — `compute_similarity` and `get_most_similar_program` each walked the whole island and re-parsed every embedding independently. A shared single-pass `_scan_island_similarities` + `compute_similarity_details` / `compute_similarity_details_thread_safe` return `(scores, most-similar program)` from one scan; both novelty judges route through them (the thread-safe variant fetches the winner in the same connection, so the async path makes one executor call instead of two full scans).

### Web UI server
- **3s change-detection poll made cheap** — `handle_get_program_count` no longer loads and JSON-parses every failed-proposal node and reads a file per node; it returns count + max timestamp + a failed-proposal COUNT via an aggregate query.
- **`/get_programs_summary` now TTL-cached** like `/get_programs`, so auto-refresh during active evolution doesn't re-read/re-parse the whole table each time. Both handlers key the cache on the resolved absolute path (distinct namespaces) — fixing a latent collision where a shared relative `db_path` could serve one handler's payload to the other.
- **`/get_programs` opt-in narrowing** — `limit`/`offset`/`include_code` query params; the default (no params) response is byte-for-byte unchanged so existing `viz_tree.html` keeps working.

### Launch
- **Batch Slurm status into one `squeue` per poll tick** — `batch_check_status_async` resolved each Slurm job with its own `squeue` subprocess every tick (~10·N spawns/sec against slurmctld). It now runs a single `squeue --jobs=id1,id2,...` per tick and falls back to the per-job path (with sacct disambiguation) if the batched query is unavailable. Local jobs keep the cheap `Popen.poll()` path.

### LLM
- **Memoize SDK clients** — the anthropic/openai/google client (and its httpx pool) was rebuilt on every query and retry. Now cached by provider + resolved model + structured-output flag + base URL + a non-reversible fingerprint of the relevant key(s); async clients cached per event loop (WeakKeyDictionary) so a loop-bound client is never reused across loops.

### Deferred (documented recommendations)
- **Embeddings as float32 BLOB (P3)** — high value but a storage-format migration with real backward-compat risk for existing JSON-embedding databases; left as follow-up. The single-pass novelty scan above already removes the redundant work without a format change.
- **Sync `add()` PCA/GMM throttle (P5)** — the production path is async, which already throttles the recompute to every `embedding_recompute_interval` inserts in a background thread; the sync path is not the production hot path and throttling it risks breaking tests that expect immediate PCA columns.
- **Per-call async DB reconstruction / connection pooling (P7)** and the parents.py power-law N+1 need connection-lifecycle / row-converter threading that pairs naturally with the duplication cleanup; deferred there to avoid churn and concurrency risk here.

### Testing
New tests: DB index existence + `EXPLAIN QUERY PLAN` uses the index; inspiration sampling returns fully-hydrated programs; single-pass similarity matches the legacy two-method result; batched `squeue`; web-UI count/summary-cache/narrowing; LLM client cache identity. Full suite green; ruff + mypy (CI config) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
