### PR TITLE
fix: drift bugs from the duplication audit (sync/async twins)

### DIFF
--- a/shinka/core/async_novelty_judge.py
+++ b/shinka/core/async_novelty_judge.py
@@ -208,6 +208,7 @@ class AsyncNoveltyJudge:
             response = await self.async_llm_client.query(
                 msg=user_msg,
                 system_msg=NOVELTY_SYSTEM_MSG,
+                llm_kwargs=self.async_llm_client.get_kwargs(),
             )
 
             if response is None or response.content is None:
@@ -231,40 +232,6 @@ class AsyncNoveltyJudge:
         except Exception as e:
             logger.error(f"Error in novelty LLM check: {e}")
             return True, f"Error in novelty check: {e}", 0.0
-
-    async def _single_novelty_check_async(
-        self, code_content: str, similar_program: Program, parent_program: Program
-    ) -> Tuple[bool, float, str]:
-        """Perform a single async novelty check against a similar program.
-
-        Returns:
-            Tuple of (is_novel, cost, explanation)
-        """
-        try:
-            # Construct novelty prompt
-            novelty_prompt = self._construct_novelty_prompt(
-                code_content, similar_program, parent_program
-            )
-
-            # Query LLM asynchronously
-            response = await self.async_llm_client.query(
-                msg=novelty_prompt,
-                system_msg="You are a code novelty assessor. Determine if the new code is sufficiently different from the existing code.",
-            )
-
-            if not response or not response.content:
-                # Fail CLOSED on empty response (is_novel=False => reject).
-                return False, 0.0, "No response from LLM (failing closed)"
-
-            # Parse response for novelty decision
-            is_novel = self._parse_novelty_response(response.content)
-            cost = response.cost if hasattr(response, "cost") else 0.0
-
-            return is_novel, cost, response.content[:200]  # Truncate explanation
-
-        except Exception as e:
-            logger.warning(f"Single novelty check failed: {e}")
-            return True, 0.0, f"Error: {str(e)}"
 
     def _read_code_file(self, exec_fname: str) -> Optional[str]:
         """Read code file content."""

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -3622,8 +3622,10 @@ class ShinkaEvolveRunner:
             meta_patch_data = {
                 "api_costs": total_costs,
                 "patch_type": patch_type,
-                "patch_name": patch_name,
-                "patch_description": patch_description,
+                "patch_name": patch_name if "patch_name" in locals() else None,
+                "patch_description": patch_description
+                if "patch_description" in locals()
+                else None,
                 "num_applied": 0,
                 "error_attempt": "Max fix attempts reached without success.",
                 "last_error_msg": error_str if "error_str" in locals() else None,
@@ -3631,7 +3633,9 @@ class ShinkaEvolveRunner:
                 "resample_attempt": resample_attempt,
                 "patch_attempt": self.evo_config.max_patch_attempts,
                 **llm_kwargs,  # Spread llm_kwargs like _run_patch_async
-                "llm_result": response.to_dict() if response else None,
+                "llm_result": response.to_dict()
+                if "response" in locals() and response
+                else None,
             }
 
             return None, meta_patch_data, False

--- a/shinka/core/async_summarizer.py
+++ b/shinka/core/async_summarizer.py
@@ -249,6 +249,7 @@ class AsyncMetaSummarizer:
         response = await self.async_llm_client.query(
             msg=user_msg,
             system_msg=META_STEP2_SYSTEM_MSG,
+            llm_kwargs=self.async_llm_client.get_kwargs(),
         )
 
         if response is None:
@@ -290,6 +291,7 @@ class AsyncMetaSummarizer:
         response = await self.async_llm_client.query(
             msg=user_msg,
             system_msg=META_STEP3_SYSTEM_MSG,
+            llm_kwargs=self.async_llm_client.get_kwargs(),
         )
 
         if response is None:

--- a/shinka/core/prompt_evolver.py
+++ b/shinka/core/prompt_evolver.py
@@ -192,13 +192,14 @@ class SystemPromptEvolver:
         """
         self.llm_client = llm_client
 
-        for p in patch_types:
-            if p not in ["diff", "full"]:
-                raise ValueError(f"Invalid patch type: {p}")
         if patch_types is None:
             patch_types = ["diff", "full"]
         if patch_type_probs is None:
             patch_type_probs = [0.7, 0.3]
+
+        for p in patch_types:
+            if p not in ["diff", "full"]:
+                raise ValueError(f"Invalid patch type: {p}")
 
         # Normalize probabilities
         prob_sum = sum(patch_type_probs)
@@ -463,6 +464,10 @@ class AsyncSystemPromptEvolver:
         if patch_type_probs is None:
             patch_type_probs = [0.7, 0.3]
 
+        for p in patch_types:
+            if p not in ["diff", "full"]:
+                raise ValueError(f"Invalid patch type: {p}")
+
         # Normalize probabilities
         prob_sum = sum(patch_type_probs)
         if not np.isclose(prob_sum, 1.0, atol=1e-6):
@@ -591,12 +596,10 @@ class AsyncSystemPromptEvolver:
         )
 
         try:
-            # Pass None if llm_kwargs is empty to let client sample params
-            kwargs = self.llm_kwargs if self.llm_kwargs else None
             response = await self.llm_client.query(
                 msg=user_msg,
                 system_msg=system_msg,
-                llm_kwargs=kwargs,
+                llm_kwargs=self.llm_kwargs,
             )
 
             if response is None or not response.content:
@@ -638,12 +641,10 @@ class AsyncSystemPromptEvolver:
         )
 
         try:
-            # Pass None if llm_kwargs is empty to let client sample params
-            kwargs = self.llm_kwargs if self.llm_kwargs else None
             response = await self.llm_client.query(
                 msg=user_msg,
                 system_msg=system_msg,
-                llm_kwargs=kwargs,
+                llm_kwargs=self.llm_kwargs,
             )
 
             if response is None or not response.content:

--- a/shinka/database/async_dbase.py
+++ b/shinka/database/async_dbase.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple, Dict, Any
 from concurrent.futures import ThreadPoolExecutor
 
 from .complexity import analyze_code_metrics
-from .dbase import Program, ProgramDatabase
+from .dbase import Program, ProgramDatabase, clean_nan_values
 
 logger = logging.getLogger(__name__)
 
@@ -915,7 +915,11 @@ class AsyncProgramDatabase:
                     if details is not None:
                         import json
 
-                        payload = json.dumps(details, sort_keys=True)
+                        # Match the sync event log: strip NaN/Inf so the stored
+                        # JSON is valid and round-trips through a strict parser.
+                        payload = json.dumps(
+                            clean_nan_values(details), sort_keys=True
+                        )
                     conn.execute(
                         """
                         INSERT INTO attempt_log (
@@ -968,7 +972,11 @@ class AsyncProgramDatabase:
                     if details is not None:
                         import json
 
-                        payload = json.dumps(details, sort_keys=True)
+                        # Match the sync event log: strip NaN/Inf so the stored
+                        # JSON is valid and round-trips through a strict parser.
+                        payload = json.dumps(
+                            clean_nan_values(details), sort_keys=True
+                        )
                     conn.execute(
                         """
                         INSERT INTO generation_event_log (

--- a/shinka/database/parents.py
+++ b/shinka/database/parents.py
@@ -300,51 +300,40 @@ class WeightedSamplingStrategy(ParentSamplingStrategy):
             logger.warning("No suitable parent found for weighted sampling")
             return None
 
+        def _safe_json(raw: Any, default: Any) -> Any:
+            """Parse a JSON column, tolerating a corrupt/malformed cell.
+
+            Matches the canonical _program_from_row, which wraps each field so
+            one bad cell (that the DB tolerates elsewhere) does not crash
+            weighted parent sampling.
+            """
+            if not raw:
+                return default
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Could not decode JSON column during parent sampling")
+                return default
+
         eligible_programs = []
         for row in archive_rows:
             p_dict = dict(row)
 
-            # Parse JSON fields
-            p_dict["public_metrics"] = (
-                json.loads(p_dict["public_metrics"])
-                if p_dict.get("public_metrics")
-                else {}
+            # Parse JSON fields (defensively)
+            p_dict["public_metrics"] = _safe_json(p_dict.get("public_metrics"), {})
+            p_dict["private_metrics"] = _safe_json(p_dict.get("private_metrics"), {})
+            p_dict["metadata"] = _safe_json(p_dict.get("metadata"), {})
+            p_dict["archive_inspiration_ids"] = _safe_json(
+                p_dict.get("archive_inspiration_ids"), []
             )
-            p_dict["private_metrics"] = (
-                json.loads(p_dict["private_metrics"])
-                if p_dict.get("private_metrics")
-                else {}
+            p_dict["top_k_inspiration_ids"] = _safe_json(
+                p_dict.get("top_k_inspiration_ids"), []
             )
-            p_dict["metadata"] = (
-                json.loads(p_dict["metadata"]) if p_dict.get("metadata") else {}
-            )
-            p_dict["archive_inspiration_ids"] = (
-                json.loads(p_dict["archive_inspiration_ids"])
-                if p_dict.get("archive_inspiration_ids")
-                else []
-            )
-            p_dict["top_k_inspiration_ids"] = (
-                json.loads(p_dict["top_k_inspiration_ids"])
-                if p_dict.get("top_k_inspiration_ids")
-                else []
-            )
-            p_dict["embedding"] = (
-                json.loads(p_dict["embedding"]) if p_dict.get("embedding") else []
-            )
-            p_dict["embedding_pca_2d"] = (
-                json.loads(p_dict["embedding_pca_2d"])
-                if p_dict.get("embedding_pca_2d")
-                else []
-            )
-            p_dict["embedding_pca_3d"] = (
-                json.loads(p_dict["embedding_pca_3d"])
-                if p_dict.get("embedding_pca_3d")
-                else []
-            )
-            p_dict["migration_history"] = (
-                json.loads(p_dict["migration_history"])
-                if p_dict.get("migration_history")
-                else []
+            p_dict["embedding"] = _safe_json(p_dict.get("embedding"), [])
+            p_dict["embedding_pca_2d"] = _safe_json(p_dict.get("embedding_pca_2d"), [])
+            p_dict["embedding_pca_3d"] = _safe_json(p_dict.get("embedding_pca_3d"), [])
+            p_dict["migration_history"] = _safe_json(
+                p_dict.get("migration_history"), []
             )
 
             # Create a simple dataclass-like object from the dict to avoid circular imports

--- a/shinka/llm/llm.py
+++ b/shinka/llm/llm.py
@@ -329,6 +329,8 @@ class LLMClient:
                     f"for model={model_name} kwargs={llm_kwargs}: {str(e)}"
                 )
                 try_count += 1
+                if try_count < MAX_RETRIES:
+                    time.sleep(1)  # Add delay between retries (parity with siblings)
         return None
 
 

--- a/shinka/llm/providers/anthropic.py
+++ b/shinka/llm/providers/anthropic.py
@@ -1,7 +1,7 @@
 import backoff
 import anthropic
 from shinka.llm.constants import BACKOFF_MAX_TIME, BACKOFF_MAX_TRIES, BACKOFF_MAX_VALUE
-from .pricing import calculate_cost
+from .pricing import calculate_cost, model_exists
 from .result import QueryResult
 import logging
 
@@ -20,7 +20,16 @@ def get_anthropic_costs(response, model):
     all_out_tokens = response.usage.output_tokens
     # Unclear how to get thinking tokens from Anthropic
     thinking_tokens = 0
-    input_cost, output_cost = calculate_cost(model, input_tokens, all_out_tokens)
+    # Fall back to a zero cost (with a warning) on an unknown model instead of
+    # raising, mirroring openai/local so a pricing-catalog miss never aborts a
+    # completed generation.
+    if model_exists(model):
+        input_cost, output_cost = calculate_cost(model, input_tokens, all_out_tokens)
+    else:
+        logger.warning(
+            "Model '%s' has no pricing entry; defaulting query cost to 0.", model
+        )
+        input_cost, output_cost = 0.0, 0.0
     return {
         "input_tokens": input_tokens,
         "output_tokens": all_out_tokens,
@@ -179,9 +188,7 @@ async def query_anthropic_async(
             ],
         }
     )
-    input_cost, output_cost = calculate_cost(
-        model, response.usage.input_tokens, response.usage.output_tokens
-    )
+    cost_results = get_anthropic_costs(response, model)
     result = QueryResult(
         content=content,
         msg=msg,
@@ -189,11 +196,7 @@ async def query_anthropic_async(
         new_msg_history=new_msg_history,
         model_name=model,
         kwargs=kwargs,
-        input_tokens=response.usage.input_tokens,
-        output_tokens=response.usage.output_tokens,
-        cost=input_cost + output_cost,
-        input_cost=input_cost,
-        output_cost=output_cost,
+        **cost_results,
         thought=thought,
         model_posteriors=model_posteriors,
     )

--- a/shinka/llm/providers/deepseek.py
+++ b/shinka/llm/providers/deepseek.py
@@ -1,7 +1,7 @@
 import backoff
 import openai
 from shinka.llm.constants import BACKOFF_MAX_TIME, BACKOFF_MAX_TRIES, BACKOFF_MAX_VALUE
-from .pricing import calculate_cost
+from .pricing import calculate_cost, model_exists
 from .result import QueryResult
 import logging
 
@@ -19,6 +19,42 @@ def backoff_handler(details):
         logger.info(
             f"DeepSeek - Retry {details['tries']} due to error: {exc}. Waiting {details['wait']:0.1f}s..."
         )
+
+
+def get_deepseek_costs(response, model):
+    """Token counts and costs for a DeepSeek response.
+
+    Reasoning ("thinking") tokens are billed within ``completion_tokens`` but
+    must be reported separately, so ``output_tokens`` excludes them. Cost is
+    still computed on the full completion count. An unknown model falls back to
+    a zero cost with a warning instead of raising, mirroring
+    ``openai.get_openai_costs`` / ``local_openai._extract_costs`` so a
+    pricing-catalog miss never aborts a completed generation.
+    """
+    in_tokens = response.usage.prompt_tokens
+    all_out_tokens = response.usage.completion_tokens
+    try:
+        thinking_tokens = response.usage.completion_tokens_details.reasoning_tokens
+    except Exception:
+        thinking_tokens = 0
+    out_tokens = all_out_tokens - thinking_tokens
+
+    if model_exists(model):
+        input_cost, output_cost = calculate_cost(model, in_tokens, all_out_tokens)
+    else:
+        logger.warning(
+            "Model '%s' has no pricing entry; defaulting query cost to 0.", model
+        )
+        input_cost, output_cost = 0.0, 0.0
+
+    return {
+        "input_tokens": in_tokens,
+        "output_tokens": out_tokens,
+        "thinking_tokens": thinking_tokens,
+        "input_cost": input_cost,
+        "output_cost": output_cost,
+        "cost": input_cost + output_cost,
+    }
 
 
 @backoff.on_exception(
@@ -61,19 +97,12 @@ def query_deepseek(
     content = response.choices[0].message.content
     try:
         thought = response.choices[0].message.reasoning_content
-    except:
+    except Exception:
         thought = ""
     new_msg_history.append({"role": "assistant", "content": content})
 
     # Get token counts and costs
-    in_tokens = response.usage.prompt_tokens
-    all_out_tokens = response.usage.completion_tokens
-    try:
-        thinking_tokens = response.usage.completion_tokens_details.reasoning_tokens
-    except Exception:
-        thinking_tokens = 0
-    out_tokens = all_out_tokens - thinking_tokens
-    input_cost, output_cost = calculate_cost(model, in_tokens, all_out_tokens)
+    cost_results = get_deepseek_costs(response, model)
 
     # Collect all results
     result = QueryResult(
@@ -83,12 +112,7 @@ def query_deepseek(
         new_msg_history=new_msg_history,
         model_name=model,
         kwargs=kwargs,
-        input_tokens=in_tokens,
-        output_tokens=out_tokens,
-        thinking_tokens=thinking_tokens,
-        cost=input_cost + output_cost,
-        input_cost=input_cost,
-        output_cost=output_cost,
+        **cost_results,
         thought=thought,
         model_posteriors=model_posteriors,
     )
@@ -135,12 +159,14 @@ async def query_deepseek_async(
     content = response.choices[0].message.content
     try:
         thought = response.choices[0].message.reasoning_content
-    except:
+    except Exception:
         thought = ""
     new_msg_history.append({"role": "assistant", "content": content})
-    input_cost, output_cost = calculate_cost(
-        model, response.usage.prompt_tokens, response.usage.completion_tokens
-    )
+
+    # Get token counts and costs (parity with the sync path: reasoning tokens
+    # are subtracted from output and reported via thinking_tokens).
+    cost_results = get_deepseek_costs(response, model)
+
     return QueryResult(
         content=content,
         msg=msg,
@@ -148,11 +174,7 @@ async def query_deepseek_async(
         new_msg_history=new_msg_history,
         model_name=model,
         kwargs=kwargs,
-        input_tokens=response.usage.prompt_tokens,
-        output_tokens=response.usage.completion_tokens,
-        cost=input_cost + output_cost,
-        input_cost=input_cost,
-        output_cost=output_cost,
+        **cost_results,
         thought=thought,
         model_posteriors=model_posteriors,
     )

--- a/shinka/llm/providers/gemini.py
+++ b/shinka/llm/providers/gemini.py
@@ -13,6 +13,26 @@ MAX_TRIES = BACKOFF_MAX_TRIES
 MAX_VALUE = BACKOFF_MAX_VALUE
 MAX_TIME = BACKOFF_MAX_TIME
 
+# Single source of truth for the thinking-token budget when the caller omits it.
+# Sync and async must share this so an omitted arg does not make one path
+# "think" while the other does not.
+DEFAULT_THINKING_BUDGET = 1024
+
+
+class GeminiStructuredOutputError(ValueError):
+    """Raised when structured output is requested but unsupported.
+
+    A dedicated ``ValueError`` subclass so the retry decorator can give up on it
+    immediately (see ``_giveup_gemini``): it is deterministic and can never
+    succeed on retry, unlike the transient errors the backoff wrapper exists to
+    absorb.
+    """
+
+
+def _giveup_gemini(exc: Exception) -> bool:
+    """Give up (do not retry) on the deterministic structured-output error only."""
+    return isinstance(exc, GeminiStructuredOutputError)
+
 
 def build_gemini_thinking_config(thinking_budget: int):
     """Build Gemini ThinkingConfig across SDK versions.
@@ -184,6 +204,7 @@ def validate_gemini_response(response, content: str) -> None:
     max_value=MAX_VALUE,
     max_time=MAX_TIME,
     on_backoff=backoff_handler,
+    giveup=_giveup_gemini,
 )
 def query_gemini(
     client,
@@ -200,7 +221,9 @@ def query_gemini(
     Based on: https://ai.google.dev/gemini-api/docs/text-generation
     """
     if output_model is not None:
-        raise ValueError("Gemini does not support structured output.")
+        raise GeminiStructuredOutputError(
+            "Gemini does not support structured output."
+        )
 
     # Build structured contents
     contents = gemini_build_contents(msg_history, msg)
@@ -209,7 +232,7 @@ def query_gemini(
     temperature = kwargs.get("temperature", 0.8)
     top_p = kwargs.get("top_p", 1.0)
     max_tokens = kwargs.get("max_tokens", 2048)
-    thinking_budget = kwargs.get("thinking_budget", 1024)
+    thinking_budget = kwargs.get("thinking_budget", DEFAULT_THINKING_BUDGET)
 
     generation_config = types.GenerateContentConfig(
         temperature=float(temperature),
@@ -263,6 +286,7 @@ def query_gemini(
     max_value=MAX_VALUE,
     max_time=MAX_TIME,
     on_backoff=backoff_handler,
+    giveup=_giveup_gemini,
 )
 async def query_gemini_async(
     client,
@@ -279,7 +303,9 @@ async def query_gemini_async(
     Based on: https://ai.google.dev/gemini-api/docs/text-generation
     """
     if output_model is not None:
-        raise ValueError("Gemini does not support structured output.")
+        raise GeminiStructuredOutputError(
+            "Gemini does not support structured output."
+        )
 
     # Build structured contents
     contents = gemini_build_contents(msg_history, msg)
@@ -288,7 +314,7 @@ async def query_gemini_async(
     temperature = kwargs.get("temperature", 0.8)
     top_p = kwargs.get("top_p", 1.0)
     max_tokens = kwargs.get("max_tokens", 2048)
-    thinking_budget = kwargs.get("thinking_budget", 0)
+    thinking_budget = kwargs.get("thinking_budget", DEFAULT_THINKING_BUDGET)
 
     generation_config = types.GenerateContentConfig(
         temperature=float(temperature),

--- a/shinka/pricing/normalization.py
+++ b/shinka/pricing/normalization.py
@@ -114,6 +114,7 @@ def _apply_overlay(
     overlay = _read_overlay(overlay_path)
     _add_model_aliases(entries, overlay.get("model_aliases", []))
     _apply_llm_overrides(entries, overlay.get("llm_overrides", []))
+    _apply_embedding_overrides(entries, overlay.get("embedding_overrides", []))
 
 
 def _read_overlay(path: Path) -> dict[str, Any]:
@@ -190,6 +191,33 @@ def _apply_llm_overrides(
         if threshold is not None:
             values["tier_threshold"] = threshold
         entries[key] = ModelPrice(**values)
+
+
+def _apply_embedding_overrides(
+    entries: dict[tuple[ModelKind, str, str], ModelPrice], overrides: Any
+) -> None:
+    """Apply pinned embedding prices at runtime, matching the CSV build.
+
+    Without this, embedding_overrides were applied only when regenerating the
+    bundled CSVs, so a live models.dev refresh silently dropped pinned prices
+    (e.g. gemini-embedding-exp-03-07 -> 0.0) back to the upstream values.
+    """
+    if not isinstance(overrides, list):
+        return
+    for override in overrides:
+        if not isinstance(override, dict):
+            continue
+        provider = override.get("provider")
+        model_name = override.get("model_name")
+        if not isinstance(provider, str) or not isinstance(model_name, str):
+            continue
+        entry = entries.get(("embedding", provider, model_name))
+        if entry is None:
+            continue
+        values = asdict(entry)
+        for field in ("input_price", "output_price"):
+            _apply_price_override(values, override, field)
+        entries[("embedding", provider, model_name)] = ModelPrice(**values)
 
 
 def _apply_price_override(

--- a/shinka/webui/viz_tree.html
+++ b/shinka/webui/viz_tree.html
@@ -3871,15 +3871,8 @@ ${'='.repeat(80)}
             }
         }
 
-        function getSelectedNodeId() {
-            const selectedNode = document.querySelector('.node.selected');
-            if (selectedNode) {
-                // Extract node ID from D3 data
-                const d3Node = d3.select(selectedNode).datum();
-                return d3Node ? d3Node.data.id : null;
-            }
-            return null;
-        }
+        // getSelectedNodeId is defined once, later in this script (the copy
+        // here was dead — shadowed by the hoisted later definition).
 
         // Function to load and process data from a database file
         function loadDatabase(dbPath) {

--- a/tests/test_core_drift.py
+++ b/tests/test_core_drift.py
@@ -1,0 +1,242 @@
+"""Regression tests for async/sync drift bugs in shinka.core.
+
+Each test pins behavior of a LIVE async path against its (correct) sync twin:
+
+1. Async summarizer / novelty / prompt-evolver must forward ``llm_kwargs`` on
+   their LLM query calls (sync twins pin it; async copies used to drop it,
+   silently falling back to default-sampled model/temperature).
+2. ``_run_fix_patch_async`` must not ``NameError`` when the FIRST LLM response
+   is ``None`` (twin ``_run_patch_async`` guards ``patch_name`` with
+   ``"patch_name" in locals()``).
+3. ``SystemPromptEvolver``/``AsyncSystemPromptEvolver`` must construct with the
+   documented ``patch_types=None`` default without raising.
+4. The dead ``_single_novelty_check_async`` (called undefined helpers) must be
+   gone from ``AsyncNoveltyJudge``.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from shinka.core.async_summarizer import AsyncMetaSummarizer
+from shinka.core.async_novelty_judge import AsyncNoveltyJudge
+from shinka.core.summarizer import MetaSummarizer
+from shinka.core.novelty_judge import NoveltyJudge
+from shinka.core.prompt_evolver import (
+    SystemPromptEvolver,
+    AsyncSystemPromptEvolver,
+)
+from shinka.core.async_runner import ShinkaEvolveRunner
+from shinka.database import Program
+from shinka.database.prompt_dbase import create_system_prompt
+
+
+SENTINEL_KWARGS = {"model_name": "sentinel-model", "temperature": 0.123}
+
+
+@dataclass
+class DummyResponse:
+    content: str
+    cost: float = 0.1
+
+
+class RecordingAsyncLLM:
+    """Async LLM stub that records the ``llm_kwargs`` forwarded to ``query``."""
+
+    def __init__(self, content: str = "NOVEL - a sufficiently long response body."):
+        self.content = content
+        self.kwargs_log: list = []
+
+    def get_kwargs(self, model_sample_probs=None):
+        # New dict each call, mirroring the real client.
+        return dict(SENTINEL_KWARGS)
+
+    async def query(self, msg, system_msg, llm_kwargs=None, **extra):
+        self.kwargs_log.append(llm_kwargs)
+        return DummyResponse(content=self.content, cost=0.1)
+
+
+# --------------------------------------------------------------------------- #
+# Bug 1: async LLM calls must forward llm_kwargs (not silently drop them)
+# --------------------------------------------------------------------------- #
+
+
+def test_async_summarizer_step2_forwards_llm_kwargs():
+    sync = MetaSummarizer(meta_llm_client=None, max_recommendations=3)
+    fake = RecordingAsyncLLM(content="Global insight block")
+    summarizer = AsyncMetaSummarizer(sync, async_llm_client=fake)
+
+    result, cost = asyncio.run(
+        summarizer._step2_global_insights_async("individual summaries", None)
+    )
+
+    assert result == "Global insight block"
+    assert fake.kwargs_log == [SENTINEL_KWARGS]
+
+
+def test_async_summarizer_step3_forwards_llm_kwargs():
+    sync = MetaSummarizer(meta_llm_client=None, max_recommendations=3)
+    fake = RecordingAsyncLLM(content="1. Recommendation A")
+    summarizer = AsyncMetaSummarizer(sync, async_llm_client=fake)
+
+    result, cost = asyncio.run(
+        summarizer._step3_generate_recommendations_async("global insights", None)
+    )
+
+    assert result == "1. Recommendation A"
+    assert fake.kwargs_log == [SENTINEL_KWARGS]
+
+
+def test_async_novelty_forwards_llm_kwargs():
+    sync_judge = NoveltyJudge(language="python")
+    fake = RecordingAsyncLLM(content="NOVEL - meaningfully different implementation.")
+    judge = AsyncNoveltyJudge(sync_judge, async_llm_client=fake)
+    similar = Program(
+        id="similar-1",
+        code="def existing():\n    return 1\n",
+        language="python",
+        generation=1,
+    )
+
+    is_novel, explanation, cost = asyncio.run(
+        judge._check_llm_novelty_async("def proposed():\n    return 2\n", similar)
+    )
+
+    assert is_novel is True
+    assert fake.kwargs_log == [SENTINEL_KWARGS]
+
+
+def test_async_prompt_evolver_diff_forwards_llm_kwargs():
+    fake = RecordingAsyncLLM(
+        content="<PROMPT>You are a rigorous engineer who writes precise code.</PROMPT>"
+    )
+    evolver = AsyncSystemPromptEvolver(fake, llm_kwargs=dict(SENTINEL_KWARGS))
+    parent = create_system_prompt(
+        prompt_text="You are an expert programmer.",
+        generation=0,
+        patch_type="init",
+    )
+
+    asyncio.run(evolver._diff_mutate_async(parent, top_programs=[]))
+
+    assert fake.kwargs_log == [SENTINEL_KWARGS]
+
+
+def test_async_prompt_evolver_full_forwards_llm_kwargs():
+    fake = RecordingAsyncLLM(
+        content="<PROMPT>You are a rigorous engineer who writes precise code.</PROMPT>"
+    )
+    evolver = AsyncSystemPromptEvolver(fake, llm_kwargs=dict(SENTINEL_KWARGS))
+    parent = create_system_prompt(
+        prompt_text="You are an expert programmer.",
+        generation=0,
+        patch_type="init",
+    )
+
+    asyncio.run(evolver._full_rewrite_async(parent, top_programs=[]))
+
+    assert fake.kwargs_log == [SENTINEL_KWARGS]
+
+
+# --------------------------------------------------------------------------- #
+# Bug 2: _run_fix_patch_async must handle a first None response gracefully
+# --------------------------------------------------------------------------- #
+
+
+class FirstNoneAsyncLLM:
+    """Async LLM stub whose first (and only) response is ``None``."""
+
+    def __init__(self):
+        self.query_calls = 0
+
+    def get_kwargs(self, model_sample_probs=None):
+        return {"model_name": "fix-model", "temperature": 0.5}
+
+    async def query(self, **kwargs):
+        self.query_calls += 1
+        return None
+
+
+def _build_fix_runner(llm, max_patch_attempts=1):
+    runner = object.__new__(ShinkaEvolveRunner)
+    runner.prompt_sampler = SimpleNamespace(
+        sample_fix=lambda **kwargs: ("fix system", "fix message", "full")
+    )
+    runner.verbose = False
+    runner.evo_config = SimpleNamespace(max_patch_attempts=max_patch_attempts)
+    runner.llm = llm
+    runner.llm_selection = None
+
+    async def _save_patch_attempt_async(**kwargs):
+        return None
+
+    runner._save_patch_attempt_async = _save_patch_attempt_async
+    return runner
+
+
+def test_run_fix_patch_async_handles_first_none_response():
+    llm = FirstNoneAsyncLLM()
+    runner = _build_fix_runner(llm, max_patch_attempts=1)
+
+    result = asyncio.run(
+        runner._run_fix_patch_async(
+            incorrect_program=SimpleNamespace(id="ip-1", code="def broken():\n    x\n"),
+            ancestor_inspirations=[],
+            generation=4,
+        )
+    )
+
+    patch_text, meta_patch_data, success = result
+
+    assert llm.query_calls == 1
+    assert patch_text is None
+    assert success is False
+    # Graceful terminal path (NOT the swallowed-NameError fallback, which would
+    # set error_attempt to a NameError string and drop llm_kwargs/metadata).
+    assert meta_patch_data["error_attempt"] == (
+        "Max fix attempts reached without success."
+    )
+    assert meta_patch_data["patch_name"] is None
+    assert meta_patch_data["patch_description"] is None
+    assert meta_patch_data["llm_result"] is None
+    # llm_kwargs were spread into the metadata (accumulated context preserved).
+    assert meta_patch_data["model_name"] == "fix-model"
+
+
+# --------------------------------------------------------------------------- #
+# Bug 3: evolver constructors must accept the documented default
+# --------------------------------------------------------------------------- #
+
+
+def test_system_prompt_evolver_constructs_with_default_patch_types():
+    evolver = SystemPromptEvolver(llm_client=object())
+    assert evolver.patch_types == ["diff", "full"]
+    assert pytest.approx(sum(evolver.patch_type_probs), abs=1e-6) == 1.0
+
+
+def test_async_system_prompt_evolver_constructs_with_default_patch_types():
+    evolver = AsyncSystemPromptEvolver(llm_client=object())
+    assert evolver.patch_types == ["diff", "full"]
+    assert pytest.approx(sum(evolver.patch_type_probs), abs=1e-6) == 1.0
+
+
+def test_system_prompt_evolver_rejects_invalid_patch_types():
+    with pytest.raises(ValueError):
+        SystemPromptEvolver(llm_client=object(), patch_types=["bogus"])
+    with pytest.raises(ValueError):
+        AsyncSystemPromptEvolver(llm_client=object(), patch_types=["bogus"])
+
+
+# --------------------------------------------------------------------------- #
+# Bug 4: dead method calling undefined helpers must be removed
+# --------------------------------------------------------------------------- #
+
+
+def test_async_novelty_judge_dead_method_removed():
+    assert "_single_novelty_check_async" not in vars(AsyncNoveltyJudge)
+    assert not hasattr(AsyncNoveltyJudge, "_single_novelty_check_async")
+    # The helpers the dead method referenced were never defined anywhere.
+    assert not hasattr(AsyncNoveltyJudge, "_construct_novelty_prompt")
+    assert not hasattr(AsyncNoveltyJudge, "_parse_novelty_response")

--- a/tests/test_dedup_drift_local.py
+++ b/tests/test_dedup_drift_local.py
@@ -1,0 +1,127 @@
+"""Regression tests for drift bugs fixed on the dedup branch (local group).
+
+- #13: embedding_overrides are applied at runtime, not only at CSV-build time.
+- #1:  the async event log strips NaN/Inf (valid JSON), like the sync log.
+- #2:  weighted parent sampling tolerates a corrupt JSON cell.
+"""
+
+import asyncio
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.database.async_dbase import AsyncProgramDatabase
+from shinka.pricing.catalog import ModelPrice
+from shinka.pricing.normalization import MILLION, _apply_embedding_overrides
+
+
+def _embedding_price(input_price: float) -> ModelPrice:
+    return ModelPrice(
+        model_name="gemini-embedding-exp-03-07",
+        api_model_name="gemini-embedding-exp-03-07",
+        provider="google",
+        kind="embedding",
+        input_price=input_price,
+        output_price=0.0,
+    )
+
+
+def test_embedding_overrides_applied_at_runtime():
+    key = ("embedding", "google", "gemini-embedding-exp-03-07")
+    entries = {key: _embedding_price(input_price=1.5 / MILLION)}
+
+    _apply_embedding_overrides(
+        entries,
+        [{"provider": "google", "model_name": "gemini-embedding-exp-03-07",
+          "input_price": 0.0}],
+    )
+
+    # The pinned 0.0 overrides the upstream price (was drifting on live refresh).
+    assert entries[key].input_price == 0.0
+
+
+def test_embedding_overrides_ignores_unknown_and_malformed():
+    key = ("embedding", "google", "gemini-embedding-exp-03-07")
+    entries = {key: _embedding_price(input_price=2.0 / MILLION)}
+    _apply_embedding_overrides(entries, "not-a-list")  # tolerated
+    _apply_embedding_overrides(entries, [{"provider": "google"}])  # no model_name
+    _apply_embedding_overrides(
+        entries, [{"provider": "x", "model_name": "y", "input_price": 0.0}]
+    )  # unknown key
+    assert entries[key].input_price == 2.0 / MILLION
+
+
+def _program(pid: str) -> Program:
+    return Program(
+        id=pid,
+        code="def f():\n    return 1\n",
+        correct=True,
+        combined_score=1.0,
+        generation=0,
+        island_idx=0,
+        embedding=[0.1, 0.2],
+    )
+
+
+def test_async_event_log_strips_nan():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "events.db"
+        sync_db = ProgramDatabase(
+            config=DatabaseConfig(db_path=str(db_path), num_islands=1)
+        )
+        sync_db.add(_program("p0"))
+        adb = AsyncProgramDatabase(sync_db, max_workers=1)
+
+        async def _run():
+            await adb.record_attempt_event_async(
+                generation=1,
+                stage="proposal",
+                status="failed",
+                details={"score": float("nan"), "ok": 1.0},
+            )
+
+        asyncio.run(_run())
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT details FROM attempt_log").fetchall()
+        conn.close()
+        assert rows, "no attempt event recorded"
+        # Strict JSON parse must succeed (NaN would be an invalid token).
+        for row in rows:
+            if row["details"]:
+                parsed = json.loads(row["details"])  # raises on 'NaN'
+                assert parsed.get("score") is None
+                assert parsed.get("ok") == 1.0
+
+
+def test_parent_sampling_tolerates_corrupt_json_cell():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "corrupt.db"
+        db = ProgramDatabase(
+            config=DatabaseConfig(db_path=str(db_path), num_islands=1)
+        )
+        db.add(_program("good"))  # a correct program is auto-added to the archive
+        # Corrupt a JSON column that weighted sampling parses.
+        db.cursor.execute(
+            "UPDATE programs SET metadata = ? WHERE id = ?",
+            ("{not valid json", "good"),
+        )
+        db.conn.commit()
+
+        # Should not raise even though a cell is corrupt.
+        from shinka.database.parents import WeightedSamplingStrategy
+
+        selector = WeightedSamplingStrategy(
+            cursor=db.cursor,
+            conn=db.conn,
+            config=db.config,
+            get_program_func=db.get,
+            island_idx=0,
+        )
+        # The internal safe-parse must swallow the bad cell; the call returns a
+        # program or None but never raises JSONDecodeError.
+        result = selector.sample_parent()
+        assert result is None or hasattr(result, "id")

--- a/tests/test_provider_correctness.py
+++ b/tests/test_provider_correctness.py
@@ -244,7 +244,10 @@ class _AsyncNoveltyLLM:
     def __init__(self, response):
         self._response = response
 
-    async def query(self, msg, system_msg):
+    def get_kwargs(self):
+        return {}
+
+    async def query(self, msg, system_msg, llm_kwargs=None):
         return self._response
 
 

--- a/tests/test_provider_drift.py
+++ b/tests/test_provider_drift.py
@@ -1,0 +1,279 @@
+"""Regression tests for sync/async (and sibling-provider) drift fixes.
+
+Each of these bugs is a case where one copy of a duplicated twin diverged from
+the other. The tests pin the copies back together:
+
+* DeepSeek async dropped reasoning-token accounting (reported full
+  ``completion_tokens`` as output and no ``thinking_tokens``) while sync
+  subtracted the reasoning tokens.
+* Gemini's default ``thinking_budget`` forked (sync=1024, async=0), so omitting
+  the arg made sync "think" and async not.
+* Gemini's backoff wrapper retried the deterministic "structured output"
+  ``ValueError`` MAX_TRIES times instead of failing fast.
+* Anthropic / DeepSeek raised on an unknown-model pricing lookup where
+  OpenAI / local fall back to a $0 cost.
+* Sync ``LLMClient.query`` hot-looped its retries with no sleep while all five
+  sibling retry loops slept ~1s.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from google.genai import types
+
+import shinka.llm.llm as llm_mod
+from shinka.llm.llm import LLMClient
+from shinka.llm.constants import MAX_RETRIES
+from shinka.llm.providers.anthropic import get_anthropic_costs
+from shinka.llm.providers.deepseek import (
+    get_deepseek_costs,
+    query_deepseek,
+    query_deepseek_async,
+)
+from shinka.llm.providers.gemini import (
+    DEFAULT_THINKING_BUDGET,
+    GeminiStructuredOutputError,
+    _giveup_gemini,
+    query_gemini,
+    query_gemini_async,
+)
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek stubs
+# ---------------------------------------------------------------------------
+
+
+def _deepseek_response(
+    *,
+    prompt_tokens,
+    completion_tokens,
+    reasoning_tokens,
+    content="ok",
+    reasoning_content="thinking",
+):
+    details = SimpleNamespace(reasoning_tokens=reasoning_tokens)
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        completion_tokens_details=details,
+    )
+    message = SimpleNamespace(content=content, reasoning_content=reasoning_content)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+class _FakeDeepSeekClient:
+    def __init__(self, response, *, is_async=False):
+        async def _acreate(**kwargs):
+            return response
+
+        def _create(**kwargs):
+            return response
+
+        create = _acreate if is_async else _create
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek async reasoning-token accounting parity
+# ---------------------------------------------------------------------------
+
+
+def test_deepseek_async_subtracts_thinking_tokens():
+    # completion_tokens includes the reasoning tokens; output must exclude them
+    # and thinking_tokens must be reported (both were dropped in the async twin).
+    response = _deepseek_response(
+        prompt_tokens=10, completion_tokens=30, reasoning_tokens=12
+    )
+    client = _FakeDeepSeekClient(response, is_async=True)
+    result = asyncio.run(
+        query_deepseek_async(client, "deepseek-drift-test", "msg", "sys", [], None)
+    )
+    assert result.input_tokens == 10
+    assert result.thinking_tokens == 12
+    assert result.output_tokens == 18  # 30 - 12, not the raw 30
+
+
+def test_deepseek_sync_and_async_report_identical_token_accounting():
+    response = _deepseek_response(
+        prompt_tokens=10, completion_tokens=30, reasoning_tokens=12
+    )
+    sync_result = query_deepseek(
+        _FakeDeepSeekClient(response), "deepseek-drift-test", "msg", "sys", [], None
+    )
+    async_result = asyncio.run(
+        query_deepseek_async(
+            _FakeDeepSeekClient(response, is_async=True),
+            "deepseek-drift-test",
+            "msg",
+            "sys",
+            [],
+            None,
+        )
+    )
+    assert sync_result.output_tokens == async_result.output_tokens == 18
+    assert sync_result.thinking_tokens == async_result.thinking_tokens == 12
+    assert sync_result.input_tokens == async_result.input_tokens == 10
+
+
+# ---------------------------------------------------------------------------
+# Unknown-model pricing falls back to $0 (anthropic + deepseek)
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_unknown_model_pricing_defaults_to_zero():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(input_tokens=10, output_tokens=20)
+    )
+    costs = get_anthropic_costs(response, "anthropic/not-in-catalog")
+    assert costs["cost"] == 0.0
+    assert costs["input_cost"] == 0.0
+    assert costs["output_cost"] == 0.0
+    # Token counts are still reported, only the price is zeroed.
+    assert costs["input_tokens"] == 10
+    assert costs["output_tokens"] == 20
+
+
+def test_deepseek_unknown_model_pricing_defaults_to_zero():
+    response = _deepseek_response(
+        prompt_tokens=5, completion_tokens=15, reasoning_tokens=5
+    )
+    costs = get_deepseek_costs(response, "deepseek/not-in-catalog")
+    assert costs["cost"] == 0.0
+    assert costs["input_cost"] == 0.0
+    assert costs["output_cost"] == 0.0
+    assert costs["output_tokens"] == 10  # 15 - 5
+    assert costs["thinking_tokens"] == 5
+
+
+def test_query_deepseek_does_not_raise_on_unknown_model():
+    # A pricing-catalog miss must not abort an otherwise-complete generation.
+    response = _deepseek_response(
+        prompt_tokens=5, completion_tokens=15, reasoning_tokens=5
+    )
+    result = query_deepseek(
+        _FakeDeepSeekClient(response), "deepseek/not-in-catalog", "msg", "sys", [], None
+    )
+    assert result.cost == 0.0
+    assert result.content == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Gemini stubs
+# ---------------------------------------------------------------------------
+
+
+def _gemini_part(text, *, thought=False):
+    return SimpleNamespace(text=text, thought=thought)
+
+
+def _gemini_response(*, parts=None, text=None, finish_reason=types.FinishReason.STOP):
+    content = SimpleNamespace(parts=parts or [_gemini_part("hi")])
+    candidate = SimpleNamespace(content=content, finish_reason=finish_reason)
+    return SimpleNamespace(candidates=[candidate], text=text)
+
+
+class _FakeGeminiClient:
+    def __init__(self, response):
+        self.models = SimpleNamespace(generate_content=lambda **kwargs: response)
+
+
+class _FakeGeminiAsyncClient:
+    def __init__(self, response):
+        async def _generate(**kwargs):
+            return response
+
+        self.aio = SimpleNamespace(
+            models=SimpleNamespace(generate_content=_generate)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gemini default thinking_budget is identical for sync and async
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_default_thinking_budget_is_identical_for_sync_and_async(monkeypatch):
+    from shinka.llm.providers import gemini as gemini_module
+
+    budgets = []
+
+    def _record(thinking_budget):
+        budgets.append(thinking_budget)
+        return None  # thinking_config=None is accepted by GenerateContentConfig
+
+    monkeypatch.setattr(gemini_module, "build_gemini_thinking_config", _record)
+
+    response = _gemini_response(parts=[_gemini_part("hi")])
+    query_gemini(
+        _FakeGeminiClient(response), "gemini-2.5-flash", "m", "s", [], None,
+        max_tokens=64,
+    )
+    asyncio.run(
+        query_gemini_async(
+            _FakeGeminiAsyncClient(response), "gemini-2.5-flash", "m", "s", [], None,
+            max_tokens=64,
+        )
+    )
+
+    # Both paths, given no explicit thinking_budget, use the same constant.
+    assert budgets == [DEFAULT_THINKING_BUDGET, DEFAULT_THINKING_BUDGET]
+    assert DEFAULT_THINKING_BUDGET == 1024
+
+
+# ---------------------------------------------------------------------------
+# Gemini deterministic structured-output error is not retried
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_giveup_predicate_targets_only_structured_output():
+    # The predicate must not broaden what backoff gives up on: transient errors
+    # (empty/truncated responses, API errors) still retry.
+    assert _giveup_gemini(GeminiStructuredOutputError("x")) is True
+    assert _giveup_gemini(ValueError("Gemini response contained no text output")) is False
+    assert _giveup_gemini(RuntimeError("boom")) is False
+
+
+def test_gemini_structured_output_error_is_not_retried(monkeypatch):
+    import time
+
+    sleeps = []
+    # backoff would sleep between retries; give-up must skip all sleeps.
+    monkeypatch.setattr(time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    response = _gemini_response(parts=[_gemini_part("hi")])
+    with pytest.raises(ValueError, match="structured output"):
+        query_gemini(
+            _FakeGeminiClient(response),
+            "gemini-2.5-flash",
+            "m",
+            "s",
+            [],
+            object(),  # any non-None output_model triggers the guard
+        )
+    assert sleeps == []  # not retried => no backoff sleep
+
+
+# ---------------------------------------------------------------------------
+# Sync LLMClient.query sleeps between retries (parity with the 5 siblings)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_llm_client_query_sleeps_between_retries(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(llm_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    def _always_fails(**kwargs):
+        raise RuntimeError("transient failure")
+
+    monkeypatch.setattr(llm_mod, "query", _always_fails)
+
+    client = LLMClient(model_names="test-model", verbose=False)
+    result = client.query("msg", "sys", llm_kwargs={"model_name": "test-model"})
+
+    assert result is None
+    # Sleeps after every failed attempt except the last => MAX_RETRIES - 1.
+    assert sleeps == [1] * (MAX_RETRIES - 1)


### PR DESCRIPTION
## Fix drift bugs from the duplication audit

The duplication audit (`docs/deepreview.md` §4) found ~3,300 duplicated lines dominated by hand-copied **sync↔async twins** (and build↔runtime copies), and — most importantly — **13 latent bugs caused by the copies drifting**, several of them in the copy that actually runs in production while only the (dead) sync copy is tested. This PR fixes those live-path bugs, which the audit lists as the highest-value output and the first consolidation step ("fix the live-path bugs now, independent of refactor"). Each fix ships with a regression test; full suite green; ruff/mypy pass.

**Stacked on `fix/performance`** (base branch of this PR).

### Database / pricing / webui
- **Async event log emitted invalid JSON** — `record_attempt/generation_event_async` used `json.dumps(details)` while the sync log wraps `clean_nan_values(details)`, so NaN/Inf metrics produced non-standard `NaN`/`Infinity` tokens that crash a strict re-parse. Async now matches sync.
- **Weighted parent sampling crashed on a corrupt JSON cell** the DB tolerates elsewhere — its inline parser now defends each field like the canonical `_program_from_row`.
- **Pricing `embedding_overrides` ignored at runtime** — applied only when rebuilding the bundled CSVs, so a live models.dev refresh dropped pinned embedding prices back to upstream. `_apply_overlay` now applies them at runtime too.
- Removed a dead, shadowed `getSelectedNodeId` definition in `viz_tree.html` (the quote-safe `escapeHtml` consolidation already landed in the security PR).

### LLM providers
- **DeepSeek async dropped reasoning-token accounting** — it reported the full `completion_tokens` as output where sync subtracts `thinking_tokens`; both now share one helper.
- **Gemini `thinking_budget` default forked** (1024 sync vs 0 async) — one `DEFAULT_THINKING_BUDGET` constant used by both.
- **Gemini retried an un-retryable error** — the deterministic "does not support structured output" `ValueError` was retried `MAX_TRIES` times; a `giveup=` predicate now surfaces it immediately.
- **Anthropic/DeepSeek aborted a completed generation on an unknown-model pricing miss** — they now fall back to $0 with a warning like OpenAI/local instead of raising.
- **Sync `LLMClient.query` hot-looped on retries** (no sleep) — now sleeps between attempts like its siblings.

### Core async
- **Async summarizer / novelty judge / prompt evolver silently dropped `llm_kwargs`** the sync copies pin, so the live path used default-sampled model/temperature — now forwarded.
- **`_run_fix_patch_async` raised `NameError` on a first `None` LLM response** (swallowed by a broad `except`, discarding costs/metadata) — guarded like its twin `_run_patch_async`.
- **`SystemPromptEvolver.__init__` raised `TypeError` on its documented default** (iterated `patch_types` before the `None`→list normalization) — reordered.
- Deleted a dead method in `async_novelty_judge.py` that called methods defined nowhere (verified zero call sites).

### Structural consolidation — recommended follow-ups (not in this PR)
The audit's consolidation priorities 2–8 (a shared `providers/_retry.py`; a `database/serialization.py` + `schema.py`; collapsing each sync/async twin to one implementation; `plots/style.py`; `shinka-common.css`/`shinka-utils.js`; making `generate_csvs.py` a thin driver over `shinka.pricing`; parametrizing `test_edit_*` and populating `conftest.py`) are larger refactors. The audit notes the async copies currently have **no tests**, so those collapses should land incrementally behind added async-path coverage rather than as one large change here. Fixing the drift bugs first (this PR) removes the immediate correctness risk; the refactors then remove the source of future drift.

### Testing
New regression tests for each drift bug (async event-log NaN, corrupt-JSON parent sampling, runtime embedding overrides, deepseek token accounting, gemini budget/giveup, unknown-model pricing fallback, sync retry sleep, forwarded llm_kwargs, fix-patch first-None guard, evolver default constructor, deleted-method absence). Full suite green; ruff + mypy (CI config) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
