### PR TITLE
fix(webui): harden visualization server boundary

### DIFF
--- a/docs/webui.md
+++ b/docs/webui.md
@@ -73,6 +73,7 @@ shinka_visualize --db results_20241201_120000/evolution_db.sqlite --open
 | `--host` | `127.0.0.1` | Address to bind; non-loopback addresses expose the unauthenticated server |
 | `--db` | Auto-detect | Path to specific SQLite database file |
 | `--open` | `False` | Auto-open browser |
+| `--max-database-snapshot-gib` | `2` | Maximum combined database and WAL snapshot size; raise for larger trusted runs |
 
 ---
 

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -70,6 +70,7 @@ shinka_visualize --db results_20241201_120000/evolution_db.sqlite --open
 |----------|---------|-------------|
 | `root_directory` | Current dir | Root directory to search for database files |
 | `-p, --port` | `8000` | Port for the web server |
+| `--host` | `127.0.0.1` | Address to bind; non-loopback addresses expose the unauthenticated server |
 | `--db` | Auto-detect | Path to specific SQLite database file |
 | `--open` | `False` | Auto-open browser |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ shinka = [
 dev = [
     "pytest>=6.0",
     "pytest-cov",
-    "ruff",
+    "ruff==0.15.6",
     "mypy",
     "black",
     "isort",

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -277,6 +277,7 @@ class ProgramDatabase:
         config: DatabaseConfig,
         embedding_model: str = "text-embedding-3-small",
         read_only: bool = False,
+        connection: Optional[sqlite3.Connection] = None,
     ):
         self.config = config
         self.embedding_model = embedding_model
@@ -307,7 +308,9 @@ class ProgramDatabase:
 
         db_path_str = getattr(self.config, "db_path", None)
 
-        if db_path_str:
+        if connection is not None:
+            self.conn = connection
+        elif db_path_str:
             db_file = Path(db_path_str).resolve()
             if not read_only:
                 # Robustness check for unclean shutdown with WAL

--- a/shinka/database/prompt_dbase.py
+++ b/shinka/database/prompt_dbase.py
@@ -227,6 +227,7 @@ class SystemPromptDatabase:
         self,
         config: SystemPromptConfig,
         read_only: bool = False,
+        connection: Optional[sqlite3.Connection] = None,
     ):
         self.config = config
         self.conn: Optional[sqlite3.Connection] = None
@@ -238,7 +239,9 @@ class SystemPromptDatabase:
 
         db_path_str = getattr(self.config, "db_path", None)
 
-        if db_path_str:
+        if connection is not None:
+            self.conn = connection
+        elif db_path_str:
             db_file = Path(db_path_str).resolve()
             if not read_only:
                 # Robustness check for unclean shutdown with WAL

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -36,13 +36,23 @@ CACHE_EXPIRATION_SECONDS = 5  # Cache data for 5 seconds
 db_cache: Dict[str, Tuple[float, Any]] = {}
 
 
+class PathValidationError(ValueError):
+    """Raised when a user-supplied path escapes the served search root."""
+
+
 class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, search_root=None, **kwargs):
+    def __init__(self, *args, search_root=None, allowed_hosts=..., **kwargs):
         self.search_root = search_root or os.getcwd()
+        # Attributes must be set before super().__init__, which handles the
+        # request immediately. `...` means "keep the class default allowlist".
+        if allowed_hosts is not ...:
+            self.allowed_hosts = allowed_hosts
         super().__init__(*args, **kwargs)
 
     def end_headers(self):
         """Disable browser caching for local HTML shells to avoid stale embedded JS."""
+        # Prevent MIME sniffing on every response (DB-sourced content is served).
+        self.send_header("X-Content-Type-Options", "nosniff")
         parsed_url = urllib.parse.urlparse(self.path)
         if parsed_url.path in ("/", "/index.html", "/viz_tree.html", "/compare.html"):
             self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
@@ -271,7 +281,35 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         finally:
             conn.close()
 
+    # Host header values allowed when the server is bound to loopback. Overwritten
+    # per-instance via the handler factory when an explicit external host is used.
+    allowed_hosts = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+    def _host_allowed(self) -> bool:
+        """Reject Host headers outside the allowlist (DNS-rebinding defense)."""
+        if self.allowed_hosts is None:
+            return True  # Explicit external bind: operator opted out of the check.
+        host_header = self.headers.get("Host", "")
+        hostname = host_header.rsplit(":", 1)[0] if host_header else ""
+        return hostname in self.allowed_hosts
+
     def do_GET(self):
+        if not self._host_allowed():
+            self.send_error(403, "Host not allowed")
+            return None
+        try:
+            return self._dispatch_get()
+        except PathValidationError as exc:
+            print(f"[SERVER] Rejected path-traversal attempt: {exc}")
+            self.send_error(403, "Access denied")
+            return None
+
+    def list_directory(self, path):
+        """Never serve auto-generated directory listings."""
+        self.send_error(403, "Directory listing is disabled")
+        return None
+
+    def _dispatch_get(self):
         print(f"\n[SERVER] Received GET request for: {self.path}")
         parsed_url = urllib.parse.urlparse(self.path)
         path = parsed_url.path
@@ -425,9 +463,33 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.send_json_response(db_files)
         print(f"[SERVER] Served DB list with {len(db_files)} entries, sorted by date.")
 
+    def _resolve_within_root(self, relative_path: str) -> str:
+        """Resolve a user-supplied path under search_root, rejecting escapes.
+
+        Returns the canonical absolute path if it is contained within
+        search_root; raises PathValidationError otherwise. Absolute inputs and
+        ``..`` traversal both fail the containment check, and symlinks are
+        resolved (realpath) before checking so an in-root symlink pointing
+        outside cannot be used to escape.
+        """
+        root = os.path.realpath(self.search_root)
+        candidate = os.path.realpath(os.path.join(root, relative_path))
+        try:
+            contained = os.path.commonpath([root, candidate]) == root
+        except ValueError:
+            # Different drives / mixed absolute-relative: treat as an escape.
+            contained = False
+        if not contained:
+            raise PathValidationError(f"Path escapes search root: {relative_path!r}")
+        return candidate
+
     def _get_actual_db_path(self, db_path: str) -> str:
-        """Convert db_path to the actual file path (now a no-op since path is not modified)."""
-        return db_path
+        """Validate db_path stays within search_root; return its absolute path.
+
+        Handlers pass the result to ``os.path.join(self.search_root, ...)``,
+        which is a no-op on the absolute path returned here.
+        """
+        return self._resolve_within_root(db_path)
 
     def handle_get_programs(self, db_path: str):
         """Fetch all programs from a given database file."""
@@ -984,29 +1046,33 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         parsed_url = urllib.parse.urlparse(self.path)
         rel_path = urllib.parse.unquote(parsed_url.path[11:])  # Remove /plot_file/
 
-        abs_path = os.path.join(self.search_root, rel_path)
-        print(f"[SERVER] Serving plot file: {abs_path}")
-
-        if not os.path.exists(abs_path):
-            self.send_error(404, f"Plot file not found: {rel_path}")
-            return
-
-        # Security check: ensure the path is within search_root
-        abs_path = os.path.abspath(abs_path)
-        abs_search_root = os.path.abspath(self.search_root)
-        if not abs_path.startswith(abs_search_root):
-            self.send_error(403, "Access denied")
-            return
-
-        # Determine content type
-        ext = os.path.splitext(abs_path)[1].lower()
+        # Restrict to image files, and containment-check BEFORE touching disk so
+        # out-of-root paths can't be probed for existence (403 vs 404 leak) and
+        # symlinks pointing outside the root are rejected (realpath + commonpath).
         content_types = {
             ".png": "image/png",
             ".gif": "image/gif",
             ".jpg": "image/jpeg",
             ".jpeg": "image/jpeg",
         }
-        content_type = content_types.get(ext, "application/octet-stream")
+        ext = os.path.splitext(rel_path)[1].lower()
+        if ext not in content_types:
+            self.send_error(403, "Access denied")
+            return
+        content_type = content_types[ext]
+
+        try:
+            abs_path = self._resolve_within_root(rel_path)
+        except PathValidationError as exc:
+            print(f"[SERVER] Rejected plot-file traversal: {exc}")
+            self.send_error(403, "Access denied")
+            return
+
+        print(f"[SERVER] Serving plot file: {abs_path}")
+
+        if not os.path.isfile(abs_path):
+            self.send_error(404, f"Plot file not found: {rel_path}")
+            return
 
         try:
             with open(abs_path, "rb") as f:
@@ -1678,7 +1744,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         payload = json.dumps(clean_data, default=self._json_encoder).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        # No "Access-Control-Allow-Origin: *": the UI is served same-origin, and
+        # a wildcard would let any site the operator visits read the full DB.
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
@@ -1708,17 +1775,36 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
-def create_handler_factory(search_root):
+def create_handler_factory(search_root, allowed_hosts=...):
     """Create a handler factory that passes the search root to handler."""
 
     def handler_factory(*args, **kwargs):
-        return DatabaseRequestHandler(*args, search_root=search_root, **kwargs)
+        return DatabaseRequestHandler(
+            *args,
+            search_root=search_root,
+            allowed_hosts=allowed_hosts,
+            **kwargs,
+        )
 
     return handler_factory
 
 
-def start_server(port: int, search_root: str, db_path: Optional[str] = None):
-    """Start the HTTP server."""
+def _is_loopback_host(host: str) -> bool:
+    return host in ("127.0.0.1", "localhost", "::1", "")
+
+
+def start_server(
+    port: int,
+    search_root: str,
+    db_path: Optional[str] = None,
+    host: str = "127.0.0.1",
+):
+    """Start the HTTP server.
+
+    Binds to 127.0.0.1 by default so the evolution database is not exposed to
+    the local network. Pass an explicit ``host`` (e.g. "0.0.0.0") to expose it,
+    which also relaxes the DNS-rebinding Host-header check.
+    """
     # Change to the webui directory inside the shinka package to serve static files
     webui_dir = os.path.dirname(__file__)
     webui_dir = os.path.abspath(webui_dir)
@@ -1730,15 +1816,24 @@ def start_server(port: int, search_root: str, db_path: Optional[str] = None):
     print(f"[DEBUG] Server root directory: {webui_dir}")
     print(f"[DEBUG] Search root directory: {search_root}")
 
-    # Create handler factory with search root
-    handler_factory = create_handler_factory(search_root)
+    # On a loopback bind, enforce the Host-header allowlist (anti DNS-rebinding).
+    # On an explicit external bind the operator has opted in, so disable it.
+    allowed_hosts = ... if _is_loopback_host(host) else None
+    handler_factory = create_handler_factory(search_root, allowed_hosts=allowed_hosts)
 
-    # Reuse the socket so you can restart quickly
-    class ReusableTCPServer(socketserver.TCPServer):
+    # Reuse the socket so you can restart quickly; threaded so one slow request
+    # (e.g. PDF export) doesn't freeze the whole UI.
+    class ReusableTCPServer(socketserver.ThreadingTCPServer):
         allow_reuse_address = True
+        daemon_threads = True
 
-    with ReusableTCPServer(("", port), handler_factory) as httpd:
-        msg = f"\n[*] Serving http://0.0.0.0:{port}  (Ctrl+C to stop)"
+    with ReusableTCPServer((host, port), handler_factory) as httpd:
+        msg = f"\n[*] Serving http://{host}:{port}  (Ctrl+C to stop)"
+        if not _is_loopback_host(host):
+            msg += (
+                "\n[!] Bound to a non-loopback address: the evolution database "
+                "is reachable from the network with no authentication."
+            )
         print(msg)
         httpd.serve_forever()
 
@@ -1775,6 +1870,15 @@ def main():
         default=None,
         help="Path to a specific database file to serve.",
     )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help=(
+            "Address to bind (default: 127.0.0.1, local only). Use 0.0.0.0 to "
+            "expose on the network — this serves the database with no auth."
+        ),
+    )
     args = parser.parse_args()
 
     # Resolve the root directory to an absolute path
@@ -1789,7 +1893,7 @@ def main():
     # Kick off the HTTP server in a daemon thread.
     server_thread = threading.Thread(
         target=start_server,
-        args=(args.port, search_root, args.db),
+        args=(args.port, search_root, args.db, args.host),
         daemon=True,
     )
     server_thread.start()

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -1831,11 +1831,8 @@ def start_server(
     allowed_hosts = ... if _is_loopback_host(host) else None
     handler_factory = create_handler_factory(search_root, allowed_hosts=allowed_hosts)
 
-    # Reuse the socket so you can restart quickly; threaded so one slow request
-    # (e.g. PDF export) doesn't freeze the whole UI.
-    class ReusableTCPServer(socketserver.ThreadingTCPServer):
+    class ReusableTCPServer(socketserver.TCPServer):
         allow_reuse_address = True
-        daemon_threads = True
 
     with ReusableTCPServer((host, port), handler_factory) as httpd:
         msg = f"\n[*] Serving http://{host}:{port}  (Ctrl+C to stop)"

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -907,11 +907,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # Construct the meta file path - try meta subdirectory first
         meta_filename = f"meta_{processed_count}.txt"
-        meta_file_path = os.path.join(db_dir, "meta", meta_filename)
+        meta_file_path = self._resolve_within_root(
+            os.path.join(db_dir, "meta", meta_filename)
+        )
 
         # Fall back to db_dir for backward compatibility
         if not os.path.exists(meta_file_path):
-            meta_file_path = os.path.join(db_dir, meta_filename)
+            meta_file_path = self._resolve_within_root(
+                os.path.join(db_dir, meta_filename)
+            )
 
         if not os.path.exists(meta_file_path):
             self.send_error(404, f"Meta file not found: {meta_filename}")
@@ -955,11 +959,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # Construct the meta file path - try meta subdirectory first
         meta_filename = f"meta_{processed_count}.txt"
-        meta_file_path = os.path.join(db_dir, "meta", meta_filename)
+        meta_file_path = self._resolve_within_root(
+            os.path.join(db_dir, "meta", meta_filename)
+        )
 
         # Fall back to db_dir for backward compatibility
         if not os.path.exists(meta_file_path):
-            meta_file_path = os.path.join(db_dir, meta_filename)
+            meta_file_path = self._resolve_within_root(
+                os.path.join(db_dir, meta_filename)
+            )
 
         if not os.path.exists(meta_file_path):
             self.send_error(404, f"Meta file not found: {meta_filename}")
@@ -1012,7 +1020,9 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # Construct the plots directory path
         # Structure: db_dir/gen_X/results/plots/
-        plots_dir = os.path.join(db_dir, f"gen_{generation}", "results", "plots")
+        plots_dir = self._resolve_within_root(
+            os.path.join(db_dir, f"gen_{generation}", "results", "plots")
+        )
 
         plot_files = []
         if os.path.exists(plots_dir):

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -10,6 +10,7 @@ import argparse
 import base64
 import errno
 import http.server
+import ipaddress
 import json
 import markdown
 import os
@@ -327,7 +328,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         if self.allowed_hosts is None:
             return True  # Explicit external bind: operator opted out of the check.
         host_header = self.headers.get("Host", "")
-        hostname = host_header.rsplit(":", 1)[0] if host_header else ""
+        hostname = host_header.rsplit(":", 1)[0].casefold() if host_header else ""
         return hostname in self.allowed_hosts
 
     def do_GET(self):
@@ -2048,7 +2049,27 @@ def create_handler_factory(search_root, allowed_hosts=...):
 
 
 def _is_loopback_host(host: str) -> bool:
-    return host in ("127.0.0.1", "localhost", "::1", "")
+    if host.casefold() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _allowed_hosts_for_bind(
+    requested_host: str, bound_host: str
+) -> Optional[frozenset[str]]:
+    if not _is_loopback_host(bound_host):
+        return None
+
+    allowed_hosts = set(DatabaseRequestHandler.allowed_hosts)
+    for host in (requested_host, bound_host):
+        normalized_host = host.casefold()
+        allowed_hosts.add(normalized_host)
+        if ":" in normalized_host:
+            allowed_hosts.add(f"[{normalized_host}]")
+    return frozenset(allowed_hosts)
 
 
 def start_server(
@@ -2076,15 +2097,17 @@ def start_server(
 
     # On a loopback bind, enforce the Host-header allowlist (anti DNS-rebinding).
     # On an explicit external bind the operator has opted in, so disable it.
-    allowed_hosts = ... if _is_loopback_host(host) else None
-    handler_factory = create_handler_factory(search_root, allowed_hosts=allowed_hosts)
-
     class ReusableTCPServer(socketserver.TCPServer):
         allow_reuse_address = True
 
-    with ReusableTCPServer((host, port), handler_factory) as httpd:
+    with ReusableTCPServer((host, port), DatabaseRequestHandler) as httpd:
+        bound_host = str(httpd.server_address[0])
+        allowed_hosts = _allowed_hosts_for_bind(host, bound_host)
+        httpd.RequestHandlerClass = create_handler_factory(
+            search_root, allowed_hosts=allowed_hosts
+        )
         msg = f"\n[*] Serving http://{host}:{port}  (Ctrl+C to stop)"
-        if not _is_loopback_host(host):
+        if not _is_loopback_host(bound_host):
             msg += (
                 "\n[!] Bound to a non-loopback address: the evolution database "
                 "is reachable from the network with no authentication."

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -868,7 +868,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         db_dir = os.path.dirname(abs_db_path)
 
         # Look in the meta subdirectory
-        meta_dir = os.path.join(db_dir, "meta")
+        meta_dir = self._resolve_within_root(os.path.join(db_dir, "meta"))
 
         if not os.path.exists(meta_dir):
             # Fall back to looking in the db_dir for backward compatibility
@@ -1130,7 +1130,9 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         # Construct path to prompts.sqlite (in same directory as programs.sqlite)
         abs_db_path = os.path.join(self.search_root, actual_db_path)
         db_dir = os.path.dirname(abs_db_path)
-        prompts_db_path = os.path.join(db_dir, "prompts.sqlite")
+        prompts_db_path = self._resolve_within_root(
+            os.path.join(db_dir, "prompts.sqlite")
+        )
 
         if not os.path.exists(prompts_db_path):
             print(f"[SERVER] Prompts database not found: {prompts_db_path}")
@@ -1232,6 +1234,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         if not os.path.exists(abs_db_path):
             self.send_json_response({"error": "not_found"})
             return
+
+        prompts_db_path = self._resolve_within_root(
+            os.path.join(os.path.dirname(abs_db_path), "prompts.sqlite")
+        )
 
         max_retries = 3
         delay = 0.1
@@ -1342,8 +1348,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 }
 
                 # Check for prompts.db in the same directory
-                db_dir = os.path.dirname(abs_db_path)
-                prompts_db_path = os.path.join(db_dir, "prompts.sqlite")
                 if os.path.exists(prompts_db_path):
                     try:
                         pconn = sqlite3.connect(

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -15,6 +15,7 @@ import json
 import markdown
 import os
 import re
+import socket
 import socketserver
 import sqlite3
 import stat
@@ -27,7 +28,7 @@ import urllib.parse
 import webbrowser
 import weakref
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple, Callable
 
 from shinka.database import DatabaseConfig, ProgramDatabase
 from shinka.database import SystemPromptConfig, SystemPromptDatabase
@@ -327,9 +328,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         """Reject Host headers outside the allowlist (DNS-rebinding defense)."""
         if self.allowed_hosts is None:
             return True  # Explicit external bind: operator opted out of the check.
-        host_header = self.headers.get("Host", "")
-        hostname = host_header.rsplit(":", 1)[0].casefold() if host_header else ""
-        return hostname in self.allowed_hosts
+        hostname = _hostname_from_host_header(self.headers.get("Host", ""))
+        return hostname in self.allowed_hosts if hostname is not None else False
 
     def do_GET(self):
         if not self._host_allowed():
@@ -2072,11 +2072,104 @@ def _allowed_hosts_for_bind(
     return frozenset(allowed_hosts)
 
 
+def _hostname_from_host_header(host_header: str) -> Optional[str]:
+    authority = host_header.strip()
+    if not authority:
+        return None
+
+    if authority.startswith("["):
+        bracket = authority.find("]")
+        if bracket < 0:
+            return None
+        hostname = authority[: bracket + 1]
+        remainder = authority[bracket + 1 :]
+        if remainder and not (
+            remainder.startswith(":") and remainder[1:].isdigit()
+        ):
+            return None
+        return hostname.casefold()
+
+    if authority.count(":") > 1:
+        return None
+    hostname, separator, port = authority.partition(":")
+    if not hostname or (separator and not port.isdigit()):
+        return None
+    return hostname.casefold()
+
+
+class _ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+class _ReusableTCPServer6(_ReusableTCPServer):
+    address_family = socket.AF_INET6
+
+
+def _server_class_for_family(family: int) -> type[socketserver.TCPServer]:
+    return _ReusableTCPServer6 if family == socket.AF_INET6 else _ReusableTCPServer
+
+
+def _bind_server(
+    host: str,
+    port: int,
+    request_handler: Callable[..., DatabaseRequestHandler],
+) -> socketserver.TCPServer:
+    addresses = socket.getaddrinfo(
+        host or None,
+        port,
+        socket.AF_UNSPEC if host else socket.AF_INET,
+        socket.SOCK_STREAM,
+        flags=socket.AI_PASSIVE if not host else 0,
+    )
+    bind_errors = []
+    attempted_addresses = set()
+    for family, _socket_type, _protocol, _canonical_name, address in addresses:
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            continue
+        candidate = (family, address)
+        if candidate in attempted_addresses:
+            continue
+        attempted_addresses.add(candidate)
+        server_class = _server_class_for_family(family)
+        try:
+            return server_class(address, request_handler)
+        except OSError as exc:
+            bind_errors.append(exc)
+
+    if bind_errors:
+        raise bind_errors[-1]
+    raise OSError(f"No usable address found for host {host!r}")
+
+
+def _browser_url(
+    bound_host: str,
+    port: int,
+    db_path: Optional[str] = None,
+) -> str:
+    try:
+        bound_is_wildcard = ipaddress.ip_address(bound_host).is_unspecified
+    except ValueError:
+        bound_is_wildcard = not bound_host
+
+    if bound_is_wildcard:
+        browser_host = "::1" if ":" in bound_host else "127.0.0.1"
+    else:
+        browser_host = bound_host
+    if ":" in browser_host:
+        browser_host = f"[{browser_host.replace('%', '%25')}]"
+
+    path = "/"
+    if db_path:
+        path = "/viz_tree.html?" + urllib.parse.urlencode({"db_path": db_path})
+    return f"http://{browser_host}:{port}{path}"
+
+
 def start_server(
     port: int,
     search_root: str,
     db_path: Optional[str] = None,
     host: str = "127.0.0.1",
+    on_ready: Optional[Callable[[socketserver.TCPServer], None]] = None,
 ):
     """Start the HTTP server.
 
@@ -2097,16 +2190,16 @@ def start_server(
 
     # On a loopback bind, enforce the Host-header allowlist (anti DNS-rebinding).
     # On an explicit external bind the operator has opted in, so disable it.
-    class ReusableTCPServer(socketserver.TCPServer):
-        allow_reuse_address = True
-
-    with ReusableTCPServer((host, port), DatabaseRequestHandler) as httpd:
+    httpd = _bind_server(host, port, DatabaseRequestHandler)
+    with httpd:
         bound_host = str(httpd.server_address[0])
         allowed_hosts = _allowed_hosts_for_bind(host, bound_host)
         httpd.RequestHandlerClass = create_handler_factory(
             search_root, allowed_hosts=allowed_hosts
         )
-        msg = f"\n[*] Serving http://{host}:{port}  (Ctrl+C to stop)"
+        bound_port = int(httpd.server_address[1])
+        display_url = _browser_url(bound_host, bound_port)
+        msg = f"\n[*] Serving {display_url}  (Ctrl+C to stop)"
         if not _is_loopback_host(bound_host):
             msg += (
                 "\n[!] Bound to a non-loopback address: the evolution database "
@@ -2118,6 +2211,14 @@ def start_server(
                 "search-root race hardening is unavailable."
             )
         print(msg)
+        if on_ready is not None:
+            def notify_ready() -> None:
+                try:
+                    on_ready(httpd)
+                except Exception as exc:
+                    print(f"[SERVER] Readiness callback failed: {exc}")
+
+            threading.Thread(target=notify_ready, daemon=True).start()
         httpd.serve_forever()
 
 
@@ -2173,40 +2274,30 @@ def main():
 
     print(f"[INFO] Searching for databases in: {search_root}")
 
-    # Kick off the HTTP server in a daemon thread.
-    server_thread = threading.Thread(
-        target=start_server,
-        args=(args.port, search_root, args.db, args.host),
-        daemon=True,
-    )
-    server_thread.start()
-    time.sleep(0.8)  # tiny delay so the banner prints before we continue
+    def announce_ready(httpd: socketserver.TCPServer) -> None:
+        bound_host = str(httpd.server_address[0])
+        bound_port = int(httpd.server_address[1])
+        viz_url = _browser_url(bound_host, bound_port, args.db)
 
-    # Construct URL, passing db path if provided
-    if args.db:
-        # If a specific DB is provided, go directly to viz_tree.html
-        base_url = f"http://localhost:{args.port}/viz_tree.html"
-        url_params = urllib.parse.urlencode({"db_path": args.db})
-        viz_url = f"{base_url}?{url_params}"
-    else:
-        # Otherwise, open the landing page with all results
-        viz_url = f"http://localhost:{args.port}/"
-
-    # Try to open a browser if requested
-    if args.open_browser:
-        try:
-            webbrowser.open_new_tab(viz_url)
-            print(f"→ Opening {viz_url} in browser")
-        except Exception as e:
-            print(f"→ Could not open browser automatically: {e}")
+        if args.open_browser:
+            try:
+                webbrowser.open_new_tab(viz_url)
+                print(f"→ Opening {viz_url} in browser")
+            except Exception as e:
+                print(f"→ Could not open browser automatically: {e}")
+                print(f"→ Visit {viz_url}")
+        else:
             print(f"→ Visit {viz_url}")
-    else:
-        print(f"→ Visit {viz_url}")
-        print("(remember to forward the port if this is a remote host)")
+            print("(remember to forward the port if this is a remote host)")
 
     try:
-        while True:
-            time.sleep(1)
+        start_server(
+            args.port,
+            search_root,
+            args.db,
+            args.host,
+            on_ready=announce_ready,
+        )
     except KeyboardInterrupt:
         print("\n[*] Shutting down.")
 

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -82,10 +82,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         if not failure_json_path:
             return None
         try:
-            failure_path = Path(self.search_root) / failure_json_path
+            failure_path = Path(self._resolve_within_root(failure_json_path))
             if not failure_path.exists():
                 return None
             return json.loads(failure_path.read_text(encoding="utf-8"))
+        except PathValidationError:
+            raise
         except Exception:
             return None
 
@@ -125,7 +127,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         failure_json_path = details.get("failure_json_path")
         if failure_json_path:
-            failure_path = Path(self.search_root) / failure_json_path
+            failure_path = Path(self._resolve_within_root(failure_json_path))
             candidates = sorted(failure_path.parent.glob("main.*"))
             if candidates:
                 return self._language_from_suffix(candidates[0].suffix)
@@ -141,15 +143,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             "generated_code_path"
         )
         if generated_code_path:
-            code_path = Path(self.search_root) / generated_code_path
-            if code_path.exists():
+            code_path = self._existing_path_within_root(generated_code_path)
+            if code_path is not None:
                 return code_path
 
         failure_json_path = details.get("failure_json_path")
         if not failure_json_path:
             return None
 
-        failure_path = Path(self.search_root) / failure_json_path
+        failure_path = Path(self._resolve_within_root(failure_json_path))
         language = self._resolve_failed_node_language(details, failure_payload)
         preferred_suffix = {
             "python": ".py",
@@ -163,11 +165,21 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         }.get(language)
         if preferred_suffix:
             preferred_path = failure_path.parent / f"main{preferred_suffix}"
-            if preferred_path.exists():
-                return preferred_path
+            resolved_path = self._existing_path_within_root(preferred_path)
+            if resolved_path is not None:
+                return resolved_path
 
-        candidates = sorted(failure_path.parent.glob("main.*"))
-        return candidates[0] if candidates else None
+        for candidate in sorted(failure_path.parent.glob("main.*")):
+            resolved_path = self._existing_path_within_root(candidate)
+            if resolved_path is not None:
+                return resolved_path
+        return None
+
+    def _existing_path_within_root(
+        self, path: os.PathLike[str] | str
+    ) -> Optional[Path]:
+        resolved_path = Path(self._resolve_within_root(os.fspath(path)))
+        return resolved_path if resolved_path.exists() else None
 
     def _build_failed_node_dict(
         self,
@@ -587,6 +599,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     self.send_error(500, f"Database error: {str(e)}")
                     return
 
+            except PathValidationError:
+                raise
             except Exception as e:
                 # Catch any other unexpected errors
                 print(f"[SERVER] An unexpected error occurred: {e}")
@@ -659,6 +673,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     self.send_error(500, f"Database error: {str(e)}")
                     return
 
+            except PathValidationError:
+                raise
             except Exception as e:
                 print(f"[SERVER] Error fetching program summaries: {e}")
                 self.send_error(500, f"Error: {str(e)}")
@@ -737,6 +753,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     self.send_error(500, f"Database error: {str(e)}")
                     return
 
+            except PathValidationError:
+                raise
             except Exception as e:
                 print(f"[SERVER] Error fetching program count: {e}")
                 self.send_error(500, f"Error: {str(e)}")
@@ -772,6 +790,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     return
                 self.send_json_response(failed_nodes[0])
                 return
+            except PathValidationError:
+                raise
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
                 self.send_error(500, f"Database error: {str(e)}")
                 return

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -8,6 +8,7 @@ It serves a web interface for exploring evolution databases and meta files.
 
 import argparse
 import base64
+import contextlib
 import errno
 import http.server
 import ipaddress
@@ -27,8 +28,8 @@ import time
 import urllib.parse
 import webbrowser
 import weakref
-from pathlib import Path
-from typing import Optional, Dict, Any, Tuple, Callable
+from pathlib import Path, PureWindowsPath
+from typing import Optional, Dict, Any, Tuple, Callable, Literal
 
 from shinka.database import DatabaseConfig, ProgramDatabase
 from shinka.database import SystemPromptConfig, SystemPromptDatabase
@@ -45,7 +46,33 @@ class PathValidationError(ValueError):
     """Raised when a user-supplied path escapes the served search root."""
 
 
+class DatabaseViewRaceError(sqlite3.OperationalError):
+    """Raised when SQLite sidecars rotate while a stable view is being built."""
+
+
+class _DatabaseMainSnapshot:
+    def __init__(
+        self,
+        version: Tuple[int, int, int],
+        directory: tempfile.TemporaryDirectory,
+        path: str,
+    ):
+        self.version = version
+        self.directory = directory
+        self.path = path
+        self.lock = threading.Lock()
+        self.leases = 0
+        self.evicted = False
+
+
 class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
+    _database_main_cache_lock = threading.Lock()
+    _database_main_cache: Dict[Tuple[int, int], _DatabaseMainSnapshot] = {}
+    _database_main_cache_build_locks: Dict[Tuple[int, int], threading.Lock] = {}
+    _database_main_cache_limit = 2
+    # Soft target: retain one oversized active DB to avoid recopying it every poll.
+    _database_main_cache_target_bytes = 2 * 1024**3
+
     def __init__(
         self,
         *args,
@@ -281,9 +308,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         include_code: bool = False,
         generation: Optional[int] = None,
     ) -> list[Dict[str, Any]]:
-        conn = sqlite3.connect(abs_db_path, timeout=5.0, isolation_level=None)
-        conn.row_factory = sqlite3.Row
-        try:
+        with self._connect_database_within_root(
+            abs_db_path, timeout=5.0, isolation_level=None
+        ) as conn:
+            conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             cursor.execute("PRAGMA busy_timeout = 5000;")
             query = """
@@ -315,10 +343,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     details=details,
                     include_code=include_code,
                 )
-
             return [selected[g] for g in sorted(selected)]
-        finally:
-            conn.close()
 
     # Host header values allowed when the server is bound to loopback. Overwritten
     # per-instance via the handler factory when an explicit external host is used.
@@ -627,6 +652,719 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         with os.fdopen(descriptor, "rb") as file:
             return file.read()
 
+    @classmethod
+    def _copy_database_descriptor(
+        cls,
+        source_descriptor: int,
+        destination_descriptor: int,
+        destination_name: str,
+        *,
+        expected_stat: os.stat_result,
+    ) -> None:
+        source_stat = os.fstat(source_descriptor)
+        if not cls._same_database_file(source_stat, expected_stat, contents=True):
+            raise DatabaseViewRaceError("Database changed before snapshotting")
+
+        destination = os.open(
+            destination_name,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0),
+            0o600,
+            dir_fd=destination_descriptor,
+        )
+        try:
+            offset = 0
+            while True:
+                chunk = os.pread(source_descriptor, 1024 * 1024, offset)
+                if not chunk:
+                    break
+                view = memoryview(chunk)
+                while view:
+                    written = os.write(destination, view)
+                    if written == 0:
+                        raise OSError("Unable to write database snapshot")
+                    view = view[written:]
+                offset += len(chunk)
+        finally:
+            os.close(destination)
+
+        source_stat = os.fstat(source_descriptor)
+        if not cls._same_database_file(source_stat, expected_stat, contents=True):
+            raise DatabaseViewRaceError("Database changed while snapshotting")
+
+    def _copy_optional_database_sidecar(
+        self,
+        parent_descriptor: int,
+        source_name: str,
+        destination_descriptor: int,
+        destination_name: str,
+    ) -> Optional[os.stat_result]:
+        try:
+            source_descriptor = os.open(
+                source_name,
+                os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+                dir_fd=parent_descriptor,
+            )
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise PathValidationError(
+                    f"Database sidecar changed during access: {source_name!r}"
+                ) from exc
+            raise
+        try:
+            source_stat = os.fstat(source_descriptor)
+            if not stat.S_ISREG(source_stat.st_mode):
+                raise PathValidationError(
+                    f"Database sidecar is not a file: {source_name!r}"
+                )
+            self._copy_database_descriptor(
+                source_descriptor,
+                destination_descriptor,
+                destination_name,
+                expected_stat=source_stat,
+            )
+            return source_stat
+        finally:
+            os.close(source_descriptor)
+
+    @staticmethod
+    def _stat_optional_database_sidecar(
+        parent_descriptor: int,
+        source_name: str,
+    ) -> Optional[os.stat_result]:
+        try:
+            source_stat = os.stat(
+                source_name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return None
+        if not stat.S_ISREG(source_stat.st_mode):
+            raise PathValidationError(
+                f"Database sidecar is not a file: {source_name!r}"
+            )
+        return source_stat
+
+    @classmethod
+    def _rollback_journal_is_hot(
+        cls,
+        parent_descriptor: int,
+        source_name: str,
+        expected_stat: os.stat_result,
+    ) -> bool:
+        try:
+            source_descriptor = os.open(
+                source_name,
+                os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+                dir_fd=parent_descriptor,
+            )
+        except FileNotFoundError as exc:
+            raise DatabaseViewRaceError(
+                "Rollback journal changed while snapshotting"
+            ) from exc
+        except OSError as exc:
+            if exc.errno == errno.ELOOP:
+                raise PathValidationError(
+                    f"Database sidecar changed during access: {source_name!r}"
+                ) from exc
+            raise
+        try:
+            if not cls._same_database_file(
+                os.fstat(source_descriptor), expected_stat, contents=True
+            ):
+                raise DatabaseViewRaceError(
+                    "Rollback journal changed while snapshotting"
+                )
+            header = os.pread(source_descriptor, 8, 0)
+            if not cls._same_database_file(
+                os.fstat(source_descriptor), expected_stat, contents=True
+            ):
+                raise DatabaseViewRaceError(
+                    "Rollback journal changed while snapshotting"
+                )
+        finally:
+            os.close(source_descriptor)
+        return header == b"\xd9\xd5\x05\xf9\x20\xa1\x63\xd7"
+
+    @contextlib.contextmanager
+    def _database_staging_directory(self, resolved_database_path: str):
+        for staging_parent in self._database_staging_parents(
+            resolved_database_path,
+        ):
+            try:
+                temp_directory = tempfile.TemporaryDirectory(
+                    prefix="shinka-webui-db-",
+                    dir=staging_parent,
+                )
+            except OSError:
+                continue
+            directory_descriptor = None
+            try:
+                directory_descriptor = os.open(
+                    temp_directory.name,
+                    self._directory_open_flags(),
+                )
+                yield directory_descriptor, temp_directory.name
+                return
+            finally:
+                if directory_descriptor is not None:
+                    os.close(directory_descriptor)
+                temp_directory.cleanup()
+
+        raise sqlite3.OperationalError("no secure writable staging directory exists")
+
+    @classmethod
+    def _database_staging_parents(
+        cls,
+        resolved_database_path: str,
+    ) -> list[str]:
+        database_parent = os.path.dirname(resolved_database_path)
+        candidates = [
+            tempfile.gettempdir(),
+            "/var/tmp",
+            "/tmp",
+            "/dev/shm",
+        ]
+        candidates.extend(
+            os.fspath(parent)
+            for parent in reversed(Path(database_parent).parents)
+        )
+
+        staging_parents = []
+        seen = set()
+        for candidate in candidates:
+            canonical_candidate = os.path.realpath(candidate)
+            if canonical_candidate in seen or canonical_candidate == database_parent:
+                continue
+            seen.add(canonical_candidate)
+            try:
+                os.stat(canonical_candidate)
+            except OSError:
+                continue
+            if not cls._is_secure_staging_parent(canonical_candidate):
+                continue
+            if not os.access(canonical_candidate, os.W_OK | os.X_OK):
+                continue
+            staging_parents.append(canonical_candidate)
+        return staging_parents
+
+    @staticmethod
+    def _database_cache_key(
+        database_stat: os.stat_result,
+    ) -> Tuple[int, int, int]:
+        return (
+            database_stat.st_size,
+            database_stat.st_mtime_ns,
+            database_stat.st_ctime_ns,
+        )
+
+    def _cached_database_main(
+        self,
+        resolved_database_path: str,
+        database_descriptor: int,
+        database_stat: os.stat_result,
+    ) -> _DatabaseMainSnapshot:
+        source_key = (database_stat.st_dev, database_stat.st_ino)
+        cache_key = self._database_cache_key(database_stat)
+        with self._database_main_cache_lock:
+            build_lock = self._database_main_cache_build_locks.setdefault(
+                source_key,
+                threading.Lock(),
+            )
+
+        with build_lock:
+            discarded: list[_DatabaseMainSnapshot] = []
+            with self._database_main_cache_lock:
+                cached = self._database_main_cache.pop(source_key, None)
+                if cached is not None and cached.version == cache_key:
+                    cached.leases += 1
+                    self._database_main_cache[source_key] = cached
+                    return cached
+                if cached is not None:
+                    cached.evicted = True
+                    discarded.append(cached)
+                self._evict_database_main_cache_entries(
+                    incoming_size=database_stat.st_size,
+                    discarded=discarded,
+                )
+            self._cleanup_database_snapshots(discarded)
+
+            staging_parents = self._database_staging_parents(
+                resolved_database_path,
+            )
+            if not staging_parents:
+                raise sqlite3.OperationalError(
+                    "no secure writable staging directory exists"
+                )
+            temp_directory = tempfile.TemporaryDirectory(
+                prefix="shinka-webui-main-",
+                dir=staging_parents[0],
+            )
+            directory_descriptor = None
+            try:
+                directory_descriptor = os.open(
+                    temp_directory.name,
+                    self._directory_open_flags(),
+                )
+                self._copy_database_descriptor(
+                    database_descriptor,
+                    directory_descriptor,
+                    "database.sqlite",
+                    expected_stat=database_stat,
+                )
+                cached_path = os.path.join(
+                    temp_directory.name,
+                    "database.sqlite",
+                )
+                os.chmod(cached_path, 0o400)
+            except Exception:
+                if directory_descriptor is not None:
+                    os.close(directory_descriptor)
+                    directory_descriptor = None
+                temp_directory.cleanup()
+                raise
+            finally:
+                if directory_descriptor is not None:
+                    os.close(directory_descriptor)
+
+            cached = _DatabaseMainSnapshot(
+                cache_key,
+                temp_directory,
+                cached_path,
+            )
+            cached.leases = 1
+            discarded = []
+            with self._database_main_cache_lock:
+                self._evict_database_main_cache_entries(
+                    incoming_size=database_stat.st_size,
+                    discarded=discarded,
+                )
+                self._database_main_cache[source_key] = cached
+            self._cleanup_database_snapshots(discarded)
+            return cached
+
+    @classmethod
+    def _evict_database_main_cache_entries(
+        cls,
+        *,
+        incoming_size: int,
+        discarded: list[_DatabaseMainSnapshot],
+    ) -> None:
+        cached_bytes = sum(
+            entry.version[0] for entry in cls._database_main_cache.values()
+        )
+        while cls._database_main_cache and (
+            len(cls._database_main_cache) >= cls._database_main_cache_limit
+            or cached_bytes + incoming_size > cls._database_main_cache_target_bytes
+        ):
+            oldest_key = next(iter(cls._database_main_cache))
+            evicted = cls._database_main_cache.pop(oldest_key)
+            evicted.evicted = True
+            cached_bytes -= evicted.version[0]
+            discarded.append(evicted)
+
+    @staticmethod
+    def _cleanup_database_snapshots(
+        snapshots: list[_DatabaseMainSnapshot],
+    ) -> None:
+        for snapshot in snapshots:
+            if snapshot.leases == 0:
+                snapshot.directory.cleanup()
+
+    @classmethod
+    def _release_database_main_snapshot(
+        cls,
+        snapshot: _DatabaseMainSnapshot,
+    ) -> None:
+        cleanup = False
+        with cls._database_main_cache_lock:
+            snapshot.leases -= 1
+            cleanup = snapshot.evicted and snapshot.leases == 0
+        if cleanup:
+            snapshot.directory.cleanup()
+
+    @classmethod
+    def clear_database_snapshot_cache(cls) -> None:
+        with cls._database_main_cache_lock:
+            cached = list(cls._database_main_cache.values())
+            cls._database_main_cache.clear()
+            cls._database_main_cache_build_locks.clear()
+            for snapshot in cached:
+                snapshot.evicted = True
+        cls._cleanup_database_snapshots(cached)
+
+    @classmethod
+    def _stage_cached_database_main(
+        cls,
+        cached_path: str,
+        destination_descriptor: int,
+    ) -> None:
+        try:
+            os.link(
+                cached_path,
+                "database.sqlite",
+                dst_dir_fd=destination_descriptor,
+                follow_symlinks=False,
+            )
+            return
+        except OSError as exc:
+            if exc.errno not in {
+                errno.EACCES,
+                errno.EPERM,
+                errno.EXDEV,
+                errno.EMLINK,
+                errno.ENOSYS,
+                errno.EROFS,
+                getattr(errno, "ENOTSUP", errno.EINVAL),
+                getattr(errno, "EOPNOTSUPP", errno.EINVAL),
+            }:
+                raise
+
+        cached_descriptor = os.open(
+            cached_path,
+            os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+        )
+        try:
+            cached_stat = os.fstat(cached_descriptor)
+            cls._copy_database_descriptor(
+                cached_descriptor,
+                destination_descriptor,
+                "database.sqlite",
+                expected_stat=cached_stat,
+            )
+        finally:
+            os.close(cached_descriptor)
+
+    @staticmethod
+    def _is_secure_staging_parent(candidate: str) -> bool:
+        effective_uid = getattr(os, "geteuid", lambda: -1)()
+        trusted_uids = {0, effective_uid}
+        current = candidate
+        while True:
+            try:
+                current_stat = os.stat(current)
+            except OSError:
+                return False
+            if not stat.S_ISDIR(current_stat.st_mode):
+                return False
+            if current_stat.st_uid not in trusted_uids:
+                return False
+            untrusted_writable = current_stat.st_mode & 0o022
+            if untrusted_writable and not current_stat.st_mode & stat.S_ISVTX:
+                return False
+            parent = os.path.dirname(current)
+            if parent == current:
+                return True
+            current = parent
+
+    @staticmethod
+    def _verify_database_sidecars(
+        parent_descriptor: int,
+        expected_sidecars: Dict[str, Optional[os.stat_result]],
+        *,
+        verify_contents: bool,
+    ) -> None:
+        for source_name, expected_stat in expected_sidecars.items():
+            try:
+                current_stat = os.stat(
+                    source_name,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                current_stat = None
+            if expected_stat is None and current_stat is None:
+                continue
+            if expected_stat is None or current_stat is None:
+                raise DatabaseViewRaceError(
+                    f"Database sidecar changed while pinning {source_name!r}"
+                )
+            sidecar_contents_matter = verify_contents and not source_name.endswith(
+                "-shm"
+            )
+            if not DatabaseRequestHandler._same_database_file(
+                current_stat,
+                expected_stat,
+                contents=sidecar_contents_matter,
+            ):
+                raise DatabaseViewRaceError(
+                    f"Database sidecar changed while pinning {source_name!r}"
+                )
+
+    @staticmethod
+    def _same_database_file(
+        current_stat: os.stat_result,
+        expected_stat: os.stat_result,
+        *,
+        contents: bool,
+    ) -> bool:
+        if (
+            current_stat.st_dev != expected_stat.st_dev
+            or current_stat.st_ino != expected_stat.st_ino
+            or not stat.S_ISREG(current_stat.st_mode)
+        ):
+            return False
+        if not contents:
+            return True
+        return (
+            current_stat.st_size == expected_stat.st_size
+            and current_stat.st_mtime_ns == expected_stat.st_mtime_ns
+            and current_stat.st_ctime_ns == expected_stat.st_ctime_ns
+        )
+
+    @staticmethod
+    def _sqlite_read_only_uri(path: os.PathLike[str] | str) -> str:
+        path_string = os.fspath(path)
+        if re.match(r"^[A-Za-z]:[\\/]", path_string):
+            uri = PureWindowsPath(path_string).as_uri()
+        else:
+            uri = Path(path_string).as_uri()
+        return uri + "?mode=ro"
+
+    @classmethod
+    def _sqlite_read_only_target(
+        cls,
+        path: os.PathLike[str] | str,
+    ) -> Tuple[str, bool]:
+        path_string = os.fspath(path)
+        if path_string.startswith("\\\\"):
+            return path_string, False
+        return cls._sqlite_read_only_uri(path_string), True
+
+    def _stage_database_view(
+        self,
+        *,
+        cached_main_path: str,
+        parent_descriptor: int,
+        source_name: str,
+        destination_descriptor: int,
+    ) -> Dict[str, Optional[os.stat_result]]:
+        self._stage_cached_database_main(
+            cached_main_path,
+            destination_descriptor,
+        )
+
+        sidecars = {}
+        for suffix in ("-wal", "-shm", "-journal"):
+            sidecar_name = source_name + suffix
+            if suffix == "-wal":
+                sidecar_stat = self._copy_optional_database_sidecar(
+                    parent_descriptor,
+                    sidecar_name,
+                    destination_descriptor,
+                    "database.sqlite" + suffix,
+                )
+            else:
+                sidecar_stat = self._stat_optional_database_sidecar(
+                    parent_descriptor,
+                    sidecar_name,
+                )
+                if (
+                    suffix == "-journal"
+                    and sidecar_stat is not None
+                    and self._rollback_journal_is_hot(
+                        parent_descriptor,
+                        sidecar_name,
+                        sidecar_stat,
+                    )
+                ):
+                    raise DatabaseViewRaceError(
+                        "Rollback journal is active while snapshotting"
+                    )
+            sidecars[sidecar_name] = sidecar_stat
+        return sidecars
+
+    def _verify_database_view(
+        self,
+        *,
+        database_descriptor: int,
+        database_stat: os.stat_result,
+        parent_descriptor: int,
+        source_name: str,
+        sidecars: Dict[str, Optional[os.stat_result]],
+    ) -> None:
+        try:
+            current_database_stat = os.stat(
+                source_name,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError as exc:
+            raise DatabaseViewRaceError(
+                "Database path changed while pinning SQLite sidecars"
+            ) from exc
+        if not self._same_database_file(
+            current_database_stat,
+            database_stat,
+            contents=False,
+        ):
+            raise DatabaseViewRaceError(
+                "Database path changed while pinning SQLite sidecars"
+            )
+        if not self._same_database_file(
+            os.fstat(database_descriptor), database_stat, contents=True
+        ):
+            raise DatabaseViewRaceError("Database changed while snapshotting")
+        self._verify_database_sidecars(
+            parent_descriptor,
+            sidecars,
+            verify_contents=True,
+        )
+
+    @contextlib.contextmanager
+    def _connect_database_within_root(
+        self,
+        path: os.PathLike[str] | str,
+        *,
+        timeout: float,
+        isolation_level: Optional[
+            Literal["DEFERRED", "EXCLUSIVE", "IMMEDIATE"]
+        ] = None,
+    ):
+        if not self._supports_descriptor_traversal():
+            resolved_path = self._resolve_within_root(os.fspath(path))
+            connection_target, use_uri = self._sqlite_read_only_target(resolved_path)
+            connection = sqlite3.connect(
+                connection_target,
+                uri=use_uri,
+                timeout=timeout,
+                isolation_level=isolation_level,
+            )
+            try:
+                if not use_uri:
+                    connection.execute("PRAGMA query_only = ON")
+                yield connection
+            finally:
+                connection.close()
+            return
+
+        resolved_path = self._resolve_within_root(os.fspath(path))
+        database_descriptor = self._open_descriptor_within_root(
+            resolved_path, os.O_RDONLY
+        )
+        parent_descriptor = None
+        try:
+            database_stat = os.fstat(database_descriptor)
+            if not stat.S_ISREG(database_stat.st_mode):
+                raise PathValidationError(f"Database is not a file: {path!r}")
+            parent_descriptor = self._open_descriptor_within_root(
+                os.path.dirname(resolved_path),
+                os.O_RDONLY | os.O_DIRECTORY,
+            )
+            source_name = os.path.basename(resolved_path)
+            race_attempts = 0
+            while race_attempts < 3:
+                attempt_database_stat = os.fstat(database_descriptor)
+                try:
+                    cached_main = self._cached_database_main(
+                        resolved_path,
+                        database_descriptor,
+                        attempt_database_stat,
+                    )
+                    with contextlib.ExitStack() as snapshot_stack:
+                        snapshot_stack.callback(
+                            self._release_database_main_snapshot,
+                            cached_main,
+                        )
+                        snapshot_stack.enter_context(cached_main.lock)
+                        staging_descriptor, staging_path = snapshot_stack.enter_context(
+                            self._database_staging_directory(resolved_path)
+                        )
+                        sidecars = self._stage_database_view(
+                            cached_main_path=cached_main.path,
+                            parent_descriptor=parent_descriptor,
+                            source_name=source_name,
+                            destination_descriptor=staging_descriptor,
+                        )
+                        self._verify_database_view(
+                            database_descriptor=database_descriptor,
+                            database_stat=attempt_database_stat,
+                            parent_descriptor=parent_descriptor,
+                            source_name=source_name,
+                            sidecars=sidecars,
+                        )
+                        stable_path = os.path.join(staging_path, "database.sqlite")
+                        connection = None
+                        try:
+                            connection = sqlite3.connect(
+                                self._sqlite_read_only_uri(stable_path),
+                                uri=True,
+                                timeout=timeout,
+                                isolation_level=isolation_level,
+                            )
+                            connection.execute("BEGIN")
+                            connection.execute("PRAGMA schema_version").fetchone()
+                        except sqlite3.DatabaseError:
+                            try:
+                                self._verify_database_view(
+                                    database_descriptor=database_descriptor,
+                                    database_stat=attempt_database_stat,
+                                    parent_descriptor=parent_descriptor,
+                                    source_name=source_name,
+                                    sidecars=sidecars,
+                                )
+                            finally:
+                                if connection is not None:
+                                    connection.close()
+                            raise
+                        try:
+                            self._verify_database_view(
+                                database_descriptor=database_descriptor,
+                                database_stat=attempt_database_stat,
+                                parent_descriptor=parent_descriptor,
+                                source_name=source_name,
+                                sidecars=sidecars,
+                            )
+                        except Exception:
+                            connection.close()
+                            raise
+                        try:
+                            yield connection
+                        finally:
+                            connection.close()
+                        return
+                except DatabaseViewRaceError:
+                    race_attempts += 1
+                    if race_attempts == 3:
+                        raise sqlite3.OperationalError(
+                            "database is busy while pinning SQLite sidecars"
+                        )
+        finally:
+            if parent_descriptor is not None:
+                os.close(parent_descriptor)
+            os.close(database_descriptor)
+
+    @contextlib.contextmanager
+    def _open_program_database_within_root(self, path: os.PathLike[str] | str):
+        with self._connect_database_within_root(path, timeout=60.0) as connection:
+            database = ProgramDatabase(
+                DatabaseConfig(db_path=os.fspath(path)),
+                read_only=True,
+                connection=connection,
+            )
+            try:
+                yield database
+            finally:
+                database.close()
+
+    @contextlib.contextmanager
+    def _open_prompt_database_within_root(self, path: os.PathLike[str] | str):
+        with self._connect_database_within_root(path, timeout=30.0) as connection:
+            database = SystemPromptDatabase(
+                SystemPromptConfig(db_path=os.fspath(path)),
+                read_only=True,
+                connection=connection,
+            )
+            try:
+                yield database
+            finally:
+                database.close()
+
     def _list_directory_within_root(
         self, path: os.PathLike[str] | str
     ) -> list[str]:
@@ -784,26 +1522,21 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         max_retries = 8
         delay = 0.2
         for i in range(max_retries):
-            db = None
             try:
-                config = DatabaseConfig(db_path=abs_db_path)
-                db = ProgramDatabase(config, read_only=True)
+                with self._open_program_database_within_root(abs_db_path) as db:
+                    # Set WAL mode compatible settings for read-only connections
+                    # Longer busy_timeout for concurrent access during evolution
+                    if db.cursor:
+                        db.cursor.execute("PRAGMA busy_timeout = 30000;")
 
-                # Set WAL mode compatible settings for read-only connections
-                # Longer busy_timeout for concurrent access during evolution
-                if db.cursor:
-                    db.cursor.execute("PRAGMA busy_timeout = 30000;")
-                    try:
-                        db.cursor.execute("PRAGMA journal_mode = WAL;")
-                    except sqlite3.OperationalError:
-                        pass
+                    programs = db.get_all_programs()
 
-                programs = db.get_all_programs()
-
-                # Convert Program objects to dicts for JSON
-                programs_dict = [p.to_dict() for p in programs]
+                    # Convert Program objects to dicts for JSON
+                    programs_dict = [p.to_dict() for p in programs]
                 programs_dict.extend(
-                    self._load_failed_proposal_nodes(abs_db_path, include_code=False)
+                    self._load_failed_proposal_nodes(
+                        abs_db_path, include_code=False
+                    )
                 )
 
                 # Update cache
@@ -817,6 +1550,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 print(success_msg)
                 return  # Success, exit the retry loop
 
+            except PathValidationError:
+                raise
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
                 error_str = str(e).lower()
                 is_retryable = (
@@ -858,14 +1593,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 print(f"[SERVER] An unexpected error occurred: {e}")
                 self.send_error(500, f"An unexpected error occurred: {str(e)}")
                 return  # Don't retry on unknown errors
-            finally:
-                # Ensure database connection is properly closed
-                if db and hasattr(db, "close"):
-                    try:
-                        db.close()
-                    except Exception as e:
-                        print(f"[SERVER] Warning: Error closing database: {e}")
-
     def handle_get_programs_summary(self, db_path: str):
         """Fetch lightweight program summaries (no code, no embeddings)."""
         print(f"[SERVER] Fetching program summaries from DB: {db_path}")
@@ -880,21 +1607,16 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         max_retries = 8
         delay = 0.2
         for i in range(max_retries):
-            db = None
             try:
-                config = DatabaseConfig(db_path=abs_db_path)
-                db = ProgramDatabase(config, read_only=True)
+                with self._open_program_database_within_root(abs_db_path) as db:
+                    if db.cursor:
+                        db.cursor.execute("PRAGMA busy_timeout = 30000;")
 
-                if db.cursor:
-                    db.cursor.execute("PRAGMA busy_timeout = 30000;")
-                    try:
-                        db.cursor.execute("PRAGMA journal_mode = WAL;")
-                    except sqlite3.OperationalError:
-                        pass
-
-                summaries = db.get_programs_summary()
+                    summaries = db.get_programs_summary()
                 summaries.extend(
-                    self._load_failed_proposal_nodes(abs_db_path, include_code=False)
+                    self._load_failed_proposal_nodes(
+                        abs_db_path, include_code=False
+                    )
                 )
                 self.send_json_response(summaries)
                 print(
@@ -931,13 +1653,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 print(f"[SERVER] Error fetching program summaries: {e}")
                 self.send_error(500, f"Error: {str(e)}")
                 return
-            finally:
-                if db and hasattr(db, "close"):
-                    try:
-                        db.close()
-                    except Exception:
-                        pass
-
     def handle_get_program_count(self, db_path: str):
         """Get program count and max timestamp for efficient change detection."""
         print(f"[SERVER] Fetching program count from DB: {db_path}")
@@ -952,19 +1667,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         max_retries = 8
         delay = 0.2
         for i in range(max_retries):
-            db = None
             try:
-                config = DatabaseConfig(db_path=abs_db_path)
-                db = ProgramDatabase(config, read_only=True)
+                with self._open_program_database_within_root(abs_db_path) as db:
+                    if db.cursor:
+                        db.cursor.execute("PRAGMA busy_timeout = 30000;")
 
-                if db.cursor:
-                    db.cursor.execute("PRAGMA busy_timeout = 30000;")
-                    try:
-                        db.cursor.execute("PRAGMA journal_mode = WAL;")
-                    except sqlite3.OperationalError:
-                        pass
-
-                result = db.get_program_count_and_timestamp()
+                    result = db.get_program_count_and_timestamp()
                 failed_nodes = self._load_failed_proposal_nodes(
                     abs_db_path, include_code=False
                 )
@@ -1011,13 +1719,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 print(f"[SERVER] Error fetching program count: {e}")
                 self.send_error(500, f"Error: {str(e)}")
                 return
-            finally:
-                if db and hasattr(db, "close"):
-                    try:
-                        db.close()
-                    except Exception:
-                        pass
-
     def handle_get_program_details(self, db_path: str, program_id: str):
         """Get full details for a single program (including code and embeddings)."""
         print(f"[SERVER] Fetching program details for ID: {program_id}")
@@ -1055,19 +1756,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         max_retries = 8
         delay = 0.2
         for i in range(max_retries):
-            db = None
             try:
-                config = DatabaseConfig(db_path=abs_db_path)
-                db = ProgramDatabase(config, read_only=True)
+                with self._open_program_database_within_root(abs_db_path) as db:
+                    if db.cursor:
+                        db.cursor.execute("PRAGMA busy_timeout = 30000;")
 
-                if db.cursor:
-                    db.cursor.execute("PRAGMA busy_timeout = 30000;")
-                    try:
-                        db.cursor.execute("PRAGMA journal_mode = WAL;")
-                    except sqlite3.OperationalError:
-                        pass
-
-                program = db.get(program_id)
+                    program = db.get(program_id)
                 if program is None:
                     self.send_error(404, f"Program not found: {program_id}")
                     return
@@ -1075,6 +1769,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 self.send_json_response(program.to_dict())
                 return
 
+            except PathValidationError:
+                raise
             except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
                 error_str = str(e).lower()
                 is_retryable = (
@@ -1101,12 +1797,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 print(f"[SERVER] Error fetching program details: {e}")
                 self.send_error(500, f"Error: {str(e)}")
                 return
-            finally:
-                if db and hasattr(db, "close"):
-                    try:
-                        db.close()
-                    except Exception:
-                        pass
 
     def handle_get_meta_files(self, db_path: str):
         """List available meta files keyed by processed-count suffix."""
@@ -1402,18 +2092,16 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         max_retries = 8
         delay = 0.2
         for i in range(max_retries):
-            prompt_db = None
             try:
-                config = SystemPromptConfig(db_path=prompts_db_path)
-                prompt_db = SystemPromptDatabase(config, read_only=True)
+                with self._open_prompt_database_within_root(
+                    prompts_db_path
+                ) as prompt_db:
+                    # Set WAL mode compatible settings for read-only connections
+                    # Longer busy_timeout for concurrent access during evolution
+                    if prompt_db.cursor:
+                        prompt_db.cursor.execute("PRAGMA busy_timeout = 30000;")
 
-                # Set WAL mode compatible settings for read-only connections
-                # Longer busy_timeout for concurrent access during evolution
-                if prompt_db.cursor:
-                    prompt_db.cursor.execute("PRAGMA busy_timeout = 30000;")
-                    prompt_db.cursor.execute("PRAGMA journal_mode = WAL;")
-
-                prompts = prompt_db.get_all_prompts()
+                    prompts = prompt_db.get_all_prompts()
 
                 # Convert SystemPrompt objects to dicts for JSON
                 prompts_dict = [p.to_dict() for p in prompts]
@@ -1468,6 +2156,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     self.send_json_response([])
                     return
 
+            except PathValidationError:
+                raise
             except Exception as e:
                 print(f"[SERVER] Error fetching system prompts: {e}")
                 import traceback
@@ -1476,13 +2166,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 # Return empty list instead of 500 - prompts are optional
                 self.send_json_response([])
                 return
-            finally:
-                if prompt_db and hasattr(prompt_db, "close"):
-                    try:
-                        prompt_db.close()
-                    except Exception as e:
-                        print(f"[SERVER] Warning: Error closing prompts database: {e}")
-
     def handle_get_database_stats(self, db_path: str):
         """Get quick aggregate stats for a database (count, best score, cost)."""
         actual_db_path = self._get_actual_db_path(db_path)
@@ -1499,9 +2182,16 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         max_retries = 3
         delay = 0.1
         for i in range(max_retries):
+            stack = contextlib.ExitStack()
             conn = None
             try:
-                conn = sqlite3.connect(abs_db_path, timeout=5.0, isolation_level=None)
+                conn = stack.enter_context(
+                    self._connect_database_within_root(
+                        abs_db_path,
+                        timeout=5.0,
+                        isolation_level=None,
+                    )
+                )
                 conn.row_factory = sqlite3.Row
                 cursor = conn.cursor()
                 cursor.execute("PRAGMA busy_timeout = 5000;")
@@ -1607,8 +2297,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 # Check for prompts.db in the same directory
                 if os.path.exists(prompts_db_path):
                     try:
-                        pconn = sqlite3.connect(
-                            prompts_db_path, timeout=2.0, isolation_level=None
+                        pconn = stack.enter_context(
+                            self._connect_database_within_root(
+                                prompts_db_path,
+                                timeout=2.0,
+                                isolation_level=None,
+                            )
                         )
                         pconn.row_factory = sqlite3.Row
                         pcursor = pconn.cursor()
@@ -1635,7 +2329,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                         """)
                         pcost_row = pcursor.fetchone()
                         stats["prompt_evo_cost"] = pcost_row["prompt_cost"] or 0
-                        pconn.close()
+                    except PathValidationError:
+                        raise
                     except Exception as pe:
                         print(f"[SERVER] Warning: Error reading prompts.db: {pe}")
 
@@ -1661,6 +2356,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     }
                 )
                 return
+            except PathValidationError:
+                raise
             except Exception as e:
                 self.send_json_response(
                     {
@@ -1674,11 +2371,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 )
                 return
             finally:
-                if conn:
-                    try:
-                        conn.close()
-                    except Exception:
-                        pass
+                stack.close()
 
     def _generate_pdf(self, content: str, generation: str) -> bytes:
         """Generate PDF from markdown content using available methods."""
@@ -2281,7 +2974,10 @@ def start_server(
                     print(f"[SERVER] Readiness callback failed: {exc}")
 
             threading.Thread(target=notify_ready, daemon=True).start()
-        httpd.serve_forever()
+        try:
+            httpd.serve_forever()
+        finally:
+            DatabaseRequestHandler.clear_database_snapshot_cache()
 
 
 def main():

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -712,10 +712,17 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         )
         try:
             offset = 0
-            while True:
-                chunk = os.pread(source_descriptor, 1024 * 1024, offset)
+            remaining = expected_stat.st_size
+            while remaining:
+                chunk = os.pread(
+                    source_descriptor,
+                    min(1024 * 1024, remaining),
+                    offset,
+                )
                 if not chunk:
-                    break
+                    raise DatabaseViewRaceError(
+                        "Database changed while snapshotting"
+                    )
                 view = memoryview(chunk)
                 while view:
                     written = os.write(destination, view)
@@ -723,6 +730,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                         raise OSError("Unable to write database snapshot")
                     view = view[written:]
                 offset += len(chunk)
+                remaining -= len(chunk)
         finally:
             os.close(destination)
 
@@ -834,10 +842,16 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         return header == b"\xd9\xd5\x05\xf9\x20\xa1\x63\xd7"
 
     @contextlib.contextmanager
-    def _database_staging_directory(self, resolved_database_path: str):
+    def _database_staging_directory(
+        self,
+        resolved_database_path: str,
+        excluded_parents: set[str],
+    ):
         for staging_parent in self._database_staging_parents(
             resolved_database_path,
         ):
+            if staging_parent in excluded_parents:
+                continue
             try:
                 temp_directory = tempfile.TemporaryDirectory(
                     prefix="shinka-webui-db-",
@@ -851,7 +865,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     temp_directory.name,
                     self._directory_open_flags(),
                 )
-                yield directory_descriptor, temp_directory.name
+                yield directory_descriptor, temp_directory.name, staging_parent
                 return
             finally:
                 if directory_descriptor is not None:
@@ -975,13 +989,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         database_descriptor: int,
         database_stat: os.stat_result,
     ) -> Tuple[tempfile.TemporaryDirectory, str]:
-        retry_errors = {
-            errno.EACCES,
-            errno.EPERM,
-            errno.ENOSPC,
-            errno.EROFS,
-            getattr(errno, "EDQUOT", -1),
-        }
         last_error = None
         for staging_parent in staging_parents:
             temp_directory = None
@@ -1010,7 +1017,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 succeeded = True
                 return temp_directory, cached_path
             except OSError as exc:
-                if exc.errno not in retry_errors:
+                if not self._is_retryable_staging_error(exc):
                     raise
                 last_error = exc
             finally:
@@ -1022,6 +1029,16 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         raise sqlite3.OperationalError(
             "no secure staging directory has enough space for the database snapshot"
         ) from last_error
+
+    @staticmethod
+    def _is_retryable_staging_error(exc: OSError) -> bool:
+        return exc.errno in {
+            errno.EACCES,
+            errno.EPERM,
+            errno.ENOSPC,
+            errno.EROFS,
+            getattr(errno, "EDQUOT", -1),
+        }
 
     @classmethod
     def _evict_database_main_cache_entries(
@@ -1335,8 +1352,11 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             )
             source_name = os.path.basename(resolved_path)
             race_attempts = 0
+            excluded_staging_parents: set[str] = set()
             while race_attempts < 3:
                 attempt_database_stat = os.fstat(database_descriptor)
+                active_staging_parent = None
+                connection_yielded = False
                 try:
                     cached_main = self._cached_database_main(
                         resolved_path,
@@ -1353,8 +1373,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                                 "database snapshot is busy"
                             )
                         snapshot_stack.callback(cached_main.lock.release)
-                        staging_descriptor, staging_path = snapshot_stack.enter_context(
-                            self._database_staging_directory(resolved_path)
+                        (
+                            staging_descriptor,
+                            staging_path,
+                            active_staging_parent,
+                        ) = snapshot_stack.enter_context(
+                            self._database_staging_directory(
+                                resolved_path,
+                                excluded_staging_parents,
+                            )
                         )
                         sidecars = self._stage_database_view(
                             cached_main_path=cached_main.path,
@@ -1409,10 +1436,20 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                             connection.close()
                             raise
                         try:
+                            connection_yielded = True
                             yield connection
                         finally:
                             connection.close()
                         return
+                except OSError as exc:
+                    if (
+                        connection_yielded
+                        or active_staging_parent is None
+                        or not self._is_retryable_staging_error(exc)
+                    ):
+                        raise
+                    excluded_staging_parents.add(active_staging_parent)
+                    continue
                 except DatabaseViewRaceError:
                     race_attempts += 1
                     if race_attempts == 3:

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -941,36 +941,11 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 raise sqlite3.OperationalError(
                     "no secure writable staging directory exists"
                 )
-            temp_directory = tempfile.TemporaryDirectory(
-                prefix="shinka-webui-main-",
-                dir=staging_parents[0],
+            temp_directory, cached_path = self._copy_database_main_to_staging(
+                staging_parents,
+                database_descriptor,
+                database_stat,
             )
-            directory_descriptor = None
-            try:
-                directory_descriptor = os.open(
-                    temp_directory.name,
-                    self._directory_open_flags(),
-                )
-                self._copy_database_descriptor(
-                    database_descriptor,
-                    directory_descriptor,
-                    "database.sqlite",
-                    expected_stat=database_stat,
-                )
-                cached_path = os.path.join(
-                    temp_directory.name,
-                    "database.sqlite",
-                )
-                os.chmod(cached_path, 0o400)
-            except Exception:
-                if directory_descriptor is not None:
-                    os.close(directory_descriptor)
-                    directory_descriptor = None
-                temp_directory.cleanup()
-                raise
-            finally:
-                if directory_descriptor is not None:
-                    os.close(directory_descriptor)
 
             cached = _DatabaseMainSnapshot(
                 cache_key,
@@ -987,6 +962,60 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 self._database_main_cache[source_key] = cached
             self._cleanup_database_snapshots(discarded)
             return cached
+
+    def _copy_database_main_to_staging(
+        self,
+        staging_parents: list[str],
+        database_descriptor: int,
+        database_stat: os.stat_result,
+    ) -> Tuple[tempfile.TemporaryDirectory, str]:
+        retry_errors = {
+            errno.EACCES,
+            errno.EPERM,
+            errno.ENOSPC,
+            errno.EROFS,
+            getattr(errno, "EDQUOT", -1),
+        }
+        last_error = None
+        for staging_parent in staging_parents:
+            temp_directory = None
+            directory_descriptor = None
+            succeeded = False
+            try:
+                temp_directory = tempfile.TemporaryDirectory(
+                    prefix="shinka-webui-main-",
+                    dir=staging_parent,
+                )
+                directory_descriptor = os.open(
+                    temp_directory.name,
+                    self._directory_open_flags(),
+                )
+                self._copy_database_descriptor(
+                    database_descriptor,
+                    directory_descriptor,
+                    "database.sqlite",
+                    expected_stat=database_stat,
+                )
+                cached_path = os.path.join(
+                    temp_directory.name,
+                    "database.sqlite",
+                )
+                os.chmod(cached_path, 0o400)
+                succeeded = True
+                return temp_directory, cached_path
+            except OSError as exc:
+                if exc.errno not in retry_errors:
+                    raise
+                last_error = exc
+            finally:
+                if directory_descriptor is not None:
+                    os.close(directory_descriptor)
+                if temp_directory is not None and not succeeded:
+                    temp_directory.cleanup()
+
+        raise sqlite3.OperationalError(
+            "no secure staging directory has enough space for the database snapshot"
+        ) from last_error
 
     @classmethod
     def _evict_database_main_cache_entries(

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -736,6 +736,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         source_name: str,
         destination_descriptor: int,
         destination_name: str,
+        *,
+        max_bytes: int,
     ) -> Optional[os.stat_result]:
         try:
             source_descriptor = os.open(
@@ -756,6 +758,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             if not stat.S_ISREG(source_stat.st_mode):
                 raise PathValidationError(
                     f"Database sidecar is not a file: {source_name!r}"
+                )
+            if source_stat.st_size > max_bytes:
+                raise sqlite3.OperationalError(
+                    "database and WAL exceed the 2 GiB WebUI snapshot limit"
                 )
             self._copy_database_descriptor(
                 source_descriptor,
@@ -1212,6 +1218,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         parent_descriptor: int,
         source_name: str,
         destination_descriptor: int,
+        max_wal_bytes: int,
     ) -> Dict[str, Optional[os.stat_result]]:
         self._stage_cached_database_main(
             cached_main_path,
@@ -1227,6 +1234,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     sidecar_name,
                     destination_descriptor,
                     "database.sqlite" + suffix,
+                    max_bytes=max_wal_bytes,
                 )
             else:
                 sidecar_stat = self._stat_optional_database_sidecar(
@@ -1353,6 +1361,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                             parent_descriptor=parent_descriptor,
                             source_name=source_name,
                             destination_descriptor=staging_descriptor,
+                            max_wal_bytes=(
+                                self._database_main_cache_max_bytes
+                                - attempt_database_stat.st_size
+                            ),
                         )
                         self._verify_database_view(
                             database_descriptor=database_descriptor,

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -441,8 +441,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             filename = os.path.basename(client_path)
             if filename.lower() in ("prompts.db", "prompts.sqlite"):
                 continue
-            if not filename.lower().endswith((".db", ".sqlite")):
-                continue
 
             path_parts = client_path.split(os.sep)
             display_name = (
@@ -524,18 +522,37 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         root = self._canonical_root()
         relative_path = os.path.relpath(resolved_path, root)
+        root_descriptor = self._duplicate_search_root_descriptor(root)
+        try:
+            return self._open_relative_descriptor(
+                root_descriptor,
+                relative_path,
+                flags,
+                original_path=os.fspath(path),
+            )
+        finally:
+            os.close(root_descriptor)
+
+    def _open_relative_descriptor(
+        self,
+        root_descriptor: int,
+        relative_path: str,
+        flags: int,
+        *,
+        original_path: str,
+    ) -> int:
         relative_parts = Path(relative_path).parts
         if os.path.isabs(relative_path) or any(
             part in (os.curdir, os.pardir) for part in relative_parts
         ):
-            raise PathValidationError(f"Path escapes search root: {path!r}")
-        descriptor = self._duplicate_search_root_descriptor(root)
-        directory_flags = self._directory_open_flags()
+            raise PathValidationError(f"Path escapes search root: {original_path!r}")
+
+        descriptor = os.dup(root_descriptor)
         try:
             for part in relative_parts[:-1]:
                 next_descriptor = os.open(
                     part,
-                    directory_flags,
+                    self._directory_open_flags(),
                     dir_fd=descriptor,
                 )
                 os.close(descriptor)
@@ -550,7 +567,9 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             )
         except OSError as exc:
             if exc.errno in (errno.ELOOP, errno.ENOTDIR):
-                raise PathValidationError(f"Path changed during access: {path!r}") from exc
+                raise PathValidationError(
+                    f"Path changed during access: {original_path!r}"
+                ) from exc
             raise
         finally:
             os.close(descriptor)
@@ -625,16 +644,54 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 os.path.relpath(os.path.join(root, filename), self.search_root)
                 for root, _, files in os.walk(self.search_root)
                 for filename in files
+                if self._is_database_filename(filename)
             ]
 
-        descriptor = self._duplicate_search_root_descriptor(self._canonical_root())
+        root_descriptor = self._duplicate_search_root_descriptor(
+            self._canonical_root()
+        )
         try:
-            return self._walk_regular_files(descriptor)
+            return self._walk_regular_files(root_descriptor)
         finally:
-            os.close(descriptor)
+            os.close(root_descriptor)
 
-    def _walk_regular_files(self, descriptor: int, prefix: str = "") -> list[str]:
+    def _walk_regular_files(self, root_descriptor: int) -> list[str]:
         paths = []
+        pending_directories = [""]
+        while pending_directories:
+            relative_directory = pending_directories.pop()
+            try:
+                descriptor = self._open_relative_descriptor(
+                    root_descriptor,
+                    relative_directory,
+                    os.O_RDONLY | os.O_DIRECTORY,
+                    original_path=relative_directory,
+                )
+            except OSError as exc:
+                if self._is_skippable_walk_error(exc):
+                    continue
+                raise
+            try:
+                child_directories = self._scan_database_directory(
+                    descriptor,
+                    relative_directory,
+                    paths,
+                )
+                pending_directories.extend(reversed(child_directories))
+            except OSError as exc:
+                if not self._is_skippable_walk_error(exc):
+                    raise
+            finally:
+                os.close(descriptor)
+        return paths
+
+    def _scan_database_directory(
+        self,
+        descriptor: int,
+        prefix: str,
+        paths: list[str],
+    ) -> list[str]:
+        child_directories = []
         for name in os.listdir(descriptor):
             try:
                 entry = os.stat(
@@ -646,12 +703,14 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 if self._is_skippable_walk_error(exc):
                     continue
                 raise
-
             relative_path = os.path.join(prefix, name) if prefix else name
             if stat.S_ISREG(entry.st_mode):
-                paths.append(relative_path)
+                if self._is_database_filename(name):
+                    paths.append(relative_path)
                 continue
             if stat.S_ISLNK(entry.st_mode):
+                if not self._is_database_filename(name):
+                    continue
                 try:
                     file_descriptor = self._open_descriptor_within_root(
                         relative_path, os.O_RDONLY
@@ -670,28 +729,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 continue
             if not stat.S_ISDIR(entry.st_mode):
                 continue
+            child_directories.append(relative_path)
+        return child_directories
 
-            try:
-                child_descriptor = os.open(
-                    name,
-                    self._directory_open_flags(),
-                    dir_fd=descriptor,
-                )
-            except OSError as exc:
-                if self._is_skippable_walk_error(exc):
-                    continue
-                raise
-            try:
-                try:
-                    paths.extend(
-                        self._walk_regular_files(child_descriptor, relative_path)
-                    )
-                except OSError as exc:
-                    if not self._is_skippable_walk_error(exc):
-                        raise
-            finally:
-                os.close(child_descriptor)
-        return paths
+    @staticmethod
+    def _is_database_filename(filename: str) -> bool:
+        return filename.lower().endswith((".db", ".sqlite"))
 
     @staticmethod
     def _is_skippable_walk_error(exc: OSError) -> bool:

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -39,7 +39,11 @@ WEASYPRINT_AVAILABLE = False
 
 DEFAULT_PORT = 8000
 CACHE_EXPIRATION_SECONDS = 5  # Cache data for 5 seconds
-db_cache: Dict[str, Tuple[float, Any]] = {}
+db_cache: Dict[
+    Tuple[str, str],
+    Tuple[Tuple[int, int, int, int, int], float, Any],
+] = {}
+db_cache_lock = threading.Lock()
 
 
 class PathValidationError(ValueError):
@@ -651,6 +655,39 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         descriptor = self._open_descriptor_within_root(path, os.O_RDONLY)
         with os.fdopen(descriptor, "rb") as file:
             return file.read()
+
+    def _database_file_identity_within_root(
+        self,
+        path: os.PathLike[str] | str,
+    ) -> Tuple[int, int, int, int, int]:
+        descriptor = self._open_descriptor_within_root(path, os.O_RDONLY)
+        try:
+            file_stat = os.fstat(descriptor)
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise PathValidationError(f"Database is not a file: {path!r}")
+            return (
+                file_stat.st_dev,
+                file_stat.st_ino,
+                file_stat.st_size,
+                file_stat.st_mtime_ns,
+                file_stat.st_ctime_ns,
+            )
+        finally:
+            os.close(descriptor)
+
+    def _program_response_cache_key(self, resolved_path: str) -> Tuple[str, str]:
+        return (
+            os.path.normcase(self._canonical_root()),
+            os.path.normcase(resolved_path),
+        )
+
+    @staticmethod
+    def clear_program_response_cache(search_root: str) -> None:
+        canonical_root = os.path.normcase(os.path.realpath(search_root))
+        with db_cache_lock:
+            stale_keys = [key for key in db_cache if key[0] == canonical_root]
+            for key in stale_keys:
+                db_cache.pop(key, None)
 
     @classmethod
     def _copy_database_descriptor(
@@ -1505,21 +1542,26 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         # Extract the actual path by removing the task name prefix if present
         actual_db_path = self._get_actual_db_path(db_path)
 
-        # Check cache first
-        if db_path in db_cache:
-            last_fetch_time, cached_data = db_cache[db_path]
-            if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
-                print(f"[SERVER] Serving from cache for DB: {db_path}")
-                self.send_json_response(cached_data)
-                return
-
         # Construct absolute path to the database from search root using actual path
         abs_db_path = os.path.join(self.search_root, actual_db_path)
         print(f"[SERVER] Absolute DB path: {abs_db_path} (from {db_path})")
-
-        if not os.path.exists(abs_db_path):
+        try:
+            database_identity = self._database_file_identity_within_root(abs_db_path)
+        except FileNotFoundError:
             self.send_error(404, f"Database file not found: {actual_db_path}")
             return
+        cache_key = self._program_response_cache_key(actual_db_path)
+
+        # Check cache first
+        with db_cache_lock:
+            cached_entry = db_cache.get(cache_key)
+        if cached_entry is not None:
+            cached_identity, last_fetch_time, cached_data = cached_entry
+            if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
+                if cached_identity == database_identity:
+                    print(f"[SERVER] Serving from cache for DB: {db_path}")
+                    self.send_json_response(cached_data)
+                    return
 
         # Retry logic for the reader with improved WAL mode support
         # More retries with longer delays during active evolution
@@ -1544,7 +1586,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 )
 
                 # Update cache
-                db_cache[db_path] = (time.time(), programs_dict)
+                with db_cache_lock:
+                    db_cache[cache_key] = (
+                        database_identity,
+                        time.time(),
+                        programs_dict,
+                    )
 
                 self.send_json_response(programs_dict)
                 success_msg = (
@@ -2988,6 +3035,7 @@ def start_server(
         try:
             httpd.serve_forever()
         finally:
+            DatabaseRequestHandler.clear_program_response_cache(search_root)
             DatabaseRequestHandler.clear_database_snapshot_cache()
 
 

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -652,6 +652,43 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         with os.fdopen(descriptor, "rb") as file:
             return file.read()
 
+    def _same_file_within_root(
+        self,
+        first_path: os.PathLike[str] | str,
+        second_path: os.PathLike[str] | str,
+    ) -> bool:
+        if not self._supports_descriptor_traversal():
+            try:
+                return os.path.samefile(
+                    self._resolve_within_root(os.fspath(first_path)),
+                    self._resolve_within_root(os.fspath(second_path)),
+                )
+            except FileNotFoundError:
+                return False
+
+        first_descriptor = self._open_descriptor_within_root(
+            first_path,
+            os.O_RDONLY,
+        )
+        try:
+            second_descriptor = self._open_descriptor_within_root(
+                second_path,
+                os.O_RDONLY,
+            )
+            try:
+                first_stat = os.fstat(first_descriptor)
+                second_stat = os.fstat(second_descriptor)
+                return (
+                    first_stat.st_dev == second_stat.st_dev
+                    and first_stat.st_ino == second_stat.st_ino
+                )
+            finally:
+                os.close(second_descriptor)
+        except FileNotFoundError:
+            return False
+        finally:
+            os.close(first_descriptor)
+
     @classmethod
     def _copy_database_descriptor(
         cls,
@@ -1271,7 +1308,11 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                             self._release_database_main_snapshot,
                             cached_main,
                         )
-                        snapshot_stack.enter_context(cached_main.lock)
+                        if not cached_main.lock.acquire(timeout=timeout):
+                            raise DatabaseViewRaceError(
+                                "database snapshot is busy"
+                            )
+                        snapshot_stack.callback(cached_main.lock.release)
                         staging_descriptor, staging_path = snapshot_stack.enter_context(
                             self._database_staging_directory(resolved_path)
                         )
@@ -2297,13 +2338,19 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 # Check for prompts.db in the same directory
                 if os.path.exists(prompts_db_path):
                     try:
-                        pconn = stack.enter_context(
-                            self._connect_database_within_root(
-                                prompts_db_path,
-                                timeout=2.0,
-                                isolation_level=None,
+                        if self._same_file_within_root(
+                            abs_db_path,
+                            prompts_db_path,
+                        ):
+                            pconn = conn
+                        else:
+                            pconn = stack.enter_context(
+                                self._connect_database_within_root(
+                                    prompts_db_path,
+                                    timeout=2.0,
+                                    isolation_level=None,
+                                )
                             )
-                        )
                         pconn.row_factory = sqlite3.Row
                         pcursor = pconn.cursor()
                         pcursor.execute("PRAGMA busy_timeout = 2000;")

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -74,8 +74,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
     _database_main_cache: Dict[Tuple[int, int], _DatabaseMainSnapshot] = {}
     _database_main_cache_build_locks: Dict[Tuple[int, int], threading.Lock] = {}
     _database_main_cache_limit = 2
-    # Soft target: retain one oversized active DB to avoid recopying it every poll.
-    _database_main_cache_target_bytes = 2 * 1024**3
+    _database_main_cache_max_bytes = 2 * 1024**3
 
     def __init__(
         self,
@@ -906,6 +905,10 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         database_descriptor: int,
         database_stat: os.stat_result,
     ) -> _DatabaseMainSnapshot:
+        if database_stat.st_size > self._database_main_cache_max_bytes:
+            raise sqlite3.OperationalError(
+                "database exceeds the 2 GiB WebUI snapshot limit"
+            )
         source_key = (database_stat.st_dev, database_stat.st_ino)
         cache_key = self._database_cache_key(database_stat)
         with self._database_main_cache_lock:
@@ -997,7 +1000,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         )
         while cls._database_main_cache and (
             len(cls._database_main_cache) >= cls._database_main_cache_limit
-            or cached_bytes + incoming_size > cls._database_main_cache_target_bytes
+            or cached_bytes + incoming_size > cls._database_main_cache_max_bytes
         ):
             oldest_key = next(iter(cls._database_main_cache))
             evicted = cls._database_main_cache.pop(oldest_key)

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -1212,6 +1212,27 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
     @staticmethod
     def _sqlite_read_only_uri(path: os.PathLike[str] | str) -> str:
         path_string = os.fspath(path)
+        extended_prefix = "\\\\?\\"
+        if path_string.startswith("\\\\.\\"):
+            raise PathValidationError("Windows device paths are not supported")
+        if path_string.startswith(extended_prefix):
+            extended_path = path_string[len(extended_prefix) :]
+            if extended_path.casefold().startswith("unc\\"):
+                path_string = "\\\\" + extended_path[4:]
+            elif re.match(r"^[A-Za-z]:[\\/]", extended_path):
+                path_string = extended_path
+            else:
+                raise PathValidationError("Windows device paths are not supported")
+
+        if path_string.startswith("\\\\"):
+            # Keep the URI authority empty. SQLite rejects remote authorities
+            # unless built with SQLITE_ALLOW_URI_AUTHORITY, while the Windows
+            # VFS accepts an absolute //server/share path as UNC.
+            quoted_path = urllib.parse.quote(
+                path_string.replace("\\", "/"),
+                safe="/:",
+            )
+            return "file://" + quoted_path + "?mode=ro"
         if re.match(r"^[A-Za-z]:[\\/]", path_string):
             uri = PureWindowsPath(path_string).as_uri()
         else:
@@ -1223,10 +1244,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         cls,
         path: os.PathLike[str] | str,
     ) -> Tuple[str, bool]:
-        path_string = os.fspath(path)
-        if path_string.startswith("\\\\"):
-            return path_string, False
-        return cls._sqlite_read_only_uri(path_string), True
+        return cls._sqlite_read_only_uri(path), True
 
     def _stage_database_view(
         self,

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -8,6 +8,7 @@ It serves a web interface for exploring evolution databases and meta files.
 
 import argparse
 import base64
+import errno
 import http.server
 import json
 import markdown
@@ -15,6 +16,7 @@ import os
 import re
 import socketserver
 import sqlite3
+import stat
 import subprocess
 import sys
 import tempfile
@@ -22,6 +24,7 @@ import threading
 import time
 import urllib.parse
 import webbrowser
+import weakref
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple
 
@@ -41,8 +44,20 @@ class PathValidationError(ValueError):
 
 
 class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, search_root=None, allowed_hosts=..., **kwargs):
+    def __init__(
+        self,
+        *args,
+        search_root=None,
+        canonical_search_root=None,
+        search_root_descriptor=None,
+        allowed_hosts=...,
+        **kwargs,
+    ):
         self.search_root = search_root or os.getcwd()
+        self._canonical_search_root = canonical_search_root or os.path.realpath(
+            self.search_root
+        )
+        self._search_root_descriptor = search_root_descriptor
         # Attributes must be set before super().__init__, which handles the
         # request immediately. `...` means "keep the class default allowlist".
         if allowed_hosts is not ...:
@@ -85,7 +100,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             failure_path = Path(self._resolve_within_root(failure_json_path))
             if not failure_path.exists():
                 return None
-            return json.loads(failure_path.read_text(encoding="utf-8"))
+            return json.loads(self._read_text_within_root(failure_path))
         except PathValidationError:
             raise
         except Exception:
@@ -128,9 +143,9 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         failure_json_path = details.get("failure_json_path")
         if failure_json_path:
             failure_path = Path(self._resolve_within_root(failure_json_path))
-            candidates = sorted(failure_path.parent.glob("main.*"))
+            candidates = self._main_candidate_names(failure_path.parent)
             if candidates:
-                return self._language_from_suffix(candidates[0].suffix)
+                return self._language_from_suffix(Path(candidates[0]).suffix)
 
         return "python"
 
@@ -169,7 +184,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             if resolved_path is not None:
                 return resolved_path
 
-        for candidate in sorted(failure_path.parent.glob("main.*")):
+        for candidate_name in self._main_candidate_names(failure_path.parent):
+            candidate = failure_path.parent / candidate_name
             resolved_path = self._existing_path_within_root(candidate)
             if resolved_path is not None:
                 return resolved_path
@@ -180,6 +196,13 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
     ) -> Optional[Path]:
         resolved_path = Path(self._resolve_within_root(os.fspath(path)))
         return resolved_path if resolved_path.exists() else None
+
+    def _main_candidate_names(self, directory: Path) -> list[str]:
+        try:
+            names = self._list_directory_within_root(directory)
+        except FileNotFoundError:
+            return []
+        return sorted(name for name in names if name.startswith("main."))
 
     def _build_failed_node_dict(
         self,
@@ -215,7 +238,9 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             code_path = self._resolve_failed_node_code_path(details, failure_payload)
             if code_path is not None:
                 try:
-                    code = code_path.read_text(encoding="utf-8")
+                    code = self._read_text_within_root(code_path)
+                except PathValidationError:
+                    raise
                 except Exception:
                     code = None
 
@@ -410,53 +435,37 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         # Get the task name from the search root directory name
         task_name = os.path.basename(self.search_root)
 
-        if os.path.exists(self.search_root):
-            print(f"[SERVER] Scanning for .db files in: {self.search_root}")
-            for root, _, files in os.walk(self.search_root):
-                for f in files:
-                    # Only list program databases, not prompt databases
-                    if f.lower() in ("prompts.db", "prompts.sqlite"):
-                        continue
-                    if f.lower().endswith((".db", ".sqlite")):
-                        full_path = os.path.join(root, f)
-                        client_path = os.path.relpath(full_path, self.search_root)
+        print(f"[SERVER] Scanning for .db files in: {self.search_root}")
+        for client_path in self._walk_files_within_root():
+            filename = os.path.basename(client_path)
+            if filename.lower() in ("prompts.db", "prompts.sqlite"):
+                continue
+            if not filename.lower().endswith((".db", ".sqlite")):
+                continue
 
-                        # Parse path components
-                        path_parts = client_path.split(os.sep)
+            path_parts = client_path.split(os.sep)
+            display_name = (
+                "/".join(path_parts[:-1])
+                if len(path_parts) >= 2
+                else client_path
+            )
+            task = path_parts[0] if len(path_parts) >= 2 else task_name
 
-                        # Extract result name (full path to db directory)
-                        # e.g., results_coral/aes_block_encrypt/triton
-                        display_name = (
-                            "/".join(path_parts[:-1])
-                            if len(path_parts) >= 2
-                            else client_path
-                        )
-
-                        # Extract task name (first path component only)
-                        # e.g., results_coral
-                        if len(path_parts) >= 2:
-                            task = path_parts[0]
-                        else:
-                            task = task_name
-
-                        # Extract date for sorting
-                        sort_key = "0"  # Default for paths without a date
-                        match = date_pattern.search(client_path)
-                        if match:
-                            sort_key = match.group(1)
-
-                        db_info = {
-                            "path": client_path,
-                            "name": display_name,
-                            "task": task,
-                            "sort_key": sort_key,
-                            "actual_path": client_path,
-                        }
-                        db_files.append(db_info)
-                        print(
-                            f"[SERVER] Found DB: {client_path} "
-                            f"(task: '{task}', result: '{display_name}')"
-                        )
+            match = date_pattern.search(client_path)
+            sort_key = match.group(1) if match else "0"
+            db_files.append(
+                {
+                    "path": client_path,
+                    "name": display_name,
+                    "task": task,
+                    "sort_key": sort_key,
+                    "actual_path": client_path,
+                }
+            )
+            print(
+                f"[SERVER] Found DB: {client_path} "
+                f"(task: '{task}', result: '{display_name}')"
+            )
 
         if not db_files:
             print("[SERVER] No database files found in search directory.")
@@ -484,7 +493,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         resolved (realpath) before checking so an in-root symlink pointing
         outside cannot be used to escape.
         """
-        root = os.path.realpath(self.search_root)
+        root = self._canonical_root()
         candidate = os.path.realpath(os.path.join(root, relative_path))
         try:
             contained = os.path.commonpath([root, candidate]) == root
@@ -494,6 +503,205 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         if not contained:
             raise PathValidationError(f"Path escapes search root: {relative_path!r}")
         return candidate
+
+    @staticmethod
+    def _supports_descriptor_traversal() -> bool:
+        return (
+            os.open in os.supports_dir_fd
+            and os.listdir in os.supports_fd
+            and os.stat in os.supports_dir_fd
+            and hasattr(os, "O_DIRECTORY")
+            and hasattr(os, "O_NOFOLLOW")
+        )
+
+    def _open_descriptor_within_root(
+        self, path: os.PathLike[str] | str, flags: int
+    ) -> int:
+        resolved_path = self._resolve_within_root(os.fspath(path))
+        if not self._supports_descriptor_traversal():
+            return os.open(resolved_path, flags)
+
+        root = self._canonical_root()
+        relative_path = os.path.relpath(resolved_path, root)
+        relative_parts = Path(relative_path).parts
+        if os.path.isabs(relative_path) or any(
+            part in (os.curdir, os.pardir) for part in relative_parts
+        ):
+            raise PathValidationError(f"Path escapes search root: {path!r}")
+        descriptor = self._duplicate_search_root_descriptor(root)
+        directory_flags = self._directory_open_flags()
+        try:
+            for part in relative_parts[:-1]:
+                next_descriptor = os.open(
+                    part,
+                    directory_flags,
+                    dir_fd=descriptor,
+                )
+                os.close(descriptor)
+                descriptor = next_descriptor
+
+            if not relative_parts:
+                return os.dup(descriptor)
+            return os.open(
+                relative_parts[-1],
+                flags | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+                dir_fd=descriptor,
+            )
+        except OSError as exc:
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                raise PathValidationError(f"Path changed during access: {path!r}") from exc
+            raise
+        finally:
+            os.close(descriptor)
+
+    def _duplicate_search_root_descriptor(self, root: str) -> int:
+        pinned_descriptor = getattr(self, "_search_root_descriptor", None)
+        if pinned_descriptor is not None:
+            return os.dup(pinned_descriptor)
+        return self._open_search_root_descriptor(root)
+
+    def _canonical_root(self) -> str:
+        root = getattr(self, "_canonical_search_root", None)
+        if root is None:
+            root = os.path.realpath(self.search_root)
+            self._canonical_search_root = root
+        return root
+
+    @staticmethod
+    def _directory_open_flags() -> int:
+        return (
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        )
+
+    @classmethod
+    def _open_search_root_descriptor(cls, search_root: os.PathLike[str] | str) -> int:
+        if not cls._supports_descriptor_traversal():
+            raise PathValidationError(
+                "Race-safe path access is unavailable on this platform"
+            )
+
+        descriptor = os.open(os.path.sep, cls._directory_open_flags())
+        try:
+            for part in Path(os.path.realpath(search_root)).parts[1:]:
+                next_descriptor = os.open(
+                    part,
+                    cls._directory_open_flags(),
+                    dir_fd=descriptor,
+                )
+                os.close(descriptor)
+                descriptor = next_descriptor
+            return descriptor
+        except Exception:
+            os.close(descriptor)
+            raise
+
+    def _read_text_within_root(
+        self, path: os.PathLike[str] | str, encoding: str = "utf-8"
+    ) -> str:
+        descriptor = self._open_descriptor_within_root(path, os.O_RDONLY)
+        with os.fdopen(descriptor, "r", encoding=encoding) as file:
+            return file.read()
+
+    def _read_bytes_within_root(self, path: os.PathLike[str] | str) -> bytes:
+        descriptor = self._open_descriptor_within_root(path, os.O_RDONLY)
+        with os.fdopen(descriptor, "rb") as file:
+            return file.read()
+
+    def _list_directory_within_root(
+        self, path: os.PathLike[str] | str
+    ) -> list[str]:
+        if not self._supports_descriptor_traversal():
+            return os.listdir(self._resolve_within_root(os.fspath(path)))
+        descriptor = self._open_descriptor_within_root(path, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            return os.listdir(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _walk_files_within_root(self) -> list[str]:
+        if not self._supports_descriptor_traversal():
+            return [
+                os.path.relpath(os.path.join(root, filename), self.search_root)
+                for root, _, files in os.walk(self.search_root)
+                for filename in files
+            ]
+
+        descriptor = self._duplicate_search_root_descriptor(self._canonical_root())
+        try:
+            return self._walk_regular_files(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def _walk_regular_files(self, descriptor: int, prefix: str = "") -> list[str]:
+        paths = []
+        for name in os.listdir(descriptor):
+            try:
+                entry = os.stat(
+                    name,
+                    dir_fd=descriptor,
+                    follow_symlinks=False,
+                )
+            except OSError as exc:
+                if self._is_skippable_walk_error(exc):
+                    continue
+                raise
+
+            relative_path = os.path.join(prefix, name) if prefix else name
+            if stat.S_ISREG(entry.st_mode):
+                paths.append(relative_path)
+                continue
+            if stat.S_ISLNK(entry.st_mode):
+                try:
+                    file_descriptor = self._open_descriptor_within_root(
+                        relative_path, os.O_RDONLY
+                    )
+                except PathValidationError:
+                    continue
+                except OSError as exc:
+                    if self._is_skippable_walk_error(exc):
+                        continue
+                    raise
+                try:
+                    if stat.S_ISREG(os.fstat(file_descriptor).st_mode):
+                        paths.append(relative_path)
+                finally:
+                    os.close(file_descriptor)
+                continue
+            if not stat.S_ISDIR(entry.st_mode):
+                continue
+
+            try:
+                child_descriptor = os.open(
+                    name,
+                    self._directory_open_flags(),
+                    dir_fd=descriptor,
+                )
+            except OSError as exc:
+                if self._is_skippable_walk_error(exc):
+                    continue
+                raise
+            try:
+                try:
+                    paths.extend(
+                        self._walk_regular_files(child_descriptor, relative_path)
+                    )
+                except OSError as exc:
+                    if not self._is_skippable_walk_error(exc):
+                        raise
+            finally:
+                os.close(child_descriptor)
+        return paths
+
+    @staticmethod
+    def _is_skippable_walk_error(exc: OSError) -> bool:
+        return exc.errno in {
+            errno.ENOENT,
+            errno.EACCES,
+            errno.EPERM,
+            errno.ELOOP,
+            errno.ENOTDIR,
+            getattr(errno, "ESTALE", -1),
+        }
 
     def _get_actual_db_path(self, db_path: str) -> str:
         """Validate db_path stays within search_root; return its absolute path.
@@ -882,7 +1090,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         meta_files = []
         try:
             # Look for meta files named by processed-count suffix
-            for file in os.listdir(meta_dir):
+            for file in self._list_directory_within_root(meta_dir):
                 if file.startswith("meta_") and file.endswith(".txt"):
                     # Extract processed count from meta_<count>.txt
                     count_str = file[5:-4]  # Remove 'meta_' and '.txt'
@@ -907,6 +1115,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             print(f"[SERVER] Found {len(meta_files)} meta files")
             self.send_json_response(meta_files)
 
+        except PathValidationError:
+            raise
         except Exception as e:
             print(f"[SERVER] Error listing meta files: {e}")
             self.send_error(500, f"Error listing meta files: {str(e)}")
@@ -942,8 +1152,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             return
 
         try:
-            with open(meta_file_path, "r", encoding="utf-8") as f:
-                content = f.read()
+            content = self._read_text_within_root(meta_file_path)
 
             response_data = {
                 "processed_count": int(processed_count),
@@ -959,6 +1168,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             )
             self.send_json_response(response_data)
 
+        except PathValidationError:
+            raise
         except Exception as e:
             print(f"[SERVER] Error reading meta file: {e}")
             self.send_error(500, f"Error reading meta file: {str(e)}")
@@ -994,8 +1205,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             return
 
         try:
-            with open(meta_file_path, "r", encoding="utf-8") as f:
-                content = f.read()
+            content = self._read_text_within_root(meta_file_path)
 
             pdf_filename = f"meta_{processed_count}.pdf"
 
@@ -1020,6 +1230,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.wfile.write(pdf_bytes)
             print(f"[SERVER] Successfully served PDF: {pdf_filename}")
 
+        except PathValidationError:
+            raise
         except Exception as e:
             print(f"[SERVER] Error converting meta file to PDF: {e}")
             self.send_error(500, f"Error converting to PDF: {str(e)}")
@@ -1046,7 +1258,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         plot_files = []
         if os.path.exists(plots_dir):
-            for filename in os.listdir(plots_dir):
+            for filename in self._list_directory_within_root(plots_dir):
                 filepath = os.path.join(plots_dir, filename)
                 if os.path.isfile(filepath):
                     ext = os.path.splitext(filename)[1].lower()
@@ -1105,8 +1317,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             return
 
         try:
-            with open(abs_path, "rb") as f:
-                file_data = f.read()
+            file_data = self._read_bytes_within_root(abs_path)
 
             self.send_response(200)
             self.send_header("Content-Type", content_type)
@@ -1116,6 +1327,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.wfile.write(file_data)
             print(f"[SERVER] Successfully served plot: {rel_path}")
 
+        except PathValidationError:
+            raise
         except Exception as e:
             print(f"[SERVER] Error serving plot file: {e}")
             self.send_error(500, f"Error serving file: {str(e)}")
@@ -1812,14 +2025,25 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 def create_handler_factory(search_root, allowed_hosts=...):
     """Create a handler factory that passes the search root to handler."""
 
+    canonical_search_root = os.path.realpath(search_root)
+    search_root_descriptor = None
+    if DatabaseRequestHandler._supports_descriptor_traversal():
+        search_root_descriptor = DatabaseRequestHandler._open_search_root_descriptor(
+            canonical_search_root
+        )
+
     def handler_factory(*args, **kwargs):
         return DatabaseRequestHandler(
             *args,
             search_root=search_root,
+            canonical_search_root=canonical_search_root,
+            search_root_descriptor=search_root_descriptor,
             allowed_hosts=allowed_hosts,
             **kwargs,
         )
 
+    if search_root_descriptor is not None:
+        weakref.finalize(handler_factory, os.close, search_root_descriptor)
     return handler_factory
 
 
@@ -1864,6 +2088,11 @@ def start_server(
             msg += (
                 "\n[!] Bound to a non-loopback address: the evolution database "
                 "is reachable from the network with no authentication."
+            )
+        if not DatabaseRequestHandler._supports_descriptor_traversal():
+            msg += (
+                "\n[!] This platform lacks descriptor-relative file access; "
+                "search-root race hardening is unavailable."
             )
         print(msg)
         httpd.serve_forever()

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -2109,9 +2109,13 @@ def _allowed_hosts_for_bind(
     allowed_hosts = set(DatabaseRequestHandler.allowed_hosts)
     for host in (requested_host, bound_host):
         normalized_host = host.casefold()
-        allowed_hosts.add(normalized_host)
-        if ":" in normalized_host:
-            allowed_hosts.add(f"[{normalized_host}]")
+        for allowed_host in {
+            normalized_host,
+            normalized_host.replace("%", "%25"),
+        }:
+            allowed_hosts.add(allowed_host)
+            if ":" in allowed_host:
+                allowed_hosts.add(f"[{allowed_host}]")
     return frozenset(allowed_hosts)
 
 
@@ -2184,6 +2188,21 @@ def _bind_server(
     raise OSError(f"No usable address found for host {host!r}")
 
 
+def _bound_host_from_server_address(server_address: tuple[Any, ...]) -> str:
+    bound_host = str(server_address[0])
+    if "%" in bound_host or len(server_address) < 4:
+        return bound_host
+
+    scope_id = int(server_address[3])
+    if not scope_id:
+        return bound_host
+    try:
+        scope = socket.if_indextoname(scope_id)
+    except (AttributeError, OSError):
+        scope = str(scope_id)
+    return f"{bound_host}%{scope}"
+
+
 def _browser_url(
     bound_host: str,
     port: int,
@@ -2235,7 +2254,7 @@ def start_server(
     # On an explicit external bind the operator has opted in, so disable it.
     httpd = _bind_server(host, port, DatabaseRequestHandler)
     with httpd:
-        bound_host = str(httpd.server_address[0])
+        bound_host = _bound_host_from_server_address(httpd.server_address)
         allowed_hosts = _allowed_hosts_for_bind(host, bound_host)
         httpd.RequestHandlerClass = create_handler_factory(
             search_root, allowed_hosts=allowed_hosts
@@ -2318,7 +2337,7 @@ def main():
     print(f"[INFO] Searching for databases in: {search_root}")
 
     def announce_ready(httpd: socketserver.TCPServer) -> None:
-        bound_host = str(httpd.server_address[0])
+        bound_host = _bound_host_from_server_address(httpd.server_address)
         bound_port = int(httpd.server_address[1])
         viz_url = _browser_url(bound_host, bound_port, args.db)
 

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -652,43 +652,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         with os.fdopen(descriptor, "rb") as file:
             return file.read()
 
-    def _same_file_within_root(
-        self,
-        first_path: os.PathLike[str] | str,
-        second_path: os.PathLike[str] | str,
-    ) -> bool:
-        if not self._supports_descriptor_traversal():
-            try:
-                return os.path.samefile(
-                    self._resolve_within_root(os.fspath(first_path)),
-                    self._resolve_within_root(os.fspath(second_path)),
-                )
-            except FileNotFoundError:
-                return False
-
-        first_descriptor = self._open_descriptor_within_root(
-            first_path,
-            os.O_RDONLY,
-        )
-        try:
-            second_descriptor = self._open_descriptor_within_root(
-                second_path,
-                os.O_RDONLY,
-            )
-            try:
-                first_stat = os.fstat(first_descriptor)
-                second_stat = os.fstat(second_descriptor)
-                return (
-                    first_stat.st_dev == second_stat.st_dev
-                    and first_stat.st_ino == second_stat.st_ino
-                )
-            finally:
-                os.close(second_descriptor)
-        except FileNotFoundError:
-            return False
-        finally:
-            os.close(first_descriptor)
-
     @classmethod
     def _copy_database_descriptor(
         cls,
@@ -2335,22 +2298,23 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     "has_prompt_evo": False,
                 }
 
+                # Prompt WAL sidecars are pathname-specific. Release the main
+                # snapshot before opening the sibling prompt database, even when
+                # both names are hardlinks to the same main inode.
+                stack.close()
+                stack = contextlib.ExitStack()
+                conn = None
+
                 # Check for prompts.db in the same directory
                 if os.path.exists(prompts_db_path):
                     try:
-                        if self._same_file_within_root(
-                            abs_db_path,
-                            prompts_db_path,
-                        ):
-                            pconn = conn
-                        else:
-                            pconn = stack.enter_context(
-                                self._connect_database_within_root(
-                                    prompts_db_path,
-                                    timeout=2.0,
-                                    isolation_level=None,
-                                )
+                        pconn = stack.enter_context(
+                            self._connect_database_within_root(
+                                prompts_db_path,
+                                timeout=2.0,
+                                isolation_level=None,
                             )
+                        )
                         pconn.row_factory = sqlite3.Row
                         pcursor = pconn.cursor()
                         pcursor.execute("PRAGMA busy_timeout = 2000;")

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -38,12 +38,23 @@ from shinka.database import SystemPromptConfig, SystemPromptDatabase
 WEASYPRINT_AVAILABLE = False
 
 DEFAULT_PORT = 8000
+DEFAULT_MAX_DATABASE_SNAPSHOT_BYTES = 2 * 1024**3
 CACHE_EXPIRATION_SECONDS = 5  # Cache data for 5 seconds
 db_cache: Dict[
     Tuple[str, str],
     Tuple[Tuple[int, int, int, int, int], float, Any],
 ] = {}
 db_cache_lock = threading.Lock()
+
+
+def _validate_snapshot_size_bytes(value: object) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 < value <= sys.maxsize
+    ):
+        raise ValueError("snapshot size must be a positive, representable integer")
+    return value
 
 
 class PathValidationError(ValueError):
@@ -74,7 +85,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
     _database_main_cache: Dict[Tuple[int, int], _DatabaseMainSnapshot] = {}
     _database_main_cache_build_locks: Dict[Tuple[int, int], threading.Lock] = {}
     _database_main_cache_limit = 2
-    _database_main_cache_max_bytes = 2 * 1024**3
+    _database_main_cache_max_bytes = DEFAULT_MAX_DATABASE_SNAPSHOT_BYTES
 
     def __init__(
         self,
@@ -83,6 +94,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         canonical_search_root=None,
         search_root_descriptor=None,
         allowed_hosts=...,
+        max_database_snapshot_bytes=DEFAULT_MAX_DATABASE_SNAPSHOT_BYTES,
         **kwargs,
     ):
         self.search_root = search_root or os.getcwd()
@@ -90,6 +102,9 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             self.search_root
         )
         self._search_root_descriptor = search_root_descriptor
+        self._database_main_cache_max_bytes = _validate_snapshot_size_bytes(
+            max_database_snapshot_bytes
+        )
         # Attributes must be set before super().__init__, which handles the
         # request immediately. `...` means "keep the class default allowlist".
         if allowed_hosts is not ...:
@@ -769,7 +784,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 )
             if source_stat.st_size > max_bytes:
                 raise sqlite3.OperationalError(
-                    "database and WAL exceed the 2 GiB WebUI snapshot limit"
+                    "database and WAL exceed the configured WebUI snapshot limit "
+                    f"({self._database_main_cache_max_bytes} bytes)"
                 )
             self._copy_database_descriptor(
                 source_descriptor,
@@ -927,7 +943,8 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
     ) -> _DatabaseMainSnapshot:
         if database_stat.st_size > self._database_main_cache_max_bytes:
             raise sqlite3.OperationalError(
-                "database exceeds the 2 GiB WebUI snapshot limit"
+                "database exceeds the configured WebUI snapshot limit "
+                f"({self._database_main_cache_max_bytes} bytes)"
             )
         source_key = (database_stat.st_dev, database_stat.st_ino)
         cache_key = self._database_cache_key(database_stat)
@@ -1040,22 +1057,21 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             getattr(errno, "EDQUOT", -1),
         }
 
-    @classmethod
     def _evict_database_main_cache_entries(
-        cls,
+        self,
         *,
         incoming_size: int,
         discarded: list[_DatabaseMainSnapshot],
     ) -> None:
         cached_bytes = sum(
-            entry.version[0] for entry in cls._database_main_cache.values()
+            entry.version[0] for entry in self._database_main_cache.values()
         )
-        while cls._database_main_cache and (
-            len(cls._database_main_cache) >= cls._database_main_cache_limit
-            or cached_bytes + incoming_size > cls._database_main_cache_max_bytes
+        while self._database_main_cache and (
+            len(self._database_main_cache) >= self._database_main_cache_limit
+            or cached_bytes + incoming_size > self._database_main_cache_max_bytes
         ):
-            oldest_key = next(iter(cls._database_main_cache))
-            evicted = cls._database_main_cache.pop(oldest_key)
+            oldest_key = next(iter(self._database_main_cache))
+            evicted = self._database_main_cache.pop(oldest_key)
             evicted.evicted = True
             cached_bytes -= evicted.version[0]
             discarded.append(evicted)
@@ -2916,9 +2932,16 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
-def create_handler_factory(search_root, allowed_hosts=...):
+def create_handler_factory(
+    search_root,
+    allowed_hosts=...,
+    max_database_snapshot_bytes=DEFAULT_MAX_DATABASE_SNAPSHOT_BYTES,
+):
     """Create a handler factory that passes the search root to handler."""
 
+    max_database_snapshot_bytes = _validate_snapshot_size_bytes(
+        max_database_snapshot_bytes
+    )
     canonical_search_root = os.path.realpath(search_root)
     search_root_descriptor = None
     if DatabaseRequestHandler._supports_descriptor_traversal():
@@ -2933,6 +2956,7 @@ def create_handler_factory(search_root, allowed_hosts=...):
             canonical_search_root=canonical_search_root,
             search_root_descriptor=search_root_descriptor,
             allowed_hosts=allowed_hosts,
+            max_database_snapshot_bytes=max_database_snapshot_bytes,
             **kwargs,
         )
 
@@ -3076,12 +3100,28 @@ def _browser_url(
     return f"http://{browser_host}:{port}{path}"
 
 
+def _snapshot_size_bytes_from_gib(value: str) -> int:
+    try:
+        size_gib = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("snapshot size must be a number") from exc
+    if not 0 < size_gib <= sys.maxsize / 1024**3:
+        raise argparse.ArgumentTypeError(
+            "snapshot size must be positive and representable"
+        )
+    try:
+        return _validate_snapshot_size_bytes(int(size_gib * 1024**3))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def start_server(
     port: int,
     search_root: str,
     db_path: Optional[str] = None,
     host: str = "127.0.0.1",
     on_ready: Optional[Callable[[socketserver.TCPServer], None]] = None,
+    max_database_snapshot_bytes: int = DEFAULT_MAX_DATABASE_SNAPSHOT_BYTES,
 ):
     """Start the HTTP server.
 
@@ -3089,6 +3129,10 @@ def start_server(
     the local network. Pass an explicit ``host`` (e.g. "0.0.0.0") to expose it,
     which also relaxes the DNS-rebinding Host-header check.
     """
+    max_database_snapshot_bytes = _validate_snapshot_size_bytes(
+        max_database_snapshot_bytes
+    )
+
     # Change to the webui directory inside the shinka package to serve static files
     webui_dir = os.path.dirname(__file__)
     webui_dir = os.path.abspath(webui_dir)
@@ -3107,7 +3151,9 @@ def start_server(
         bound_host = _bound_host_from_server_address(httpd.server_address)
         allowed_hosts = _allowed_hosts_for_bind(host, bound_host)
         httpd.RequestHandlerClass = create_handler_factory(
-            search_root, allowed_hosts=allowed_hosts
+            search_root,
+            allowed_hosts=allowed_hosts,
+            max_database_snapshot_bytes=max_database_snapshot_bytes,
         )
         bound_port = int(httpd.server_address[1])
         display_url = _browser_url(bound_host, bound_port)
@@ -3179,6 +3225,16 @@ def main():
             "expose on the network — this serves the database with no auth."
         ),
     )
+    parser.add_argument(
+        "--max-database-snapshot-gib",
+        dest="max_database_snapshot_bytes",
+        type=_snapshot_size_bytes_from_gib,
+        default=DEFAULT_MAX_DATABASE_SNAPSHOT_BYTES,
+        help=(
+            "Maximum combined database and WAL snapshot size in GiB "
+            "(default: 2)."
+        ),
+    )
     args = parser.parse_args()
 
     # Resolve the root directory to an absolute path
@@ -3213,6 +3269,7 @@ def main():
             args.db,
             args.host,
             on_ready=announce_ready,
+            max_database_snapshot_bytes=args.max_database_snapshot_bytes,
         )
     except KeyboardInterrupt:
         print("\n[*] Shutting down.")

--- a/tests/test_webui_descriptor_security.py
+++ b/tests/test_webui_descriptor_security.py
@@ -1,0 +1,218 @@
+import os
+
+import pytest
+
+from shinka.webui.visualization import DatabaseRequestHandler, PathValidationError
+
+
+requires_descriptor_traversal = pytest.mark.skipif(
+    not (
+        os.open in os.supports_dir_fd
+        and os.listdir in os.supports_fd
+        and os.stat in os.supports_dir_fd
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+    ),
+    reason="race-safe descriptor traversal requires Unix openat support",
+)
+
+
+def _handler(root):
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.search_root = str(root)
+    handler._canonical_search_root = os.path.realpath(root)
+    return handler
+
+
+@requires_descriptor_traversal
+def test_text_read_rejects_file_symlink_swap_after_resolution(tmp_path, monkeypatch):
+    served = tmp_path / "served"
+    served.mkdir()
+    target = served / "artifact.txt"
+    target.write_text("safe", encoding="utf-8")
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    handler = _handler(served)
+    resolve_path = handler._resolve_within_root
+
+    def resolve_then_swap(path):
+        resolved = resolve_path(path)
+        target.unlink()
+        target.symlink_to(outside)
+        return resolved
+
+    monkeypatch.setattr(handler, "_resolve_within_root", resolve_then_swap)
+
+    with pytest.raises(PathValidationError):
+        handler._read_text_within_root("artifact.txt")
+
+
+@requires_descriptor_traversal
+def test_text_read_rejects_parent_symlink_swap_after_resolution(
+    tmp_path, monkeypatch
+):
+    served = tmp_path / "served"
+    artifact_dir = served / "run"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "artifact.txt").write_text("safe", encoding="utf-8")
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "artifact.txt").write_text("secret", encoding="utf-8")
+    handler = _handler(served)
+    resolve_path = handler._resolve_within_root
+
+    def resolve_then_swap(path):
+        resolved = resolve_path(path)
+        artifact_dir.rename(served / "parked")
+        artifact_dir.symlink_to(outside_dir)
+        return resolved
+
+    monkeypatch.setattr(handler, "_resolve_within_root", resolve_then_swap)
+
+    with pytest.raises(PathValidationError):
+        handler._read_text_within_root("run/artifact.txt")
+
+
+@requires_descriptor_traversal
+def test_text_read_accepts_symlink_resolving_within_search_root(tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("safe", encoding="utf-8")
+    (tmp_path / "link.txt").symlink_to(target)
+    handler = _handler(tmp_path)
+
+    assert handler._read_text_within_root("link.txt") == "safe"
+
+
+def test_text_read_preserves_fallback_without_descriptor_traversal(tmp_path, monkeypatch):
+    target = tmp_path / "artifact.txt"
+    target.write_text("safe", encoding="utf-8")
+    handler = _handler(tmp_path)
+    monkeypatch.setattr(handler, "_supports_descriptor_traversal", lambda: False)
+
+    assert handler._read_text_within_root("artifact.txt") == "safe"
+
+
+@requires_descriptor_traversal
+def test_text_read_uses_pinned_root_after_ancestor_swap(tmp_path):
+    parent = tmp_path / "parent"
+    served = parent / "served"
+    served.mkdir(parents=True)
+    (served / "artifact.txt").write_text("safe", encoding="utf-8")
+    outside_parent = tmp_path / "outside-parent"
+    outside_served = outside_parent / "served"
+    outside_served.mkdir(parents=True)
+    (outside_served / "artifact.txt").write_text("secret", encoding="utf-8")
+    handler = _handler(served)
+    handler._search_root_descriptor = handler._open_search_root_descriptor(served)
+
+    parent.rename(tmp_path / "parked-parent")
+    parent.symlink_to(outside_parent)
+
+    try:
+        with pytest.raises(PathValidationError):
+            handler._read_text_within_root("artifact.txt")
+    finally:
+        os.close(handler._search_root_descriptor)
+
+
+@requires_descriptor_traversal
+def test_text_read_rejects_parent_component_from_changed_resolution(
+    tmp_path, monkeypatch
+):
+    served = tmp_path / "served"
+    served.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "artifact.txt"
+    secret.write_text("secret", encoding="utf-8")
+    handler = _handler(served)
+    handler._search_root_descriptor = handler._open_search_root_descriptor(served)
+    monkeypatch.setattr(handler, "_resolve_within_root", lambda path: str(secret))
+
+    try:
+        with pytest.raises(PathValidationError):
+            handler._read_text_within_root("artifact.txt")
+    finally:
+        os.close(handler._search_root_descriptor)
+
+
+@requires_descriptor_traversal
+def test_database_listing_uses_pinned_root_after_ancestor_swap(tmp_path):
+    parent = tmp_path / "parent"
+    served = parent / "served"
+    served.mkdir(parents=True)
+    (served / "safe.sqlite").write_text("", encoding="utf-8")
+    outside_parent = tmp_path / "outside-parent"
+    outside_served = outside_parent / "served"
+    outside_served.mkdir(parents=True)
+    (outside_served / "secret.sqlite").write_text("", encoding="utf-8")
+    handler = _handler(served)
+    handler._search_root_descriptor = handler._open_search_root_descriptor(served)
+    sent = {}
+    handler.send_json_response = lambda data: sent.setdefault("data", data)
+
+    parent.rename(tmp_path / "parked-parent")
+    parent.symlink_to(outside_parent)
+
+    try:
+        handler.handle_list_databases()
+        assert [database["path"] for database in sent["data"]] == ["safe.sqlite"]
+    finally:
+        os.close(handler._search_root_descriptor)
+
+
+@requires_descriptor_traversal
+def test_database_listing_skips_unreadable_subdirectory(tmp_path):
+    (tmp_path / "safe.sqlite").write_text("", encoding="utf-8")
+    blocked = tmp_path / "blocked"
+    blocked.mkdir()
+    (blocked / "secret.sqlite").write_text("", encoding="utf-8")
+    blocked.chmod(0)
+    handler = _handler(tmp_path)
+
+    try:
+        assert handler._walk_files_within_root() == ["safe.sqlite"]
+    finally:
+        blocked.chmod(0o700)
+
+
+@requires_descriptor_traversal
+def test_directory_listing_rejects_symlink_swap_after_resolution(
+    tmp_path, monkeypatch
+):
+    served = tmp_path / "served"
+    meta_dir = served / "run" / "meta"
+    meta_dir.mkdir(parents=True)
+    (meta_dir / "meta_1.txt").write_text("safe", encoding="utf-8")
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "meta_2.txt").write_text("secret", encoding="utf-8")
+    handler = _handler(served)
+    resolve_path = handler._resolve_within_root
+
+    def resolve_then_swap(path):
+        resolved = resolve_path(path)
+        meta_dir.rename(served / "parked")
+        meta_dir.symlink_to(outside_dir)
+        return resolved
+
+    monkeypatch.setattr(handler, "_resolve_within_root", resolve_then_swap)
+
+    with pytest.raises(PathValidationError):
+        handler._list_directory_within_root("run/meta")
+
+
+def test_meta_listing_propagates_directory_race_rejection(tmp_path):
+    run_dir = tmp_path / "run"
+    meta_dir = run_dir / "meta"
+    meta_dir.mkdir(parents=True)
+    (run_dir / "programs.sqlite").write_text("", encoding="utf-8")
+    handler = _handler(tmp_path)
+
+    def reject_listing(path):
+        raise PathValidationError("path changed during access")
+
+    handler._list_directory_within_root = reject_listing
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_meta_files("run/programs.sqlite")

--- a/tests/test_webui_descriptor_security.py
+++ b/tests/test_webui_descriptor_security.py
@@ -4,7 +4,6 @@ import pytest
 
 from shinka.webui.visualization import DatabaseRequestHandler, PathValidationError
 
-
 requires_descriptor_traversal = pytest.mark.skipif(
     not (
         os.open in os.supports_dir_fd

--- a/tests/test_webui_descriptor_security.py
+++ b/tests/test_webui_descriptor_security.py
@@ -176,6 +176,55 @@ def test_database_listing_skips_unreadable_subdirectory(tmp_path):
 
 
 @requires_descriptor_traversal
+def test_database_listing_handles_tree_deeper_than_fd_limit(tmp_path):
+    resource = pytest.importorskip("resource")
+    directory = tmp_path
+    relative_parts = []
+    for depth in range(48):
+        name = f"d{depth}"
+        relative_parts.append(name)
+        directory /= name
+        directory.mkdir()
+    (directory / "programs.sqlite").write_text("", encoding="utf-8")
+    handler = _handler(tmp_path)
+
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if hard_limit < 32:
+        pytest.skip("file descriptor hard limit is below test threshold")
+    resource.setrlimit(resource.RLIMIT_NOFILE, (32, hard_limit))
+    try:
+        expected = os.path.join(*relative_parts, "programs.sqlite")
+        assert handler._walk_files_within_root() == [expected]
+    finally:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
+
+
+@requires_descriptor_traversal
+def test_database_listing_walk_ignores_non_database_files(tmp_path):
+    (tmp_path / "programs.sqlite").write_text("", encoding="utf-8")
+    for index in range(20):
+        (tmp_path / f"artifact-{index}.txt").write_text("x", encoding="utf-8")
+
+    assert _handler(tmp_path)._walk_files_within_root() == ["programs.sqlite"]
+
+
+@requires_descriptor_traversal
+def test_database_listing_preserves_os_walk_sibling_order(tmp_path):
+    for name in ("gamma", "beta", "alpha"):
+        directory = tmp_path / name
+        directory.mkdir()
+        (directory / "programs.sqlite").write_text("", encoding="utf-8")
+
+    expected = [
+        os.path.relpath(os.path.join(root, filename), tmp_path)
+        for root, _, files in os.walk(tmp_path)
+        for filename in files
+    ]
+
+    assert _handler(tmp_path)._walk_files_within_root() == expected
+
+
+@requires_descriptor_traversal
 def test_directory_listing_rejects_symlink_swap_after_resolution(
     tmp_path, monkeypatch
 ):

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -1,0 +1,138 @@
+"""Security regression tests for the visualization server.
+
+Covers the path-traversal containment that gates every db_path/meta/plot handler,
+plus the DNS-rebinding Host check, absent CORS wildcard, nosniff, and disabled
+directory listing.
+"""
+
+import http.client
+import os
+import socketserver
+import threading
+
+import pytest
+
+from shinka.webui.visualization import (
+    DatabaseRequestHandler,
+    PathValidationError,
+    create_handler_factory,
+)
+
+
+def _handler(root):
+    # Build a handler without running the socket-bound __init__.
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.search_root = str(root)
+    return handler
+
+
+def test_resolve_accepts_path_within_root(tmp_path):
+    (tmp_path / "run").mkdir()
+    db = tmp_path / "run" / "programs.sqlite"
+    db.write_text("x")
+    handler = _handler(tmp_path)
+    assert handler._resolve_within_root("run/programs.sqlite") == os.path.realpath(
+        str(db)
+    )
+
+
+def test_resolve_rejects_absolute_path(tmp_path):
+    handler = _handler(tmp_path)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("/etc/passwd")
+
+
+def test_resolve_rejects_parent_traversal(tmp_path):
+    served = tmp_path / "served"
+    served.mkdir()
+    (tmp_path / "secret.db").write_text("secret")
+    handler = _handler(served)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("../secret.db")
+
+
+def test_resolve_rejects_symlink_escape(tmp_path):
+    served = tmp_path / "served"
+    served.mkdir()
+    outside = tmp_path / "outside.db"
+    outside.write_text("outside")
+    os.symlink(outside, served / "link.db")
+    handler = _handler(served)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("link.db")
+
+
+def test_resolve_rejects_sibling_prefix_dir(tmp_path):
+    # Root "<x>/served" must not allow reaching a sibling "<x>/served_bak".
+    served = tmp_path / "served"
+    served.mkdir()
+    sibling = tmp_path / "served_bak"
+    sibling.mkdir()
+    (sibling / "leak.db").write_text("leak")
+    handler = _handler(served)
+    with pytest.raises(PathValidationError):
+        handler._resolve_within_root("../served_bak/leak.db")
+
+
+class _Server:
+    """Direct ThreadingTCPServer for the handler (no start_server chdir)."""
+
+    def __init__(self, search_root):
+        self.httpd = socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0), create_handler_factory(str(search_root))
+        )
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def get(self, path, host=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        headers = {"Host": host} if host else {}
+        conn.request("GET", path, headers=headers)
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        return resp, body
+
+    def close(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture
+def server(tmp_path):
+    (tmp_path / "run").mkdir()
+    (tmp_path / "run" / "programs.sqlite").write_text("db")
+    srv = _Server(tmp_path)
+    yield srv
+    srv.close()
+
+
+def test_http_rejects_absolute_db_path(server):
+    resp, _ = server.get(
+        "/get_programs?db_path=/etc/passwd", host=f"127.0.0.1:{server.port}"
+    )
+    assert resp.status == 403
+
+
+def test_http_rejects_foreign_host_header(server):
+    # DNS-rebinding: a request whose Host is an attacker domain is refused.
+    resp, _ = server.get("/list_databases", host="evil.example.com")
+    assert resp.status == 403
+
+
+def test_http_json_has_no_cors_wildcard_and_sets_nosniff(server):
+    resp, _ = server.get("/list_databases", host=f"127.0.0.1:{server.port}")
+    assert resp.status == 200
+    assert resp.getheader("Access-Control-Allow-Origin") is None
+    assert resp.getheader("X-Content-Type-Options") == "nosniff"
+
+
+def test_list_directory_override_forbids(tmp_path):
+    # The override must refuse to render an auto-generated index unconditionally.
+    handler = object.__new__(DatabaseRequestHandler)
+    sent = {}
+    handler.send_error = lambda code, msg=None: sent.update(code=code, msg=msg)
+    result = handler.list_directory(str(tmp_path))
+    assert result is None
+    assert sent["code"] == 403

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -9,6 +9,7 @@ import http.client
 import os
 import socketserver
 import threading
+import urllib.parse
 
 import pytest
 
@@ -112,6 +113,44 @@ def test_http_rejects_absolute_db_path(server):
     resp, _ = server.get(
         "/get_programs?db_path=/etc/passwd", host=f"127.0.0.1:{server.port}"
     )
+    assert resp.status == 403
+
+
+def test_http_rejects_meta_content_processed_count_traversal(server):
+    query = urllib.parse.urlencode(
+        {
+            "db_path": "run/programs.sqlite",
+            "processed_count": "../../../../../outside",
+        }
+    )
+    resp, _ = server.get(
+        f"/get_meta_content?{query}", host=f"127.0.0.1:{server.port}"
+    )
+    assert resp.status == 403
+
+
+def test_http_rejects_meta_pdf_processed_count_traversal(server):
+    query = urllib.parse.urlencode(
+        {
+            "db_path": "run/programs.sqlite",
+            "processed_count": "../../../../../outside",
+        }
+    )
+    resp, _ = server.get(
+        f"/download_meta_pdf?{query}", host=f"127.0.0.1:{server.port}"
+    )
+    assert resp.status == 403
+
+
+def test_http_rejects_plot_generation_traversal(server):
+    query = urllib.parse.urlencode(
+        {
+            "db_path": "run/programs.sqlite",
+            "generation": "../../../../outside",
+            "program_id": "program-1",
+        }
+    )
+    resp, _ = server.get(f"/get_plots?{query}", host=f"127.0.0.1:{server.port}")
     assert resp.status == 403
 
 

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -8,6 +8,7 @@ directory listing.
 import http.client
 import os
 import socketserver
+import sqlite3
 import threading
 import urllib.parse
 
@@ -141,6 +142,62 @@ def test_failed_node_details_propagates_path_validation_error(tmp_path):
 
     with pytest.raises(PathValidationError):
         handler.handle_get_program_details("programs.sqlite", "failed:proposal:1")
+
+
+def test_meta_listing_rejects_directory_symlink_outside_search_root(tmp_path):
+    run_dir = tmp_path / "served" / "run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "programs.sqlite").write_text("", encoding="utf-8")
+    outside_meta = tmp_path / "outside-meta"
+    outside_meta.mkdir()
+    (outside_meta / "meta_1.txt").write_text("secret", encoding="utf-8")
+    (run_dir / "meta").symlink_to(outside_meta)
+    handler = _handler(tmp_path / "served")
+    handler.send_json_response = lambda data: None
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_meta_files("run/programs.sqlite")
+
+
+def test_system_prompts_rejects_database_symlink_outside_search_root(tmp_path):
+    run_dir = tmp_path / "served" / "run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "programs.sqlite").write_text("", encoding="utf-8")
+    outside_prompts = tmp_path / "outside-prompts.sqlite"
+    outside_prompts.write_text("", encoding="utf-8")
+    (run_dir / "prompts.sqlite").symlink_to(outside_prompts)
+    handler = _handler(tmp_path / "served")
+    handler.send_json_response = lambda data: None
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_system_prompts("run/programs.sqlite")
+
+
+def test_database_stats_rejects_prompts_symlink_outside_search_root(tmp_path):
+    run_dir = tmp_path / "served" / "run"
+    run_dir.mkdir(parents=True)
+    programs_db = run_dir / "programs.sqlite"
+    with sqlite3.connect(programs_db) as connection:
+        connection.execute(
+            """
+            CREATE TABLE programs (
+                generation INTEGER,
+                correct INTEGER,
+                combined_score REAL,
+                timestamp REAL,
+                metadata TEXT
+            )
+            """
+        )
+    outside_prompts = tmp_path / "outside-prompts.sqlite"
+    with sqlite3.connect(outside_prompts) as connection:
+        connection.execute("CREATE TABLE system_prompts (metadata TEXT)")
+    (run_dir / "prompts.sqlite").symlink_to(outside_prompts)
+    handler = _handler(tmp_path / "served")
+    handler.send_json_response = lambda data: None
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_database_stats("run/programs.sqlite")
 
 
 class _Server:

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -75,6 +75,74 @@ def test_resolve_rejects_sibling_prefix_dir(tmp_path):
         handler._resolve_within_root("../served_bak/leak.db")
 
 
+def test_read_failure_json_rejects_path_outside_search_root(tmp_path):
+    outside_payload = tmp_path / "outside.json"
+    outside_payload.write_text('{"failure_reason":"secret"}', encoding="utf-8")
+    search_root = tmp_path / "served"
+    search_root.mkdir()
+    handler = _handler(search_root)
+
+    with pytest.raises(PathValidationError):
+        handler._read_failure_json(str(outside_payload))
+
+
+def test_failed_node_code_path_rejects_path_outside_search_root(tmp_path):
+    outside_code = tmp_path / "secret.py"
+    outside_code.write_text("secret = True\n", encoding="utf-8")
+    search_root = tmp_path / "served"
+    search_root.mkdir()
+    handler = _handler(search_root)
+
+    with pytest.raises(PathValidationError):
+        handler._resolve_failed_node_code_path(
+            {"failure_json_path": "failure.json"},
+            {"artifacts": {"generated_code_path": str(outside_code)}},
+        )
+
+
+def test_failed_node_code_path_rejects_symlinked_preferred_file(tmp_path):
+    outside_code = tmp_path / "secret.py"
+    outside_code.write_text("secret = True\n", encoding="utf-8")
+    failure_dir = tmp_path / "served" / "results" / "gen_1"
+    failure_dir.mkdir(parents=True)
+    (failure_dir / "main.py").symlink_to(outside_code)
+    handler = _handler(tmp_path / "served")
+
+    with pytest.raises(PathValidationError):
+        handler._resolve_failed_node_code_path(
+            {"failure_json_path": "results/gen_1/failure.json"},
+            {"language": "python"},
+        )
+
+
+def test_failed_node_code_path_rejects_symlinked_generic_fallback(tmp_path):
+    outside_code = tmp_path / "secret.rs"
+    outside_code.write_text("const SECRET: bool = true;\n", encoding="utf-8")
+    failure_dir = tmp_path / "served" / "results" / "gen_1"
+    failure_dir.mkdir(parents=True)
+    (failure_dir / "main.rs").symlink_to(outside_code)
+    handler = _handler(tmp_path / "served")
+
+    with pytest.raises(PathValidationError):
+        handler._resolve_failed_node_code_path(
+            {"failure_json_path": "results/gen_1/failure.json"},
+            {"language": "rust"},
+        )
+
+
+def test_failed_node_details_propagates_path_validation_error(tmp_path):
+    (tmp_path / "programs.sqlite").write_text("", encoding="utf-8")
+    handler = _handler(tmp_path)
+
+    def reject_failed_node(*args, **kwargs):
+        raise PathValidationError("outside search root")
+
+    handler._load_failed_proposal_nodes = reject_failed_node
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_program_details("programs.sqlite", "failed:proposal:1")
+
+
 class _Server:
     """Direct ThreadingTCPServer for the handler (no start_server chdir)."""
 

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -112,6 +112,13 @@ def test_resolved_loopback_alias_keeps_host_protection():
     assert {"127.1", "127.0.0.1"} <= allowed_hosts
 
 
+def test_scoped_ipv6_loopback_allows_uri_encoded_host_header():
+    allowed_hosts = _allowed_hosts_for_bind("::1%lo", "::1%lo")
+
+    assert allowed_hosts is not None
+    assert "[::1%25lo]" in allowed_hosts
+
+
 def test_wildcard_bind_disables_local_host_allowlist():
     assert _allowed_hosts_for_bind("", "0.0.0.0") is None
 

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -17,6 +17,8 @@ import pytest
 from shinka.webui.visualization import (
     DatabaseRequestHandler,
     PathValidationError,
+    _allowed_hosts_for_bind,
+    _is_loopback_host,
     create_handler_factory,
 )
 
@@ -75,6 +77,43 @@ def test_resolve_rejects_sibling_prefix_dir(tmp_path):
     handler = _handler(served)
     with pytest.raises(PathValidationError):
         handler._resolve_within_root("../served_bak/leak.db")
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("localhost", True),
+        ("LOCALHOST", True),
+        ("127.0.0.1", True),
+        ("127.0.0.2", True),
+        ("127.255.255.255", True),
+        ("::1", True),
+        ("", False),
+        ("0.0.0.0", False),
+        ("::", False),
+        ("192.168.1.20", False),
+    ],
+)
+def test_loopback_host_classification(host, expected):
+    assert _is_loopback_host(host) is expected
+
+
+def test_custom_loopback_bind_allows_its_host_header():
+    allowed_hosts = _allowed_hosts_for_bind("127.0.0.2", "127.0.0.2")
+
+    assert allowed_hosts is not None
+    assert "127.0.0.2" in allowed_hosts
+
+
+def test_resolved_loopback_alias_keeps_host_protection():
+    allowed_hosts = _allowed_hosts_for_bind("127.1", "127.0.0.1")
+
+    assert allowed_hosts is not None
+    assert {"127.1", "127.0.0.1"} <= allowed_hosts
+
+
+def test_wildcard_bind_disables_local_host_allowlist():
+    assert _allowed_hosts_for_bind("", "0.0.0.0") is None
 
 
 def test_failed_node_language_defaults_when_artifact_directory_is_missing(tmp_path):

--- a/tests/test_webui_security.py
+++ b/tests/test_webui_security.py
@@ -25,6 +25,7 @@ def _handler(root):
     # Build a handler without running the socket-bound __init__.
     handler = object.__new__(DatabaseRequestHandler)
     handler.search_root = str(root)
+    handler._canonical_search_root = os.path.realpath(root)
     return handler
 
 
@@ -74,6 +75,17 @@ def test_resolve_rejects_sibling_prefix_dir(tmp_path):
     handler = _handler(served)
     with pytest.raises(PathValidationError):
         handler._resolve_within_root("../served_bak/leak.db")
+
+
+def test_failed_node_language_defaults_when_artifact_directory_is_missing(tmp_path):
+    handler = _handler(tmp_path)
+
+    language = handler._resolve_failed_node_language(
+        {"failure_json_path": "missing/gen/failure.json"},
+        None,
+    )
+
+    assert language == "python"
 
 
 def test_read_failure_json_rejects_path_outside_search_root(tmp_path):

--- a/tests/test_webui_server_startup.py
+++ b/tests/test_webui_server_startup.py
@@ -9,6 +9,7 @@ from shinka.webui import visualization
 from shinka.webui.visualization import (
     DatabaseRequestHandler,
     _bind_server,
+    _bound_host_from_server_address,
     _browser_url,
     create_handler_factory,
 )
@@ -90,6 +91,15 @@ def test_browser_url_encodes_database_path():
     assert url == (
         "http://127.0.0.2:8765/viz_tree.html?db_path=run%2Fa+b.sqlite"
     )
+
+
+def test_scoped_ipv6_browser_url_preserves_interface(monkeypatch):
+    monkeypatch.setattr(socket, "if_indextoname", lambda scope_id: "eth0")
+
+    bound_host = _bound_host_from_server_address(("fe80::1", 8765, 0, 3))
+
+    assert bound_host == "fe80::1%eth0"
+    assert _browser_url(bound_host, 8765) == "http://[fe80::1%25eth0]:8765/"
 
 
 def test_bind_server_falls_back_to_next_resolved_address(monkeypatch):

--- a/tests/test_webui_server_startup.py
+++ b/tests/test_webui_server_startup.py
@@ -1,0 +1,168 @@
+import http.client
+import os
+import socket
+import threading
+
+import pytest
+
+from shinka.webui import visualization
+from shinka.webui.visualization import (
+    DatabaseRequestHandler,
+    _bind_server,
+    _browser_url,
+    create_handler_factory,
+)
+
+
+def test_ipv6_host_selects_ipv6_server():
+    server = _bind_server("::1", 0, DatabaseRequestHandler)
+    try:
+        assert server.address_family == socket.AF_INET6
+    finally:
+        server.server_close()
+
+
+def test_empty_host_preserves_ipv4_wildcard_bind():
+    server = _bind_server("", 0, DatabaseRequestHandler)
+    try:
+        assert server.address_family == socket.AF_INET
+        assert server.server_address[0] == "0.0.0.0"
+    finally:
+        server.server_close()
+
+
+@pytest.mark.skipif(not socket.has_ipv6, reason="IPv6 is unavailable")
+@pytest.mark.parametrize("host_header", ["[::1]", "[::1]:{port}"])
+def test_ipv6_server_accepts_bracketed_host_headers(tmp_path, host_header):
+    try:
+        server = _bind_server(
+            "::1",
+            0,
+            create_handler_factory(os.fspath(tmp_path)),
+        )
+    except OSError as exc:
+        pytest.skip(f"IPv6 loopback bind unavailable: {exc}")
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = int(server.server_address[1])
+    connection = http.client.HTTPConnection("::1", port, timeout=5)
+    try:
+        connection.putrequest("GET", "/list_databases", skip_host=True)
+        connection.putheader("Host", host_header.format(port=port))
+        connection.endheaders()
+        response = connection.getresponse()
+        response.read()
+        assert response.status == 200
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("host_header", ["[::1]", "[::1]:8000"])
+def test_ipv6_host_header_is_accepted_with_or_without_port(host_header):
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.allowed_hosts = frozenset({"[::1]"})
+    handler.headers = {"Host": host_header}
+
+    assert handler._host_allowed()
+
+
+@pytest.mark.parametrize(
+    ("bound_host", "expected"),
+    [
+        ("::1", "http://[::1]:8765/"),
+        ("192.168.1.20", "http://192.168.1.20:8765/"),
+        ("127.0.0.1", "http://127.0.0.1:8765/"),
+        ("0.0.0.0", "http://127.0.0.1:8765/"),
+        ("::", "http://[::1]:8765/"),
+    ],
+)
+def test_browser_url_uses_reachable_bound_address(bound_host, expected):
+    assert _browser_url(bound_host, 8765) == expected
+
+
+def test_browser_url_encodes_database_path():
+    url = _browser_url("127.0.0.2", 8765, "run/a b.sqlite")
+
+    assert url == (
+        "http://127.0.0.2:8765/viz_tree.html?db_path=run%2Fa+b.sqlite"
+    )
+
+
+def test_bind_server_falls_back_to_next_resolved_address(monkeypatch):
+    addresses = [
+        (socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("::1", 8000, 0, 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 8000)),
+    ]
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *args, **kwargs: addresses)
+
+    class FailingServer:
+        def __init__(self, address, request_handler):
+            raise OSError("IPv6 unavailable")
+
+    expected_server = object()
+    monkeypatch.setattr(
+        visualization,
+        "_server_class_for_family",
+        lambda family: FailingServer if family == socket.AF_INET6 else (
+            lambda address, request_handler: expected_server
+        ),
+    )
+
+    assert _bind_server("dual-stack.example", 8000, DatabaseRequestHandler) is (
+        expected_server
+    )
+
+
+def test_readiness_callback_can_request_server(tmp_path):
+    callback_complete = threading.Event()
+    errors = []
+
+    def probe(httpd):
+        connection = http.client.HTTPConnection(
+            str(httpd.server_address[0]),
+            int(httpd.server_address[1]),
+            timeout=5,
+        )
+        try:
+            connection.request("GET", "/list_databases")
+            response = connection.getresponse()
+            response.read()
+            assert response.status == 200
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            connection.close()
+            httpd.shutdown()
+            callback_complete.set()
+
+    original_directory = os.getcwd()
+    try:
+        visualization.start_server(
+            0,
+            os.fspath(tmp_path),
+            host="127.0.0.1",
+            on_ready=probe,
+        )
+    finally:
+        os.chdir(original_directory)
+
+    assert callback_complete.wait(timeout=5)
+    assert errors == []
+
+
+def test_main_propagates_server_startup_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["shinka_visualize", os.fspath(tmp_path)],
+    )
+    monkeypatch.setattr(
+        visualization,
+        "start_server",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("bind failed")),
+    )
+    with pytest.raises(OSError, match="bind failed"):
+        visualization.main()

--- a/tests/test_webui_server_startup.py
+++ b/tests/test_webui_server_startup.py
@@ -71,6 +71,42 @@ def test_ipv6_host_header_is_accepted_with_or_without_port(host_header):
     assert handler._host_allowed()
 
 
+def test_handler_factory_configures_database_snapshot_limit(tmp_path, monkeypatch):
+    captured = {}
+    factory = create_handler_factory(
+        os.fspath(tmp_path),
+        max_database_snapshot_bytes=1234,
+    )
+
+    def capture_init(self, *args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(DatabaseRequestHandler, "__init__", capture_init)
+
+    factory()
+
+    assert captured["max_database_snapshot_bytes"] == 1234
+
+
+@pytest.mark.parametrize("limit", [0, -1, True, 1.5, float("inf")])
+def test_handler_factory_rejects_invalid_database_snapshot_limit(tmp_path, limit):
+    with pytest.raises(ValueError, match="snapshot size"):
+        create_handler_factory(
+            os.fspath(tmp_path),
+            max_database_snapshot_bytes=limit,
+        )
+
+
+@pytest.mark.parametrize("limit", [0, -1, True, 1.5, float("inf")])
+def test_start_server_rejects_invalid_database_snapshot_limit(tmp_path, limit):
+    with pytest.raises(ValueError, match="snapshot size"):
+        visualization.start_server(
+            0,
+            os.fspath(tmp_path),
+            max_database_snapshot_bytes=limit,
+        )
+
+
 @pytest.mark.parametrize(
     ("bound_host", "expected"),
     [
@@ -175,4 +211,44 @@ def test_main_propagates_server_startup_failure(tmp_path, monkeypatch):
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("bind failed")),
     )
     with pytest.raises(OSError, match="bind failed"):
+        visualization.main()
+
+
+def test_main_configures_database_snapshot_limit(tmp_path, monkeypatch):
+    captured = {}
+
+    def capture_start_server(*args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "shinka_visualize",
+            os.fspath(tmp_path),
+            "--max-database-snapshot-gib",
+            "4.5",
+        ],
+    )
+    monkeypatch.setattr(visualization, "start_server", capture_start_server)
+
+    visualization.main()
+
+    assert captured["max_database_snapshot_bytes"] == int(4.5 * 1024**3)
+
+
+@pytest.mark.parametrize("limit", ["0", "1e-300", "1e300", "nan", "inf"])
+def test_main_rejects_unrepresentable_database_snapshot_limit(
+    tmp_path, monkeypatch, limit
+):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "shinka_visualize",
+            os.fspath(tmp_path),
+            "--max-database-snapshot-gib",
+            limit,
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
         visualization.main()

--- a/tests/test_webui_server_startup.py
+++ b/tests/test_webui_server_startup.py
@@ -132,7 +132,7 @@ def test_readiness_callback_can_request_server(tmp_path):
             response = connection.getresponse()
             response.read()
             assert response.status == 200
-        except Exception as exc:
+        except (AssertionError, OSError, http.client.HTTPException) as exc:
             errors.append(exc)
         finally:
             connection.close()

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -7,7 +7,6 @@ import pytest
 from shinka.database import DatabaseConfig, ProgramDatabase
 from shinka.webui.visualization import DatabaseRequestHandler
 
-
 requires_descriptor_traversal = pytest.mark.skipif(
     not DatabaseRequestHandler._supports_descriptor_traversal(),
     reason="database race hardening requires descriptor traversal",

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -388,6 +388,63 @@ def test_database_snapshot_retries_staging_parent_after_enospc(
     assert not list(first_staging_parent.iterdir())
 
 
+@requires_descriptor_traversal
+def test_database_snapshot_retries_wal_staging_after_enospc(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    first_staging_parent = tmp_path / "first-staging"
+    second_staging_parent = tmp_path / "second-staging"
+    first_staging_parent.mkdir()
+    second_staging_parent.mkdir()
+    writer = sqlite3.connect(database_path)
+    writer.execute("PRAGMA journal_mode = WAL")
+    writer.execute("PRAGMA wal_autocheckpoint = 0")
+    writer.execute("CREATE TABLE programs (id INTEGER)")
+    writer.execute("INSERT INTO programs VALUES (1)")
+    writer.commit()
+    handler = _handler(tmp_path)
+    copy_sidecar = handler._copy_optional_database_sidecar
+    wal_copy_attempts = 0
+
+    def fail_first_wal_copy(*args, **kwargs):
+        nonlocal wal_copy_attempts
+        wal_copy_attempts += 1
+        if wal_copy_attempts == 1:
+            raise OSError(errno.ENOSPC, "staging filesystem full")
+        return copy_sidecar(*args, **kwargs)
+
+    monkeypatch.setattr(
+        handler,
+        "_database_staging_parents",
+        lambda path: [
+            os.fspath(first_staging_parent),
+            os.fspath(second_staging_parent),
+        ],
+    )
+    monkeypatch.setattr(
+        handler,
+        "_copy_optional_database_sidecar",
+        fail_first_wal_copy,
+    )
+    try:
+        with handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as connection:
+            assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+    finally:
+        writer.close()
+
+    assert wal_copy_attempts == 2
+    assert not [
+        path
+        for path in first_staging_parent.iterdir()
+        if path.name.startswith("shinka-webui-db-")
+    ]
+    handler.clear_database_snapshot_cache()
+
+
 @pytest.mark.parametrize(
     ("path", "expected_target"),
     [

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -311,6 +311,43 @@ def test_database_snapshot_rejects_oversized_source_before_copy(
 
 
 @requires_descriptor_traversal
+def test_database_snapshot_rejects_oversized_wal_before_copy(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path)
+    wal_path = tmp_path / "programs.sqlite-wal"
+    wal_path.write_bytes(b"xx")
+    handler = _handler(tmp_path)
+    copy_database_descriptor = handler._copy_database_descriptor
+    wal_copied = False
+
+    def record_wal_copy(*args, **kwargs):
+        nonlocal wal_copied
+        if args[2].endswith("-wal"):
+            wal_copied = True
+        return copy_database_descriptor(*args, **kwargs)
+
+    monkeypatch.setattr(
+        handler,
+        "_database_main_cache_max_bytes",
+        database_path.stat().st_size + 1,
+    )
+    monkeypatch.setattr(handler, "_copy_database_descriptor", record_wal_copy)
+
+    with (
+        pytest.raises(sqlite3.OperationalError, match="WAL exceed"),
+        handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ),
+    ):
+        pass
+
+    assert not wal_copied
+
+
+@requires_descriptor_traversal
 def test_database_snapshot_retries_staging_parent_after_enospc(
     tmp_path, monkeypatch
 ):

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -445,27 +445,6 @@ def test_database_snapshot_retries_wal_staging_after_enospc(
     handler.clear_database_snapshot_cache()
 
 
-@pytest.mark.parametrize(
-    ("path", "expected_target"),
-    [
-        (
-            r"C:\Users\Rob Lange\programs.sqlite",
-            ("file:///C:/Users/Rob%20Lange/programs.sqlite?mode=ro", True),
-        ),
-        (
-            r"\\server\results\programs.sqlite",
-            (r"\\server\results\programs.sqlite", False),
-        ),
-        (
-            r"\\?\C:\results\programs.sqlite",
-            (r"\\?\C:\results\programs.sqlite", False),
-        ),
-    ],
-)
-def test_sqlite_read_only_target_supports_windows_paths(path, expected_target):
-    assert DatabaseRequestHandler._sqlite_read_only_target(path) == expected_target
-
-
 @requires_descriptor_traversal
 def test_staging_parent_rejects_foreign_owned_ancestor(tmp_path, monkeypatch):
     staging_parent = tmp_path / "staging"

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import os
 import sqlite3
 import stat
@@ -307,6 +308,47 @@ def test_database_snapshot_rejects_oversized_source_before_copy(
         pass
 
     assert not copied
+
+
+@requires_descriptor_traversal
+def test_database_snapshot_retries_staging_parent_after_enospc(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    first_staging_parent = tmp_path / "first-staging"
+    second_staging_parent = tmp_path / "second-staging"
+    first_staging_parent.mkdir()
+    second_staging_parent.mkdir()
+    _create_stats_database(database_path)
+    handler = _handler(tmp_path)
+    copy_database_descriptor = handler._copy_database_descriptor
+    copy_attempts = 0
+
+    def fail_first_copy(*args, **kwargs):
+        nonlocal copy_attempts
+        copy_attempts += 1
+        if copy_attempts == 1:
+            raise OSError(errno.ENOSPC, "staging filesystem full")
+        return copy_database_descriptor(*args, **kwargs)
+
+    monkeypatch.setattr(
+        handler,
+        "_database_staging_parents",
+        lambda path: [
+            os.fspath(first_staging_parent),
+            os.fspath(second_staging_parent),
+        ],
+    )
+    monkeypatch.setattr(handler, "_copy_database_descriptor", fail_first_copy)
+
+    with handler._connect_database_within_root(
+        database_path,
+        timeout=5.0,
+    ) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 0
+
+    assert copy_attempts == 2
+    assert not list(first_staging_parent.iterdir())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sqlite3
 import stat
@@ -120,6 +121,53 @@ def test_fallback_program_count_does_not_change_journal_mode(tmp_path, monkeypat
     assert response is not None
     assert database_path.read_bytes() == contents_before
     assert journal_mode == "delete"
+
+
+@requires_descriptor_traversal
+def test_database_stats_reuses_connection_for_hardlinked_prompts(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    prompts_path = tmp_path / "prompts.sqlite"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE programs (
+                generation INTEGER,
+                correct INTEGER,
+                combined_score REAL,
+                timestamp REAL,
+                metadata TEXT
+            )
+            """
+        )
+        connection.execute("CREATE TABLE system_prompts (metadata TEXT)")
+        connection.execute("INSERT INTO system_prompts VALUES ('{}')")
+    os.link(database_path, prompts_path)
+
+    handler = _handler(tmp_path)
+    connect_database = handler._connect_database_within_root
+    connected_paths = []
+    response = None
+
+    @contextlib.contextmanager
+    def count_connections(path, **kwargs):
+        connected_paths.append(os.fspath(path))
+        with connect_database(path, **kwargs) as connection:
+            yield connection
+
+    def capture_response(data):
+        nonlocal response
+        response = data
+
+    monkeypatch.setattr(handler, "_connect_database_within_root", count_connections)
+    handler.send_json_response = capture_response
+
+    handler.handle_get_database_stats("programs.sqlite")
+
+    assert response is not None
+    assert response["prompt_count"] == 1
+    assert connected_paths == [os.fspath(database_path)]
 
 
 @requires_descriptor_traversal

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -124,7 +124,7 @@ def test_fallback_program_count_does_not_change_journal_mode(tmp_path, monkeypat
 
 
 @requires_descriptor_traversal
-def test_database_stats_reuses_connection_for_hardlinked_prompts(
+def test_database_stats_reads_path_specific_wal_for_hardlinked_prompts(
     tmp_path, monkeypatch
 ):
     database_path = tmp_path / "programs.sqlite"
@@ -142,8 +142,12 @@ def test_database_stats_reuses_connection_for_hardlinked_prompts(
             """
         )
         connection.execute("CREATE TABLE system_prompts (metadata TEXT)")
-        connection.execute("INSERT INTO system_prompts VALUES ('{}')")
     os.link(database_path, prompts_path)
+    prompt_writer = sqlite3.connect(prompts_path)
+    prompt_writer.execute("PRAGMA journal_mode = WAL")
+    prompt_writer.execute("PRAGMA wal_autocheckpoint = 0")
+    prompt_writer.execute("INSERT INTO system_prompts VALUES ('{}')")
+    prompt_writer.commit()
 
     handler = _handler(tmp_path)
     connect_database = handler._connect_database_within_root
@@ -163,11 +167,17 @@ def test_database_stats_reuses_connection_for_hardlinked_prompts(
     monkeypatch.setattr(handler, "_connect_database_within_root", count_connections)
     handler.send_json_response = capture_response
 
-    handler.handle_get_database_stats("programs.sqlite")
+    try:
+        handler.handle_get_database_stats("programs.sqlite")
 
-    assert response is not None
-    assert response["prompt_count"] == 1
-    assert connected_paths == [os.fspath(database_path)]
+        assert response is not None
+        assert response["prompt_count"] == 1
+        assert connected_paths == [
+            os.fspath(database_path),
+            os.fspath(prompts_path),
+        ]
+    finally:
+        prompt_writer.close()
 
 
 @requires_descriptor_traversal

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -1,0 +1,224 @@
+import os
+import sqlite3
+import stat
+
+import pytest
+
+from shinka.database import DatabaseConfig, ProgramDatabase
+from shinka.webui.visualization import DatabaseRequestHandler
+
+
+requires_descriptor_traversal = pytest.mark.skipif(
+    not DatabaseRequestHandler._supports_descriptor_traversal(),
+    reason="database race hardening requires descriptor traversal",
+)
+
+
+def _handler(root):
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.search_root = os.fspath(root)
+    handler._canonical_search_root = os.path.realpath(root)
+    return handler
+
+
+def _create_stats_database(path, *, program_count=0):
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE programs (
+                generation INTEGER,
+                correct INTEGER,
+                combined_score REAL,
+                timestamp REAL,
+                metadata TEXT
+            )
+            """
+        )
+        for generation in range(program_count):
+            connection.execute(
+                "INSERT INTO programs VALUES (?, 1, 1.0, 1.0, '{}')",
+                (generation,),
+            )
+
+
+@requires_descriptor_traversal
+def test_database_view_holds_snapshot_after_final_verification(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    writer = sqlite3.connect(database_path)
+    writer.execute("PRAGMA journal_mode = WAL")
+    writer.execute("PRAGMA wal_autocheckpoint = 0")
+    writer.execute("CREATE TABLE programs (id INTEGER)")
+    writer.execute("INSERT INTO programs VALUES (1)")
+    writer.commit()
+
+    handler = _handler(tmp_path)
+    verify_database_view = handler._verify_database_view
+    replacement_writers = []
+    verifications = 0
+
+    def verify_then_rotate(*args, **kwargs):
+        nonlocal verifications, writer
+        verify_database_view(*args, **kwargs)
+        verifications += 1
+        if verifications == 2:
+            writer.close()
+            replacement = sqlite3.connect(database_path)
+            replacement.execute("PRAGMA journal_mode = WAL")
+            replacement.execute("PRAGMA wal_autocheckpoint = 0")
+            replacement.execute("INSERT INTO programs VALUES (2)")
+            replacement.commit()
+            replacement_writers.append(replacement)
+
+    monkeypatch.setattr(handler, "_verify_database_view", verify_then_rotate)
+    try:
+        with handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+    finally:
+        for replacement in replacement_writers:
+            replacement.close()
+        if not replacement_writers:
+            writer.close()
+
+
+def test_database_view_reads_without_descriptor_traversal(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path, program_count=1)
+    handler = _handler(tmp_path)
+    monkeypatch.setattr(handler, "_supports_descriptor_traversal", lambda: False)
+
+    with handler._connect_database_within_root(
+        database_path,
+        timeout=5.0,
+    ) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+
+
+def test_fallback_program_count_does_not_change_journal_mode(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    database = ProgramDatabase(DatabaseConfig(db_path=os.fspath(database_path)))
+    database.close()
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("PRAGMA journal_mode = DELETE").fetchone()
+    contents_before = database_path.read_bytes()
+    handler = _handler(tmp_path)
+    response = None
+    monkeypatch.setattr(handler, "_supports_descriptor_traversal", lambda: False)
+
+    def capture_response(data):
+        nonlocal response
+        response = data
+
+    handler.send_json_response = capture_response
+    handler.send_error = lambda *args: pytest.fail(f"unexpected error: {args}")
+
+    handler.handle_get_program_count("programs.sqlite")
+
+    with sqlite3.connect(database_path) as connection:
+        journal_mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
+    assert response is not None
+    assert database_path.read_bytes() == contents_before
+    assert journal_mode == "delete"
+
+
+@requires_descriptor_traversal
+def test_database_main_snapshot_replaces_checkpointed_version(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    writer = sqlite3.connect(database_path)
+    writer.execute("PRAGMA journal_mode = WAL")
+    writer.execute("PRAGMA wal_autocheckpoint = 0")
+    writer.execute("CREATE TABLE programs (id INTEGER)")
+    writer.execute("INSERT INTO programs VALUES (1)")
+    writer.commit()
+    handler = _handler(tmp_path)
+    copy_database_descriptor = handler._copy_database_descriptor
+    main_copies = 0
+    old_snapshot_directory = None
+
+    def count_main_copies(*args, **kwargs):
+        nonlocal main_copies
+        if args[2] == "database.sqlite":
+            main_copies += 1
+            if main_copies == 2:
+                assert old_snapshot_directory is not None
+                assert not os.path.exists(old_snapshot_directory)
+        return copy_database_descriptor(*args, **kwargs)
+
+    monkeypatch.setattr(handler, "_copy_database_descriptor", count_main_copies)
+    try:
+        with handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+
+        initial_stat = database_path.stat()
+        source_key = (initial_stat.st_dev, initial_stat.st_ino)
+        old_snapshot_directory = handler._database_main_cache[
+            source_key
+        ].directory.name
+
+        writer.execute("INSERT INTO programs VALUES (2)")
+        writer.commit()
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+        with handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 2
+    finally:
+        writer.close()
+
+    database_stat = database_path.stat()
+    source_key = (database_stat.st_dev, database_stat.st_ino)
+    assert main_copies == 2
+    assert source_key in handler._database_main_cache
+    assert handler._database_main_cache[
+        source_key
+    ].version == handler._database_cache_key(database_stat)
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_target"),
+    [
+        (
+            r"C:\Users\Rob Lange\programs.sqlite",
+            ("file:///C:/Users/Rob%20Lange/programs.sqlite?mode=ro", True),
+        ),
+        (
+            r"\\server\results\programs.sqlite",
+            (r"\\server\results\programs.sqlite", False),
+        ),
+        (
+            r"\\?\C:\results\programs.sqlite",
+            (r"\\?\C:\results\programs.sqlite", False),
+        ),
+    ],
+)
+def test_sqlite_read_only_target_supports_windows_paths(path, expected_target):
+    assert DatabaseRequestHandler._sqlite_read_only_target(path) == expected_target
+
+
+@requires_descriptor_traversal
+def test_staging_parent_rejects_foreign_owned_ancestor(tmp_path, monkeypatch):
+    staging_parent = tmp_path / "staging"
+    staging_parent.mkdir()
+    real_stat = os.stat
+    foreign_uid = os.geteuid() + 1
+
+    def stat_with_foreign_owner(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if os.path.realpath(path) != os.path.realpath(tmp_path):
+            return result
+        values = list(result)
+        values[stat.ST_UID] = foreign_uid
+        return os.stat_result(values)
+
+    monkeypatch.setattr(os, "stat", stat_with_foreign_owner)
+
+    assert not DatabaseRequestHandler._is_secure_staging_parent(
+        os.fspath(staging_parent)
+    )

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -281,6 +281,34 @@ def test_database_main_snapshot_replaces_checkpointed_version(tmp_path, monkeypa
     ].version == handler._database_cache_key(database_stat)
 
 
+@requires_descriptor_traversal
+def test_database_snapshot_rejects_oversized_source_before_copy(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path)
+    handler = _handler(tmp_path)
+    copied = False
+
+    def record_copy(*args, **kwargs):
+        nonlocal copied
+        copied = True
+
+    monkeypatch.setattr(handler, "_database_main_cache_max_bytes", 1)
+    monkeypatch.setattr(handler, "_copy_database_descriptor", record_copy)
+
+    with (
+        pytest.raises(sqlite3.OperationalError, match="snapshot limit"),
+        handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ),
+    ):
+        pass
+
+    assert not copied
+
+
 @pytest.mark.parametrize(
     ("path", "expected_target"),
     [

--- a/tests/test_webui_sqlite_platform.py
+++ b/tests/test_webui_sqlite_platform.py
@@ -6,6 +6,7 @@ import stat
 import pytest
 
 from shinka.database import DatabaseConfig, ProgramDatabase
+from shinka.webui import visualization
 from shinka.webui.visualization import DatabaseRequestHandler
 
 requires_descriptor_traversal = pytest.mark.skipif(
@@ -121,6 +122,48 @@ def test_fallback_program_count_does_not_change_journal_mode(tmp_path, monkeypat
     assert response is not None
     assert database_path.read_bytes() == contents_before
     assert journal_mode == "delete"
+
+
+@requires_descriptor_traversal
+def test_program_response_cache_does_not_cross_search_roots(tmp_path):
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first_root.mkdir()
+    second_root.mkdir()
+    database_path = first_root / "programs.sqlite"
+    database = ProgramDatabase(DatabaseConfig(db_path=os.fspath(database_path)))
+    database.close()
+    first_handler = _handler(first_root)
+    first_response = None
+
+    def capture_first_response(data):
+        nonlocal first_response
+        first_response = data
+
+    first_handler.send_json_response = capture_first_response
+    first_handler.send_error = lambda *args: pytest.fail(f"unexpected error: {args}")
+    second_handler = _handler(second_root)
+    second_error = None
+
+    def capture_second_error(*args):
+        nonlocal second_error
+        second_error = args
+
+    second_handler.send_json_response = lambda data: pytest.fail(
+        f"unexpected cached response: {data}"
+    )
+    second_handler.send_error = capture_second_error
+
+    visualization.db_cache.clear()
+    try:
+        first_handler.handle_get_programs("programs.sqlite")
+        second_handler.handle_get_programs("programs.sqlite")
+    finally:
+        visualization.db_cache.clear()
+
+    assert first_response == []
+    assert second_error is not None
+    assert second_error[0] == 404
 
 
 @requires_descriptor_traversal

--- a/tests/test_webui_sqlite_reliability.py
+++ b/tests/test_webui_sqlite_reliability.py
@@ -1,0 +1,74 @@
+import errno
+import os
+import sqlite3
+
+import pytest
+
+from shinka.webui.visualization import DatabaseRequestHandler, DatabaseViewRaceError
+
+requires_descriptor_traversal = pytest.mark.skipif(
+    not DatabaseRequestHandler._supports_descriptor_traversal(),
+    reason="database race hardening requires descriptor traversal",
+)
+
+
+def _handler(root):
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.search_root = os.fspath(root)
+    handler._canonical_search_root = os.path.realpath(root)
+    return handler
+
+
+def _create_database(path):
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE programs (id INTEGER)")
+
+
+@requires_descriptor_traversal
+def test_database_copy_never_exceeds_captured_source_size(tmp_path, monkeypatch):
+    source_path = tmp_path / "source.sqlite"
+    destination_path = tmp_path / "snapshot.sqlite"
+    source_path.write_bytes(b"abc")
+    source_descriptor = os.open(source_path, os.O_RDONLY)
+    destination_descriptor = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    expected_stat = os.fstat(source_descriptor)
+    real_pread = os.pread
+    appended = False
+
+    def append_before_read(descriptor, size, offset):
+        nonlocal appended
+        if descriptor == source_descriptor and not appended:
+            appended = True
+            with source_path.open("ab") as source:
+                source.write(b"growth")
+        return real_pread(descriptor, size, offset)
+
+    monkeypatch.setattr(os, "pread", append_before_read)
+    try:
+        with pytest.raises(DatabaseViewRaceError, match="changed"):
+            DatabaseRequestHandler._copy_database_descriptor(
+                source_descriptor,
+                destination_descriptor,
+                destination_path.name,
+                expected_stat=expected_stat,
+            )
+    finally:
+        os.close(destination_descriptor)
+        os.close(source_descriptor)
+
+    assert destination_path.read_bytes() == b"abc"
+
+
+@requires_descriptor_traversal
+def test_database_context_does_not_retry_caller_enospc(tmp_path):
+    database_path = tmp_path / "programs.sqlite"
+    _create_database(database_path)
+
+    with (
+        pytest.raises(OSError, match="caller filesystem full"),
+        _handler(tmp_path)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ),
+    ):
+        raise OSError(errno.ENOSPC, "caller filesystem full")

--- a/tests/test_webui_sqlite_security.py
+++ b/tests/test_webui_sqlite_security.py
@@ -12,7 +12,6 @@ from shinka.webui.visualization import (
     PathValidationError,
 )
 
-
 requires_descriptor_traversal = pytest.mark.skipif(
     not DatabaseRequestHandler._supports_descriptor_traversal(),
     reason="database race hardening requires descriptor traversal",
@@ -171,9 +170,8 @@ def test_stable_database_connection_is_read_only(tmp_path):
     with _handler(tmp_path)._connect_database_within_root(
         database_path,
         timeout=5.0,
-    ) as connection:
-        with pytest.raises(sqlite3.OperationalError, match="readonly"):
-            connection.execute("INSERT INTO programs DEFAULT VALUES")
+    ) as connection, pytest.raises(sqlite3.OperationalError, match="readonly"):
+        connection.execute("INSERT INTO programs DEFAULT VALUES")
 
     assert database_path.read_bytes() == contents_before
     assert database_path.stat().st_mtime_ns == mtime_before
@@ -312,12 +310,14 @@ def test_database_snapshot_reports_active_rollback_journal_as_busy(
 
         monkeypatch.setattr(os, "link", reject_hardlink)
 
-        with pytest.raises(sqlite3.OperationalError, match="busy"):
-            with _handler(tmp_path)._connect_database_within_root(
+        with (
+            pytest.raises(sqlite3.OperationalError, match="busy"),
+            _handler(tmp_path)._connect_database_within_root(
                 database_path,
                 timeout=0.1,
-            ):
-                pass
+            ),
+        ):
+            pass
     finally:
         writer.rollback()
         writer.close()
@@ -380,7 +380,7 @@ def test_database_snapshot_closes_connection_when_initial_read_fails(
 
         def execute(self, statement):
             if statement == "BEGIN":
-                return None
+                return
             raise sqlite3.DatabaseError("initial read failed")
 
         def close(self):
@@ -395,12 +395,14 @@ def test_database_snapshot_closes_connection_when_initial_read_fails(
 
     monkeypatch.setattr(sqlite3, "connect", fail_staged_connect)
 
-    with pytest.raises(sqlite3.DatabaseError, match="initial read failed"):
-        with _handler(tmp_path)._connect_database_within_root(
+    with (
+        pytest.raises(sqlite3.DatabaseError, match="initial read failed"),
+        _handler(tmp_path)._connect_database_within_root(
             database_path,
             timeout=5.0,
-        ):
-            pass
+        ),
+    ):
+        pass
 
     assert staged_connection is not None
     assert staged_connection.closed
@@ -484,11 +486,13 @@ def test_database_view_rejects_main_and_sidecar_pairing_swap(tmp_path, monkeypat
 
     monkeypatch.setattr(handler, "_stage_cached_database_main", stage_then_swap)
     try:
-        with pytest.raises((PathValidationError, sqlite3.OperationalError)):
-            with handler._connect_database_within_root(
+        with (
+            pytest.raises((PathValidationError, sqlite3.OperationalError)),
+            handler._connect_database_within_root(
                 database_path,
                 timeout=5.0,
-            ):
-                pass
+            ),
+        ):
+            pass
     finally:
         replacement_writer.close()

--- a/tests/test_webui_sqlite_security.py
+++ b/tests/test_webui_sqlite_security.py
@@ -1,0 +1,494 @@
+import errno
+import os
+import shutil
+import sqlite3
+import tempfile
+
+import pytest
+
+from shinka.webui.visualization import (
+    DatabaseRequestHandler,
+    DatabaseViewRaceError,
+    PathValidationError,
+)
+
+
+requires_descriptor_traversal = pytest.mark.skipif(
+    not DatabaseRequestHandler._supports_descriptor_traversal(),
+    reason="database race hardening requires descriptor traversal",
+)
+
+
+def _handler(root):
+    handler = object.__new__(DatabaseRequestHandler)
+    handler.search_root = os.fspath(root)
+    handler._canonical_search_root = os.path.realpath(root)
+    return handler
+
+
+def _create_stats_database(path, *, program_count=0):
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE programs (
+                generation INTEGER,
+                correct INTEGER,
+                combined_score REAL,
+                timestamp REAL,
+                metadata TEXT
+            )
+            """
+        )
+        for generation in range(program_count):
+            connection.execute(
+                "INSERT INTO programs VALUES (?, 1, 1.0, 1.0, '{}')",
+                (generation,),
+            )
+
+
+@requires_descriptor_traversal
+def test_database_stats_rejects_main_database_swap_after_validation(
+    tmp_path, monkeypatch
+):
+    search_root = tmp_path / "served"
+    run_dir = search_root / "run"
+    run_dir.mkdir(parents=True)
+    programs_db = run_dir / "programs.sqlite"
+    _create_stats_database(programs_db)
+    outside_db = tmp_path / "outside.sqlite"
+    _create_stats_database(outside_db, program_count=1)
+    handler = _handler(search_root)
+    resolve_path = handler._resolve_within_root
+    swapped = False
+
+    def resolve_then_swap(path):
+        nonlocal swapped
+        resolved = resolve_path(path)
+        if not swapped and os.fspath(path).endswith("programs.sqlite"):
+            swapped = True
+            programs_db.rename(run_dir / "parked.sqlite")
+            programs_db.symlink_to(outside_db)
+        return resolved
+
+    monkeypatch.setattr(handler, "_resolve_within_root", resolve_then_swap)
+    handler.send_json_response = lambda data: None
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_database_stats("run/programs.sqlite")
+
+
+@requires_descriptor_traversal
+def test_database_stats_rejects_prompt_database_swap_after_validation(
+    tmp_path, monkeypatch
+):
+    search_root = tmp_path / "served"
+    run_dir = search_root / "run"
+    run_dir.mkdir(parents=True)
+    _create_stats_database(run_dir / "programs.sqlite")
+    prompts_db = run_dir / "prompts.sqlite"
+    with sqlite3.connect(prompts_db) as connection:
+        connection.execute("CREATE TABLE system_prompts (metadata TEXT)")
+    outside_db = tmp_path / "outside-prompts.sqlite"
+    with sqlite3.connect(outside_db) as connection:
+        connection.execute("CREATE TABLE system_prompts (metadata TEXT)")
+        connection.execute("INSERT INTO system_prompts VALUES ('{}')")
+    handler = _handler(search_root)
+    resolve_path = handler._resolve_within_root
+    swapped = False
+
+    def resolve_then_swap(path):
+        nonlocal swapped
+        resolved = resolve_path(path)
+        if not swapped and os.fspath(path).endswith("prompts.sqlite"):
+            swapped = True
+            prompts_db.rename(run_dir / "parked-prompts.sqlite")
+            prompts_db.symlink_to(outside_db)
+        return resolved
+
+    monkeypatch.setattr(handler, "_resolve_within_root", resolve_then_swap)
+    handler.send_json_response = lambda data: None
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_database_stats("run/programs.sqlite")
+
+
+@requires_descriptor_traversal
+def test_program_details_propagates_database_swap_rejection(tmp_path, monkeypatch):
+    search_root = tmp_path / "served"
+    search_root.mkdir()
+    programs_db = search_root / "programs.sqlite"
+    programs_db.write_bytes(b"inside")
+    outside_db = tmp_path / "outside.sqlite"
+    outside_db.write_bytes(b"outside")
+    handler = _handler(search_root)
+    resolve_path = handler._resolve_within_root
+    swapped = False
+
+    def resolve_then_swap(path):
+        nonlocal swapped
+        resolved = resolve_path(path)
+        if not swapped:
+            swapped = True
+            programs_db.rename(search_root / "parked.sqlite")
+            programs_db.symlink_to(outside_db)
+        return resolved
+
+    monkeypatch.setattr(handler, "_resolve_within_root", resolve_then_swap)
+
+    with pytest.raises(PathValidationError):
+        handler.handle_get_program_details("programs.sqlite", "program-1")
+
+
+@requires_descriptor_traversal
+def test_stable_database_view_reads_uncheckpointed_wal(tmp_path):
+    database_path = tmp_path / "programs.sqlite"
+    writer = sqlite3.connect(database_path)
+    try:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("CREATE TABLE programs (id INTEGER)")
+        writer.commit()
+        writer.execute("INSERT INTO programs VALUES (1)")
+        writer.commit()
+        assert (tmp_path / "programs.sqlite-wal").exists()
+
+        with _handler(tmp_path)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+    finally:
+        writer.close()
+
+
+@requires_descriptor_traversal
+def test_stable_database_connection_is_read_only(tmp_path):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path)
+    contents_before = database_path.read_bytes()
+    mtime_before = database_path.stat().st_mtime_ns
+
+    with _handler(tmp_path)._connect_database_within_root(
+        database_path,
+        timeout=5.0,
+    ) as connection:
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            connection.execute("INSERT INTO programs DEFAULT VALUES")
+
+    assert database_path.read_bytes() == contents_before
+    assert database_path.stat().st_mtime_ns == mtime_before
+
+
+@requires_descriptor_traversal
+def test_stable_database_view_retries_sidecar_rotation(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path)
+    handler = _handler(tmp_path)
+    copy_sidecar = handler._copy_optional_database_sidecar
+    attempts = 0
+
+    def race_once(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise DatabaseViewRaceError("sidecar rotated")
+        return copy_sidecar(*args, **kwargs)
+
+    monkeypatch.setattr(handler, "_copy_optional_database_sidecar", race_once)
+
+    with handler._connect_database_within_root(
+        database_path,
+        timeout=5.0,
+    ) as connection:
+        connection.execute("SELECT COUNT(*) FROM programs").fetchone()
+
+    assert attempts > 1
+
+
+@requires_descriptor_traversal
+def test_stable_database_view_supports_nondefault_filesystem():
+    shared_memory = "/dev/shm"
+    if not os.path.isdir(shared_memory) or not os.access(shared_memory, os.W_OK):
+        pytest.skip("writable secondary filesystem unavailable")
+    if os.stat(shared_memory).st_dev == os.stat(tempfile.gettempdir()).st_dev:
+        pytest.skip("secondary filesystem shares the default temp device")
+
+    with tempfile.TemporaryDirectory(dir=shared_memory) as search_root:
+        database_path = os.path.join(search_root, "programs.sqlite")
+        _create_stats_database(database_path)
+
+        with _handler(search_root)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as connection:
+            assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 0
+
+
+@requires_descriptor_traversal
+def test_stable_database_view_supports_read_only_parent(tmp_path):
+    search_root = tmp_path / "results"
+    search_root.mkdir()
+    database_path = search_root / "programs.sqlite"
+    _create_stats_database(database_path)
+    search_root.chmod(0o555)
+    try:
+        with _handler(search_root)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as connection:
+            assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 0
+        assert list(search_root.iterdir()) == [database_path]
+    finally:
+        search_root.chmod(0o755)
+
+
+@requires_descriptor_traversal
+def test_database_snapshot_supports_unavailable_hardlinks(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path, program_count=1)
+    contents_before = database_path.read_bytes()
+
+    def reject_hardlink(*args, **kwargs):
+        raise OSError(errno.EPERM, "hardlinks disabled")
+
+    monkeypatch.setattr(os, "link", reject_hardlink)
+
+    with _handler(tmp_path)._connect_database_within_root(
+        database_path,
+        timeout=5.0,
+    ) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+
+    assert database_path.read_bytes() == contents_before
+
+
+@requires_descriptor_traversal
+def test_database_snapshot_reads_wal_without_hardlinks(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    writer = sqlite3.connect(database_path)
+    try:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("PRAGMA wal_autocheckpoint = 0")
+        writer.execute("CREATE TABLE programs (id INTEGER)")
+        writer.execute("INSERT INTO programs VALUES (1)")
+        writer.commit()
+
+        def reject_hardlink(*args, **kwargs):
+            raise OSError(errno.EPERM, "hardlinks disabled")
+
+        monkeypatch.setattr(os, "link", reject_hardlink)
+
+        with _handler(tmp_path)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+    finally:
+        writer.close()
+
+
+@requires_descriptor_traversal
+def test_database_snapshot_reports_active_rollback_journal_as_busy(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    writer = sqlite3.connect(database_path, isolation_level=None)
+    try:
+        writer.execute("PRAGMA journal_mode = DELETE")
+        writer.execute("PRAGMA cache_size = 5")
+        writer.execute("CREATE TABLE programs (value BLOB)")
+        writer.executemany(
+            "INSERT INTO programs VALUES (?)",
+            [(b"a" * 3000,) for _ in range(100)],
+        )
+        writer.execute("BEGIN IMMEDIATE")
+        writer.execute("UPDATE programs SET value = ?", (b"b" * 3000,))
+        assert (tmp_path / "programs.sqlite-journal").exists()
+
+        def reject_hardlink(*args, **kwargs):
+            raise OSError(errno.EPERM, "hardlinks disabled")
+
+        monkeypatch.setattr(os, "link", reject_hardlink)
+
+        with pytest.raises(sqlite3.OperationalError, match="busy"):
+            with _handler(tmp_path)._connect_database_within_root(
+                database_path,
+                timeout=0.1,
+            ):
+                pass
+    finally:
+        writer.rollback()
+        writer.close()
+
+
+@requires_descriptor_traversal
+def test_database_snapshot_accepts_idle_persist_journal(tmp_path):
+    database_path = tmp_path / "programs.sqlite"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute("PRAGMA journal_mode = PERSIST")
+        connection.execute("CREATE TABLE programs (id INTEGER)")
+        connection.execute("INSERT INTO programs VALUES (1)")
+        connection.commit()
+    assert (tmp_path / "programs.sqlite-journal").exists()
+
+    with _handler(tmp_path)._connect_database_within_root(
+        database_path,
+        timeout=5.0,
+    ) as reader:
+        assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+
+
+@requires_descriptor_traversal
+def test_database_main_snapshot_is_reused_between_polls(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path, program_count=1)
+    handler = _handler(tmp_path)
+    copy_database_descriptor = handler._copy_database_descriptor
+    main_copies = 0
+
+    def count_main_copies(*args, **kwargs):
+        nonlocal main_copies
+        if args[2] == "database.sqlite":
+            main_copies += 1
+        return copy_database_descriptor(*args, **kwargs)
+
+    monkeypatch.setattr(handler, "_copy_database_descriptor", count_main_copies)
+
+    for _ in range(2):
+        with handler._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as connection:
+            assert connection.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 1
+
+    assert main_copies == 1
+
+
+@requires_descriptor_traversal
+def test_database_snapshot_closes_connection_when_initial_read_fails(
+    tmp_path, monkeypatch
+):
+    database_path = tmp_path / "programs.sqlite"
+    _create_stats_database(database_path)
+    real_connect = sqlite3.connect
+    staged_connection = None
+
+    class FailingConnection:
+        closed = False
+
+        def execute(self, statement):
+            if statement == "BEGIN":
+                return None
+            raise sqlite3.DatabaseError("initial read failed")
+
+        def close(self):
+            self.closed = True
+
+    def fail_staged_connect(database, *args, **kwargs):
+        nonlocal staged_connection
+        if "shinka-webui-db-" not in os.fspath(database):
+            return real_connect(database, *args, **kwargs)
+        staged_connection = FailingConnection()
+        return staged_connection
+
+    monkeypatch.setattr(sqlite3, "connect", fail_staged_connect)
+
+    with pytest.raises(sqlite3.DatabaseError, match="initial read failed"):
+        with _handler(tmp_path)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ):
+            pass
+
+    assert staged_connection is not None
+    assert staged_connection.closed
+
+
+@requires_descriptor_traversal
+def test_database_view_retries_rotation_before_sqlite_connect(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    writer = sqlite3.connect(database_path)
+    writer.execute("PRAGMA journal_mode = WAL")
+    writer.execute("PRAGMA wal_autocheckpoint = 0")
+    writer.execute("CREATE TABLE programs (id INTEGER)")
+    writer.execute("INSERT INTO programs VALUES (1)")
+    writer.commit()
+    original_connect = sqlite3.connect
+    replacement_writers = []
+    staged_connections = 0
+
+    def rotate_before_first_staged_connect(database, *args, **kwargs):
+        nonlocal staged_connections, writer
+        if "shinka-webui-db-" in os.fspath(database):
+            staged_connections += 1
+            if staged_connections == 1:
+                writer.close()
+                replacement = original_connect(database_path)
+                replacement.execute("PRAGMA journal_mode = WAL")
+                replacement.execute("PRAGMA wal_autocheckpoint = 0")
+                replacement.execute("INSERT INTO programs VALUES (2)")
+                replacement.commit()
+                replacement_writers.append(replacement)
+        return original_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", rotate_before_first_staged_connect)
+    try:
+        with _handler(tmp_path)._connect_database_within_root(
+            database_path,
+            timeout=5.0,
+        ) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM programs").fetchone()[0] == 2
+        assert staged_connections == 2
+    finally:
+        for replacement in replacement_writers:
+            replacement.close()
+        if not replacement_writers:
+            writer.close()
+
+
+@requires_descriptor_traversal
+def test_database_view_rejects_main_and_sidecar_pairing_swap(tmp_path, monkeypatch):
+    database_path = tmp_path / "programs.sqlite"
+    with sqlite3.connect(database_path) as writer:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("CREATE TABLE programs (value INTEGER)")
+        writer.execute("INSERT INTO programs VALUES (111)")
+        writer.commit()
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    replacement_path = tmp_path / "replacement.sqlite"
+    shutil.copyfile(database_path, replacement_path)
+    replacement_writer = sqlite3.connect(replacement_path)
+    replacement_writer.execute("PRAGMA journal_mode = WAL")
+    replacement_writer.execute("PRAGMA wal_autocheckpoint = 0")
+    replacement_writer.execute("UPDATE programs SET value = 999")
+    replacement_writer.commit()
+
+    handler = _handler(tmp_path)
+    stage_cached_database_main = handler._stage_cached_database_main
+    swapped = False
+
+    def stage_then_swap(*args, **kwargs):
+        nonlocal swapped
+        stage_cached_database_main(*args, **kwargs)
+        if not swapped:
+            swapped = True
+            os.replace(replacement_path, database_path)
+            for suffix in ("-wal", "-shm"):
+                os.replace(
+                    os.fspath(replacement_path) + suffix,
+                    os.fspath(database_path) + suffix,
+                )
+
+    monkeypatch.setattr(handler, "_stage_cached_database_main", stage_then_swap)
+    try:
+        with pytest.raises((PathValidationError, sqlite3.OperationalError)):
+            with handler._connect_database_within_root(
+                database_path,
+                timeout=5.0,
+            ):
+                pass
+    finally:
+        replacement_writer.close()

--- a/tests/test_webui_sqlite_windows.py
+++ b/tests/test_webui_sqlite_windows.py
@@ -1,0 +1,48 @@
+import pytest
+
+from shinka.webui.visualization import DatabaseRequestHandler, PathValidationError
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_target"),
+    [
+        (
+            r"C:\Users\Rob Lange\programs.sqlite",
+            ("file:///C:/Users/Rob%20Lange/programs.sqlite?mode=ro", True),
+        ),
+        (
+            r"\\server\results\programs.sqlite",
+            ("file:////server/results/programs.sqlite?mode=ro", True),
+        ),
+        (
+            r"\\?\C:\results\programs.sqlite",
+            ("file:///C:/results/programs.sqlite?mode=ro", True),
+        ),
+        (
+            r"\\?\UNC\server\results\programs #1.sqlite",
+            (
+                "file:////server/results/programs%20%231.sqlite?mode=ro",
+                True,
+            ),
+        ),
+        (
+            r"\\?\unc\server\results\programs.sqlite",
+            ("file:////server/results/programs.sqlite?mode=ro", True),
+        ),
+    ],
+)
+def test_sqlite_read_only_target_supports_windows_paths(path, expected_target):
+    assert DatabaseRequestHandler._sqlite_read_only_target(path) == expected_target
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        r"\\.\C:\results\programs.sqlite",
+        r"\\?\GLOBALROOT\Device\HarddiskVolume1\programs.sqlite",
+        r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\programs.sqlite",
+    ],
+)
+def test_sqlite_read_only_target_rejects_device_namespaces(path):
+    with pytest.raises(PathValidationError, match="device paths"):
+        DatabaseRequestHandler._sqlite_read_only_target(path)


### PR DESCRIPTION
## What changed
- Restrict server binding, CORS behavior, and request path handling.
- Constrain database, metadata, PDF, and plot paths to the configured search root.
- Add traversal regressions through the HTTP boundary.

## Review scope
Security-boundary extraction from #151. Based directly on #150.

## Verification
- Focused WebUI security tests
- Ruff, Mypy, Bandit
- Integrated 876-test gate

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.