### PR TITLE
fix(launch): secure evaluation environments

### DIFF
--- a/shinka/core/wrap_eval.py
+++ b/shinka/core/wrap_eval.py
@@ -25,7 +25,14 @@ DEFAULT_METRICS_ON_ERROR = {
 
 
 def load_program(program_path: str) -> Any:
-    """Loads a Python module dynamically from a given file path."""
+    """Loads a Python module dynamically from a given file path.
+
+    Security note: ``program_path`` points at LLM-generated code, and importing
+    it executes it in-process with no sandbox. Run evolution only with models
+    and initial programs you trust, or use an isolated eval (Docker/Slurm). The
+    local launcher honours ``SHINKA_STRIP_EVAL_SECRETS=1`` to withhold provider
+    credentials from the eval subprocess (see shinka.launch.local).
+    """
     spec = importlib.util.spec_from_file_location("program", program_path)
     if spec is None:
         raise ImportError(f"Could not load spec for module at {program_path}")

--- a/shinka/env.py
+++ b/shinka/env.py
@@ -23,6 +23,10 @@ def load_shinka_dotenv(
         env_paths.append(launch_env)
 
     for env_path in env_paths:
-        load_dotenv(dotenv_path=env_path, override=True)
+        # The package-dir .env fills gaps only (override=False) so a stray or
+        # shipped .env cannot silently shadow the operator's real environment.
+        # The launch-dir .env keeps its intended precedence (override=True).
+        override = env_path == launch_env
+        load_dotenv(dotenv_path=env_path, override=override)
 
     return tuple(env_paths)

--- a/shinka/launch/local.py
+++ b/shinka/launch/local.py
@@ -10,6 +10,48 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Environment variable name-parts that identify provider credentials. A local
+# evaluation runs LLM-generated program code with no isolation, inheriting the
+# parent environment; when SHINKA_STRIP_EVAL_SECRETS is truthy these are removed
+# so an adversarial/prompt-injected program cannot read the operator's keys.
+_SECRET_NAME_MARKERS = (
+    "API_KEY",
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "OPENAI",
+    "ANTHROPIC",
+    "GEMINI",
+    "DEEPSEEK",
+    "AZURE",
+    "AWS_",
+    "HUGGINGFACE",
+    "WANDB",
+    "XAI",
+    "GROQ",
+    "MISTRAL",
+    "COHERE",
+    "OPENROUTER",
+)
+
+
+def _should_strip_eval_secrets() -> bool:
+    return os.environ.get("SHINKA_STRIP_EVAL_SECRETS", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _strip_provider_secrets(env: Dict[str, str]) -> Dict[str, str]:
+    """Drop provider-credential variables from an environment mapping."""
+    return {
+        key: value
+        for key, value in env.items()
+        if not any(marker in key.upper() for marker in _SECRET_NAME_MARKERS)
+    }
+
 
 class ProcessWithLogging:
     """Wrapper for subprocess.Popen with real-time logging capabilities."""
@@ -113,8 +155,14 @@ def submit(
     stdout_path = log_dir_path / "job_log.out"
     stderr_path = log_dir_path / "job_log.err"
 
-    # Set up environment to force unbuffered output
+    # Set up environment to force unbuffered output. The evaluated program is
+    # LLM-generated and runs unsandboxed here, inheriting this environment; set
+    # SHINKA_STRIP_EVAL_SECRETS=1 to withhold provider credentials from it.
+    # Explicit env_overrides are applied AFTER stripping so an eval that needs a
+    # key (e.g. an LLM judge) can still be given one deliberately.
     env = os.environ.copy()
+    if _should_strip_eval_secrets():
+        env = _strip_provider_secrets(env)
     env["PYTHONUNBUFFERED"] = "1"  # Force Python to be unbuffered
     env["PYTHONIOENCODING"] = "utf-8"  # Ensure proper encoding
     if env_overrides:

--- a/shinka/launch/slurm.py
+++ b/shinka/launch/slurm.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import shlex
 import subprocess
 import tempfile
 import time
@@ -17,14 +18,18 @@ def _render_env_exports(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as newline-joined ``export K=V`` lines for a script."""
     if not eval_env:
         return ""
-    return "\n".join(f"export {k}={v}" for k, v in eval_env.items())
+    # shlex.quote the value so a value containing spaces/;/$(...) cannot inject
+    # extra shell commands when this string is spliced into a bash script.
+    return "\n".join(f"export {k}={shlex.quote(str(v))}" for k, v in eval_env.items())
 
 
 def _render_env_docker_flags(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as space-joined ``-e K=V`` flags for ``docker run``."""
     if not eval_env:
         return ""
-    return " ".join(f"-e {k}={v}" for k, v in eval_env.items())
+    return " ".join(
+        f"-e {shlex.quote(f'{k}={v}')}" for k, v in eval_env.items()
+    )
 
 
 # Configuration for Docker image caching
@@ -480,7 +485,9 @@ def submit_local_conda(
         activate_script=activate_script,
         separator="; ",
     )
-    env_exports = "; ".join(f"export {k}={v}" for k, v in (eval_env or {}).items())
+    env_exports = "; ".join(
+        f"export {k}={shlex.quote(str(v))}" for k, v in (eval_env or {}).items()
+    )
     full_cmd = "; ".join(
         segment
         for segment in [

--- a/shinka/launch/slurm.py
+++ b/shinka/launch/slurm.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import re
 import shlex
 import subprocess
 import tempfile
@@ -13,22 +14,30 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_ENV_NAME_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _validated_env_items(eval_env: Optional[Dict[str, str]]):
+    for key, value in (eval_env or {}).items():
+        name = str(key)
+        if _ENV_NAME_PATTERN.fullmatch(name) is None:
+            raise ValueError(f"Invalid environment variable name: {name!r}")
+        yield name, value
+
 
 def _render_env_exports(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as newline-joined ``export K=V`` lines for a script."""
-    if not eval_env:
-        return ""
-    # shlex.quote the value so a value containing spaces/;/$(...) cannot inject
-    # extra shell commands when this string is spliced into a bash script.
-    return "\n".join(f"export {k}={shlex.quote(str(v))}" for k, v in eval_env.items())
+    return "\n".join(
+        f"export {name}={shlex.quote(str(value))}"
+        for name, value in _validated_env_items(eval_env)
+    )
 
 
 def _render_env_docker_flags(eval_env: Optional[Dict[str, str]]) -> str:
     """Render an env dict as space-joined ``-e K=V`` flags for ``docker run``."""
-    if not eval_env:
-        return ""
     return " ".join(
-        f"-e {shlex.quote(f'{k}={v}')}" for k, v in eval_env.items()
+        f"-e {shlex.quote(f'{name}={value}')}"
+        for name, value in _validated_env_items(eval_env)
     )
 
 
@@ -485,9 +494,7 @@ def submit_local_conda(
         activate_script=activate_script,
         separator="; ",
     )
-    env_exports = "; ".join(
-        f"export {k}={shlex.quote(str(v))}" for k, v in (eval_env or {}).items()
-    )
+    env_exports = _render_env_exports(eval_env).replace("\n", "; ")
     full_cmd = "; ".join(
         segment
         for segment in [

--- a/tests/test_dotenv_loading.py
+++ b/tests/test_dotenv_loading.py
@@ -61,3 +61,23 @@ def test_load_shinka_dotenv_prefers_launch_directory_over_package_env(
     load_shinka_dotenv(package_root=package_root, cwd=launch_dir)
 
     assert os.getenv(env_key) == "from-launch-dir"
+
+
+def test_package_env_does_not_shadow_real_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A package-dir .env must not override a variable set in the real env."""
+    from shinka.env import load_shinka_dotenv
+
+    env_key = "SHINKA_TEST_SHELL_PRECEDENCE_KEY"
+    package_root = tmp_path / "package-root"
+    launch_dir = tmp_path / "launch-dir"
+    package_root.mkdir()
+    launch_dir.mkdir()
+    (package_root / ".env").write_text(f"{env_key}=from-package\n", encoding="utf-8")
+    # No launch-dir .env; the real environment already sets the key.
+    monkeypatch.setenv(env_key, "from-shell")
+
+    load_shinka_dotenv(package_root=package_root, cwd=launch_dir)
+
+    assert os.getenv(env_key) == "from-shell"

--- a/tests/test_launch_job_status.py
+++ b/tests/test_launch_job_status.py
@@ -119,6 +119,22 @@ def test_env_exports_shell_quote_injection():
     assert flags == "-e 'BAR=b $(whoami)'"
 
 
+@pytest.mark.parametrize(
+    "renderer",
+    [
+        pytest.param("exports", id="shell-exports"),
+        pytest.param("docker", id="docker-flags"),
+    ],
+)
+def test_env_renderers_reject_shell_metacharacters_in_names(renderer):
+    from shinka.launch.slurm import _render_env_docker_flags, _render_env_exports
+
+    render = _render_env_exports if renderer == "exports" else _render_env_docker_flags
+
+    with pytest.raises(ValueError, match="Invalid environment variable name"):
+        render({"SAFE; touch /tmp/injected; #": "value"})
+
+
 def test_strip_provider_secrets_opt_in(monkeypatch):
     """SHINKA_STRIP_EVAL_SECRETS removes provider credentials from eval env."""
     from shinka.launch.local import (

--- a/tests/test_launch_job_status.py
+++ b/tests/test_launch_job_status.py
@@ -157,3 +157,49 @@ def test_strip_provider_secrets_opt_in(monkeypatch):
     assert _should_strip_eval_secrets() is False
     monkeypatch.setenv("SHINKA_STRIP_EVAL_SECRETS", "1")
     assert _should_strip_eval_secrets() is True
+
+
+def test_local_submit_strips_inherited_secrets_then_applies_overrides(
+    monkeypatch, tmp_path
+):
+    from shinka.launch import local
+
+    captured = {}
+
+    class FakeProcess:
+        pid = 123
+        returncode = None
+        stdout = object()
+        stderr = object()
+
+    class FakeThread:
+        def __init__(self, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    def popen(command, **kwargs):
+        captured.update(kwargs["env"])
+        return FakeProcess()
+
+    monkeypatch.setenv("SHINKA_STRIP_EVAL_SECRETS", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "inherited-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "inherited-openai")
+    monkeypatch.setenv("SAFE_SETTING", "preserved")
+    monkeypatch.setattr(local.subprocess, "Popen", popen)
+    monkeypatch.setattr(local.threading, "Thread", FakeThread)
+
+    process = local.submit(
+        str(tmp_path),
+        ["python", "evaluate.py"],
+        env_overrides={"OPENAI_API_KEY": "explicit-openai"},
+    )
+    process.cleanup_logging()
+
+    assert "ANTHROPIC_API_KEY" not in captured
+    assert captured["OPENAI_API_KEY"] == "explicit-openai"
+    assert captured["SAFE_SETTING"] == "preserved"

--- a/tests/test_launch_job_status.py
+++ b/tests/test_launch_job_status.py
@@ -105,3 +105,39 @@ def test_kill_terminates_child_process_group(tmp_path):
         time.sleep(0.05)
     else:
         pytest.fail("grandchild survived process-group kill")
+
+
+def test_env_exports_shell_quote_injection():
+    """A malicious eval_env value must be shell-quoted, not spliced as commands."""
+    from shinka.launch.slurm import _render_env_exports, _render_env_docker_flags
+
+    exports = _render_env_exports({"FOO": "a; rm -rf /tmp/x"})
+    # The dangerous ';' is inside a single-quoted value, not a command separator.
+    assert exports == "export FOO='a; rm -rf /tmp/x'"
+
+    flags = _render_env_docker_flags({"BAR": "b $(whoami)"})
+    assert flags == "-e 'BAR=b $(whoami)'"
+
+
+def test_strip_provider_secrets_opt_in(monkeypatch):
+    """SHINKA_STRIP_EVAL_SECRETS removes provider credentials from eval env."""
+    from shinka.launch.local import (
+        _strip_provider_secrets,
+        _should_strip_eval_secrets,
+    )
+
+    env = {
+        "PATH": "/usr/bin",
+        "OPENAI_API_KEY": "sk-secret",
+        "ANTHROPIC_API_KEY": "sk-ant",
+        "AWS_SECRET_ACCESS_KEY": "aws",
+        "HF_TOKEN": "hf",
+        "CUDA_VISIBLE_DEVICES": "0",
+    }
+    stripped = _strip_provider_secrets(env)
+    assert stripped == {"PATH": "/usr/bin", "CUDA_VISIBLE_DEVICES": "0"}
+
+    monkeypatch.delenv("SHINKA_STRIP_EVAL_SECRETS", raising=False)
+    assert _should_strip_eval_secrets() is False
+    monkeypatch.setenv("SHINKA_STRIP_EVAL_SECRETS", "1")
+    assert _should_strip_eval_secrets() is True


### PR DESCRIPTION
## What changed
- Quote generated shell commands safely.
- Strip inherited secrets while preserving explicit environment overrides.
- Reject unsafe environment-variable names.
- Cover local and scheduler launch paths.

## Review scope
Launch/environment extraction from #151. Based directly on #150.

## Verification
- 12 focused launch tests
- Ruff, Mypy, Bandit
- Integrated 876-test gate

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.