### PR TITLE
feat: add universal Headless agent image

### DIFF
--- a/.github/workflows/headless-agents-image.yml
+++ b/.github/workflows/headless-agents-image.yml
@@ -1,0 +1,70 @@
+name: Publish Headless agents image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Mutable convenience tag; experiments must use the reported digest
+        required: true
+        default: manual
+        type: string
+  push:
+    tags:
+      - headless-agents-v*
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/shinka-headless-agents
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,prefix=sha-
+
+      - name: Build and publish
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: containers/headless-agents
+          file: containers/headless-agents/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Report immutable reference
+        env:
+          IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/shinka-headless-agents
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: echo "Use ${IMAGE_NAME}@${IMAGE_DIGEST}" >> "$GITHUB_STEP_SUMMARY"

--- a/containers/headless-agents/Dockerfile
+++ b/containers/headless-agents/Dockerfile
@@ -1,0 +1,94 @@
+FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
+
+ARG TARGETARCH
+ARG HEADLESS_VERSION=0.4.0
+ARG CLAUDE_VERSION=2.1.119
+ARG CODEX_VERSION=0.125.0
+ARG GEMINI_VERSION=0.39.1
+ARG OPENCODE_VERSION=1.14.25
+ARG PI_VERSION=0.70.2
+ARG CURSOR_AGENT_VERSION=2026.04.17-787b533
+ARG CURSOR_AGENT_SHA256_AMD64=942b2b583239497715f2390336eb8e2df3673703bd167bd59f7be33a27e15c5a
+ARG CURSOR_AGENT_SHA256_ARM64=985191ffc606da1317e1399f99306481f58643f345ed2252033b011504c780ce
+ARG AGY_RELEASE=1.1.4-6277569641840640
+ARG AGY_SHA512_AMD64=a088a1f231d8565b6673cecd8656fc3504e49c89e9c6b8c4116937b5fe7069c8dcfba78bbb2bc5c0ff8e87ba64fe21b63db7001e3a5794504927dad9e89da973
+ARG AGY_SHA512_ARM64=8d3c464303b235b6f2c2d441eca07b0c1cc35efa68f7ae16b167a5a2d49373903efdf686b3e41063424f0cf0c5b5d5eb056f7944dade7abf1b8eb225cb8c438c
+
+LABEL io.shinka.headless.version="${HEADLESS_VERSION}" \
+      io.shinka.headless.agents="antigravity,claude,codex,cursor,gemini,opencode,pi" \
+      io.shinka.antigravity.release="${AGY_RELEASE}" \
+      io.shinka.claude.version="${CLAUDE_VERSION}" \
+      io.shinka.codex.version="${CODEX_VERSION}" \
+      io.shinka.cursor.version="${CURSOR_AGENT_VERSION}" \
+      io.shinka.gemini.version="${GEMINI_VERSION}" \
+      io.shinka.opencode.version="${OPENCODE_VERSION}" \
+      io.shinka.pi.version="${PI_VERSION}" \
+      io.shinka.sandbox-user="65532:65532"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+        "@roberttlange/headless@${HEADLESS_VERSION}" \
+        "@anthropic-ai/claude-code@${CLAUDE_VERSION}" \
+        "@google/gemini-cli@${GEMINI_VERSION}" \
+        "@mariozechner/pi-coding-agent@${PI_VERSION}" \
+        "@openai/codex@${CODEX_VERSION}" \
+        "opencode-ai@${OPENCODE_VERSION}"
+
+RUN set -eu; \
+    case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+        amd64) cursor_arch="x64"; cursor_sha256="${CURSOR_AGENT_SHA256_AMD64}" ;; \
+        arm64) cursor_arch="arm64"; cursor_sha256="${CURSOR_AGENT_SHA256_ARM64}" ;; \
+        *) echo "unsupported Cursor architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
+    esac; \
+    cursor_tarball="/tmp/cursor-agent.tar.gz"; \
+    curl "https://downloads.cursor.com/lab/${CURSOR_AGENT_VERSION}/linux/${cursor_arch}/agent-cli-package.tar.gz" -fsSL -o "${cursor_tarball}"; \
+    echo "${cursor_sha256}  ${cursor_tarball}" | sha256sum -c -; \
+    mkdir -p /opt/cursor-agent; \
+    tar --strip-components=1 -xzf "${cursor_tarball}" -C /opt/cursor-agent; \
+    ln -s /opt/cursor-agent/cursor-agent /usr/local/bin/cursor-agent; \
+    ln -s /usr/local/bin/cursor-agent /usr/local/bin/agent; \
+    rm -f "${cursor_tarball}"
+
+RUN set -eu; \
+    case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+        amd64) agy_arch="linux-x64"; agy_file="cli_linux_x64.tar.gz"; agy_sha512="${AGY_SHA512_AMD64}" ;; \
+        arm64) agy_arch="linux-arm"; agy_file="cli_linux_arm64.tar.gz"; agy_sha512="${AGY_SHA512_ARM64}" ;; \
+        *) echo "unsupported Antigravity architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
+    esac; \
+    agy_tarball="/tmp/agy.tar.gz"; \
+    curl "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_RELEASE}/${agy_arch}/${agy_file}" -fsSL -o "${agy_tarball}"; \
+    echo "${agy_sha512}  ${agy_tarball}" | sha512sum -c -; \
+    tar -xzf "${agy_tarball}" -C /tmp antigravity; \
+    install -m 0755 /tmp/antigravity /usr/local/bin/agy; \
+    rm -f "${agy_tarball}" /tmp/antigravity
+
+RUN groupadd --gid 65532 shinka \
+    && useradd --uid 65532 --gid 65532 --home-dir /headless-home \
+        --shell /bin/sh shinka \
+    && command -v headless \
+    && command -v agy \
+    && command -v claude \
+    && command -v codex \
+    && command -v agent \
+    && command -v gemini \
+    && command -v opencode \
+    && command -v pi
+
+ENV AGY_CLI_DISABLE_AUTO_UPDATE=true \
+    DISABLE_AUTOUPDATER=1 \
+    GEMINI_CLI_NO_UPDATE_NOTIFIER=true \
+    NODE_USE_ENV_PROXY=1 \
+    NO_UPDATE_NOTIFIER=1 \
+    OPENCODE_DISABLE_AUTOUPDATE=true \
+    PATH="/headless-home/.local/bin:/headless-home/.cursor/bin:/headless-home/.cursor/cli/bin:${PATH}"
+
+WORKDIR /workspace
+USER 65532:65532

--- a/containers/headless-agents/Dockerfile
+++ b/containers/headless-agents/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 ARG TARGETARCH
-ARG HEADLESS_VERSION=0.4.0
+ARG HEADLESS_VERSION=0.5.0
 ARG CLAUDE_VERSION=2.1.119
 ARG CODEX_VERSION=0.125.0
 ARG GEMINI_VERSION=0.39.1
@@ -10,13 +10,13 @@ ARG PI_VERSION=0.70.2
 ARG CURSOR_AGENT_VERSION=2026.04.17-787b533
 ARG CURSOR_AGENT_SHA256_AMD64=942b2b583239497715f2390336eb8e2df3673703bd167bd59f7be33a27e15c5a
 ARG CURSOR_AGENT_SHA256_ARM64=985191ffc606da1317e1399f99306481f58643f345ed2252033b011504c780ce
-ARG AGY_RELEASE=1.1.4-6277569641840640
-ARG AGY_SHA512_AMD64=a088a1f231d8565b6673cecd8656fc3504e49c89e9c6b8c4116937b5fe7069c8dcfba78bbb2bc5c0ff8e87ba64fe21b63db7001e3a5794504927dad9e89da973
-ARG AGY_SHA512_ARM64=8d3c464303b235b6f2c2d441eca07b0c1cc35efa68f7ae16b167a5a2d49373903efdf686b3e41063424f0cf0c5b5d5eb056f7944dade7abf1b8eb225cb8c438c
+ARG AGY_VERSION=1.1.8
+ARG AGY_SHA256_AMD64=e92e6215532b3ce84455e341944067753ad90f6d24cebcec8002ce137e5162ce
+ARG AGY_SHA256_ARM64=e75cebb03fce0fcad7d3bb682eb84c356a3c50ff8fb3dc4a89d2051f34fca0ab
 
 LABEL io.shinka.headless.version="${HEADLESS_VERSION}" \
       io.shinka.headless.agents="antigravity,claude,codex,cursor,gemini,opencode,pi" \
-      io.shinka.antigravity.release="${AGY_RELEASE}" \
+      io.shinka.antigravity.release="${AGY_VERSION}" \
       io.shinka.claude.version="${CLAUDE_VERSION}" \
       io.shinka.codex.version="${CODEX_VERSION}" \
       io.shinka.cursor.version="${CURSOR_AGENT_VERSION}" \
@@ -59,13 +59,13 @@ RUN set -eu; \
 
 RUN set -eu; \
     case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
-        amd64) agy_arch="linux-x64"; agy_file="cli_linux_x64.tar.gz"; agy_sha512="${AGY_SHA512_AMD64}" ;; \
-        arm64) agy_arch="linux-arm"; agy_file="cli_linux_arm64.tar.gz"; agy_sha512="${AGY_SHA512_ARM64}" ;; \
+        amd64) agy_file="agy_cli_linux_x64.tar.gz"; agy_sha256="${AGY_SHA256_AMD64}" ;; \
+        arm64) agy_file="agy_cli_linux_arm64.tar.gz"; agy_sha256="${AGY_SHA256_ARM64}" ;; \
         *) echo "unsupported Antigravity architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
     esac; \
     agy_tarball="/tmp/agy.tar.gz"; \
-    curl "https://storage.googleapis.com/antigravity-public/antigravity-cli/${AGY_RELEASE}/${agy_arch}/${agy_file}" -fsSL -o "${agy_tarball}"; \
-    echo "${agy_sha512}  ${agy_tarball}" | sha512sum -c -; \
+    curl "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${agy_file}" -fsSL -o "${agy_tarball}"; \
+    echo "${agy_sha256}  ${agy_tarball}" | sha256sum -c -; \
     tar -xzf "${agy_tarball}" -C /tmp antigravity; \
     install -m 0755 /tmp/antigravity /usr/local/bin/agy; \
     rm -f "${agy_tarball}" /tmp/antigravity
@@ -73,6 +73,8 @@ RUN set -eu; \
 RUN groupadd --gid 65532 shinka \
     && useradd --uid 65532 --gid 65532 --home-dir /headless-home \
         --shell /bin/sh shinka \
+    && mkdir -p /headless-home \
+    && chown 65532:65532 /headless-home \
     && command -v headless \
     && command -v agy \
     && command -v claude \
@@ -88,6 +90,7 @@ ENV AGY_CLI_DISABLE_AUTO_UPDATE=true \
     NODE_USE_ENV_PROXY=1 \
     NO_UPDATE_NOTIFIER=1 \
     OPENCODE_DISABLE_AUTOUPDATE=true \
+    HOME=/headless-home \
     PATH="/headless-home/.local/bin:/headless-home/.cursor/bin:/headless-home/.cursor/cli/bin:${PATH}"
 
 WORKDIR /workspace

--- a/containers/headless-agents/Dockerfile
+++ b/containers/headless-agents/Dockerfile
@@ -1,22 +1,23 @@
-FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
+FROM node:22-bookworm-slim@sha256:f32b81066cde10a75dbac96646099533316d94bac4150c55da1636e1f0ffdc46
 
 ARG TARGETARCH
 ARG HEADLESS_VERSION=0.5.0
-ARG CLAUDE_VERSION=2.1.119
-ARG CODEX_VERSION=0.125.0
-ARG GEMINI_VERSION=0.39.1
-ARG OPENCODE_VERSION=1.14.25
-ARG PI_VERSION=0.70.2
-ARG CURSOR_AGENT_VERSION=2026.04.17-787b533
-ARG CURSOR_AGENT_SHA256_AMD64=942b2b583239497715f2390336eb8e2df3673703bd167bd59f7be33a27e15c5a
-ARG CURSOR_AGENT_SHA256_ARM64=985191ffc606da1317e1399f99306481f58643f345ed2252033b011504c780ce
-ARG AGY_VERSION=1.1.8
-ARG AGY_SHA256_AMD64=e92e6215532b3ce84455e341944067753ad90f6d24cebcec8002ce137e5162ce
-ARG AGY_SHA256_ARM64=e75cebb03fce0fcad7d3bb682eb84c356a3c50ff8fb3dc4a89d2051f34fca0ab
+ARG CLAUDE_VERSION=2.1.221
+ARG CODEX_VERSION=0.146.0
+ARG GEMINI_VERSION=0.53.1
+ARG OPENCODE_VERSION=1.18.12
+ARG PI_PACKAGE=@earendil-works/pi-coding-agent
+ARG PI_VERSION=0.83.0
+ARG CURSOR_AGENT_VERSION=2026.07.23-e383d2b
+ARG CURSOR_AGENT_SHA256_AMD64=702ad595213bee5df0268be9f80a19f29fcceaa2a42fc55e39f2b5199051f0c4
+ARG CURSOR_AGENT_SHA256_ARM64=f40b99647cb24e0da885e97620a2048034f1fe8961910d573d827d77c4d26dcb
+ARG AGY_RELEASE=1.1.10
+ARG AGY_SHA512_AMD64=e64d4e58ede0f8440f2b3dc021f9d6d36b05f5c2f74d5a9215c1f11b20d536c8c2e020f4ce5257aa67e940e94c94d5a16d3aa6461cda18ee7f3e74d3a20ca1ac
+ARG AGY_SHA512_ARM64=2d64c4e09eb22c824bc298ca61e48cb0e62688353db4122996b2e4bba8c9a1570d2cbf6e6452ed7ef30df0940bf8f058789e466aed5264c1ae2e4613eca5b573
 
 LABEL io.shinka.headless.version="${HEADLESS_VERSION}" \
       io.shinka.headless.agents="antigravity,claude,codex,cursor,gemini,opencode,pi" \
-      io.shinka.antigravity.release="${AGY_VERSION}" \
+      io.shinka.antigravity.release="${AGY_RELEASE}" \
       io.shinka.claude.version="${CLAUDE_VERSION}" \
       io.shinka.codex.version="${CODEX_VERSION}" \
       io.shinka.cursor.version="${CURSOR_AGENT_VERSION}" \
@@ -38,7 +39,7 @@ RUN npm install -g \
         "@roberttlange/headless@${HEADLESS_VERSION}" \
         "@anthropic-ai/claude-code@${CLAUDE_VERSION}" \
         "@google/gemini-cli@${GEMINI_VERSION}" \
-        "@mariozechner/pi-coding-agent@${PI_VERSION}" \
+        "${PI_PACKAGE}@${PI_VERSION}" \
         "@openai/codex@${CODEX_VERSION}" \
         "opencode-ai@${OPENCODE_VERSION}"
 
@@ -59,13 +60,13 @@ RUN set -eu; \
 
 RUN set -eu; \
     case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
-        amd64) agy_file="agy_cli_linux_x64.tar.gz"; agy_sha256="${AGY_SHA256_AMD64}" ;; \
-        arm64) agy_file="agy_cli_linux_arm64.tar.gz"; agy_sha256="${AGY_SHA256_ARM64}" ;; \
+        amd64) agy_file="agy_cli_linux_x64.tar.gz"; agy_sha512="${AGY_SHA512_AMD64}" ;; \
+        arm64) agy_file="agy_cli_linux_arm64.tar.gz"; agy_sha512="${AGY_SHA512_ARM64}" ;; \
         *) echo "unsupported Antigravity architecture: ${TARGETARCH:-unknown}" >&2; exit 1 ;; \
     esac; \
     agy_tarball="/tmp/agy.tar.gz"; \
-    curl "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${agy_file}" -fsSL -o "${agy_tarball}"; \
-    echo "${agy_sha256}  ${agy_tarball}" | sha256sum -c -; \
+    curl "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_RELEASE}/${agy_file}" -fsSL -o "${agy_tarball}"; \
+    echo "${agy_sha512}  ${agy_tarball}" | sha512sum -c -; \
     tar -xzf "${agy_tarball}" -C /tmp antigravity; \
     install -m 0755 /tmp/antigravity /usr/local/bin/agy; \
     rm -f "${agy_tarball}" /tmp/antigravity
@@ -87,10 +88,10 @@ RUN groupadd --gid 65532 shinka \
 ENV AGY_CLI_DISABLE_AUTO_UPDATE=true \
     DISABLE_AUTOUPDATER=1 \
     GEMINI_CLI_NO_UPDATE_NOTIFIER=true \
+    HOME=/headless-home \
     NODE_USE_ENV_PROXY=1 \
     NO_UPDATE_NOTIFIER=1 \
     OPENCODE_DISABLE_AUTOUPDATE=true \
-    HOME=/headless-home \
     PATH="/headless-home/.local/bin:/headless-home/.cursor/bin:/headless-home/.cursor/cli/bin:${PATH}"
 
 WORKDIR /workspace

--- a/containers/headless-agents/README.md
+++ b/containers/headless-agents/README.md
@@ -1,0 +1,72 @@
+# Secure universal Headless agent image
+
+This image provides Headless plus every native CLI supported by Shinka's secure
+adapter: Antigravity, Claude Code, Codex, Cursor Agent, Gemini CLI, OpenCode, and
+Pi. Package versions and the Node base are pinned; Cursor and Antigravity
+downloads are architecture-specific and checksum-verified for AMD64/ARM64.
+There is deliberately no separate Antigravity image: it has the same image,
+runtime identity, and preflight contract as every other route.
+
+Build in a trusted preparation step, push to the operator registry, and configure
+the resulting immutable `repository@sha256:<manifest-digest>` reference. Runtime
+uses the dedicated non-root `65532:65532` identity. Shinka invokes the selected
+route as:
+
+```text
+headless <agent> [--model <model>] [--reasoning-effort <effort>] --allow yolo --json
+```
+
+The manual `Publish Headless agents image` GitHub workflow builds AMD64 and
+ARM64, publishes `ghcr.io/<owner>/shinka-headless-agents`, and reports the
+immutable manifest digest. A local equivalent is:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag registry.example/shinka/headless-agents:0.4.0 \
+  --push \
+  containers/headless-agents
+```
+
+Preflight checks `io.shinka.headless.agents` plus Headless/native-agent version
+and sandbox-user OCI labels, and fails before a proposal if any configured route
+or identity is absent. The image build itself verifies every native executable.
+
+The image intentionally does not bundle credentials. Configure one dedicated
+minimal profile per selected agent:
+
+| Agent | Allowlisted profile paths |
+| --- | --- |
+| `antigravity` | `.gemini/antigravity-cli/antigravity-oauth-token` plus bounded Antigravity settings/state |
+| `claude` | `.claude.json`, `.claude/settings.json`, `.claude/.credentials.json`, `.claude/auth.json` |
+| `codex` | `.codex/auth.json`, `.codex/config.toml` |
+| `cursor` | `.cursor/cli-config.json` |
+| `gemini` | selected `.gemini` account/settings/state files |
+| `opencode` | `.config/opencode` |
+| `pi` | `.pi/agent/auth.json`, `.pi/agent/settings.json` |
+
+API-key authentication is also supported only through each agent's explicit
+`agent_credential_env_names` allowlist:
+
+| Agent | Permitted credential environment names |
+| --- | --- |
+| `antigravity` | none; use its container OAuth file |
+| `claude` | `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` |
+| `codex` | `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `CODEX_API_KEY` |
+| `cursor` | `CURSOR_API_KEY` |
+| `gemini` | `GOOGLE_API_KEY`, `GEMINI_API_KEY` |
+| `opencode` | selected OpenAI, Anthropic, OpenRouter, or Google/Gemini API key |
+| `pi` | selected OpenAI, Anthropic, OpenRouter, Google/Gemini, or `PI_CODING_AGENT_*` credential/model variables |
+
+An API-auth route still needs a dedicated profile directory, which may be empty.
+Never use a normal home directory.
+
+Provider egress is independent of the image. Configure the proxy with only the
+DNS suffixes needed by the selected routes. If one run selects several agents,
+the proxy allowlist is the union of those reviewed provider endpoints. Add
+`models.dev` when Headless must convert non-native token counts to dollar cost.
+The image enables Node's standard environment-proxy support so that lookup uses
+Shinka's controlled proxy rather than requiring direct egress.
+
+ACP registry/custom-command execution is not included: dynamically resolving an
+arbitrary ACP implementation would violate the pinned-binary execution contract.

--- a/containers/headless-agents/README.md
+++ b/containers/headless-agents/README.md
@@ -6,6 +6,9 @@ Pi. Package versions and the Node base are pinned; Cursor and Antigravity
 downloads are architecture-specific and checksum-verified for AMD64/ARM64.
 There is deliberately no separate Antigravity image: it has the same image,
 runtime identity, and preflight contract as every other route.
+The current pins are Headless 0.5.0, Claude 2.1.221, Codex 0.146.0, Gemini
+0.53.1, OpenCode 1.18.12, Pi 0.83.0, Cursor Agent 2026.07.23-e383d2b, and
+Antigravity CLI 1.1.10.
 
 Build in a trusted preparation step, push to the operator registry, and configure
 the resulting immutable `repository@sha256:<manifest-digest>` reference. Runtime

--- a/containers/headless-agents/README.md
+++ b/containers/headless-agents/README.md
@@ -13,7 +13,7 @@ uses the dedicated non-root `65532:65532` identity. Shinka invokes the selected
 route as:
 
 ```text
-headless <agent> [--model <model>] [--reasoning-effort <effort>] --allow yolo --json
+headless <agent> [--model <model>] [--reasoning-effort <effort>] --allow yolo --json --usage
 ```
 
 The manual `Publish Headless agents image` GitHub workflow builds AMD64 and
@@ -23,7 +23,7 @@ immutable manifest digest. A local equivalent is:
 ```bash
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  --tag registry.example/shinka/headless-agents:0.4.0 \
+  --tag registry.example/shinka/headless-agents:0.5.0 \
   --push \
   containers/headless-agents
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,7 @@ markers = [
     "models_dev_live: live models.dev catalog contract coverage",
     "requires_secrets: tests that need CI secrets or private credentials",
 ]
+
+[tool.ruff.lint]
+# Preserve the established CI rule baseline across Ruff releases.
+select = ["E4", "E7", "E9", "F"]

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -103,6 +103,31 @@ def test_packaged_hydra_configs_are_importable():
     assert Path(shinka.configs.__file__).resolve().name == "__init__.py"
 
 
+def test_secure_headless_image_is_one_universal_recipe():
+    dockerfile = (REPO_ROOT / "containers/headless-agents/Dockerfile").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        'io.shinka.headless.agents="antigravity,claude,codex,cursor,gemini,opencode,pi"'
+        in dockerfile
+    )
+    for executable in ("agy", "claude", "codex", "agent", "gemini", "opencode", "pi"):
+        assert f"command -v {executable}" in dockerfile
+    assert not (REPO_ROOT / "containers/headless-antigravity/Dockerfile").exists()
+
+
+def test_secure_headless_image_has_multi_arch_publish_workflow():
+    workflow = (
+        REPO_ROOT / ".github/workflows/headless-agents-image.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "platforms: linux/amd64,linux/arm64" in workflow
+    assert "ghcr.io/${{ github.repository_owner }}/shinka-headless-agents" in workflow
+    assert "provenance: mode=max" in workflow
+    assert "sbom: true" in workflow
+
+
 def test_shinka_launch_preprocesses_global_args():
     processed = cli_launch.preprocess_args(
         ["task=circle_packing", "variant=default", "verbose=true"]

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -113,12 +113,20 @@ def test_secure_headless_image_is_one_universal_recipe():
         in dockerfile
     )
     assert "ARG HEADLESS_VERSION=0.5.0" in dockerfile
-    assert "ARG AGY_VERSION=1.1.8" in dockerfile
-    assert "AGY_SHA256_AMD64=" in dockerfile
-    assert "AGY_SHA256_ARM64=" in dockerfile
+    assert "ARG CLAUDE_VERSION=2.1.221" in dockerfile
+    assert "ARG CODEX_VERSION=0.146.0" in dockerfile
+    assert "ARG GEMINI_VERSION=0.53.1" in dockerfile
+    assert "ARG OPENCODE_VERSION=1.18.12" in dockerfile
+    assert "ARG PI_PACKAGE=@earendil-works/pi-coding-agent" in dockerfile
+    assert "ARG PI_VERSION=0.83.0" in dockerfile
+    assert "ARG CURSOR_AGENT_VERSION=2026.07.23-e383d2b" in dockerfile
+    assert "ARG AGY_RELEASE=1.1.10" in dockerfile
+    assert "AGY_SHA512_AMD64=" in dockerfile
+    assert "AGY_SHA512_ARM64=" in dockerfile
     assert "github.com/google-antigravity/antigravity-cli/releases/download/" in dockerfile
-    assert "sha256sum -c -" in dockerfile
-    assert "AGY_SHA512" not in dockerfile
+    assert "sha512sum -c -" in dockerfile
+    assert "AGY_VERSION" not in dockerfile
+    assert "AGY_SHA256" not in dockerfile
     assert "storage.googleapis.com/antigravity-public" not in dockerfile
     assert "HOME=/headless-home" in dockerfile
     for executable in ("agy", "claude", "codex", "agent", "gemini", "opencode", "pi"):

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -112,6 +112,15 @@ def test_secure_headless_image_is_one_universal_recipe():
         'io.shinka.headless.agents="antigravity,claude,codex,cursor,gemini,opencode,pi"'
         in dockerfile
     )
+    assert "ARG HEADLESS_VERSION=0.5.0" in dockerfile
+    assert "ARG AGY_VERSION=1.1.8" in dockerfile
+    assert "AGY_SHA256_AMD64=" in dockerfile
+    assert "AGY_SHA256_ARM64=" in dockerfile
+    assert "github.com/google-antigravity/antigravity-cli/releases/download/" in dockerfile
+    assert "sha256sum -c -" in dockerfile
+    assert "AGY_SHA512" not in dockerfile
+    assert "storage.googleapis.com/antigravity-public" not in dockerfile
+    assert "HOME=/headless-home" in dockerfile
     for executable in ("agy", "claude", "codex", "agent", "gemini", "opencode", "pi"):
         assert f"command -v {executable}" in dockerfile
     assert not (REPO_ROOT / "containers/headless-antigravity/Dockerfile").exists()


### PR DESCRIPTION
## What changed

Add the universal pinned Headless agent image used by secure mutation runs.

- Packages Headless 0.5.0, Claude 2.1.221, Codex 0.146.0, Gemini CLI 0.53.1, OpenCode 1.18.12, Pi 0.83.0, Cursor Agent 2026.07.23-e383d2b, and Antigravity CLI 1.1.10.
- Uses the successor `@earendil-works/pi-coding-agent` package because the old Pi package is deprecated.
- Refreshes the pinned Node base and architecture-specific Cursor/Antigravity checksums for AMD64 and ARM64.
- Downloads Antigravity from its official GitHub release artifacts and verifies SHA-512 checksums.
- Keeps the non-root `65532:65532` runtime identity, `/workspace` contract, multi-architecture publish workflow, provenance, SBOM, and exact-digest qualification.

The image intentionally does not contain credentials. The final immutable image digest must be recorded after the trusted workflow run.

## Validation

- `python3 -m pytest -q tests/test_packaging_release.py` — 12 passed
- `ruff check tests/test_packaging_release.py` — passed
- ARM64 Docker build — passed; all eight CLI version checks passed and the image ran as UID 65532
- AMD64/ARM64 build check — passed with both Cursor and Antigravity checksum paths

After merging, publish the image and record the resulting universal manifest digest in the secure-image documentation.
