### PR TITLE
perf(db): remove generation hot-path scans

### DIFF
--- a/shinka/core/async_novelty_judge.py
+++ b/shinka/core/async_novelty_judge.py
@@ -91,9 +91,11 @@ class AsyncNoveltyJudge:
                 return True, novelty_metadata
 
             loop = asyncio.get_event_loop()
-            similarity_scores = await loop.run_in_executor(
+            # One thread-safe scan returns both the scores and the most similar
+            # program, replacing two full island scans per candidate.
+            similarity_scores, most_similar_program = await loop.run_in_executor(
                 None,
-                db.compute_similarity_thread_safe,
+                db.compute_similarity_details_thread_safe,
                 code_embedding,
                 parent_program.island_idx,
             )
@@ -127,15 +129,7 @@ class AsyncNoveltyJudge:
             novelty_cost = 0.0
 
             if self.async_llm_client is not None:
-                # Get the most similar program for LLM comparison (thread-safe)
-                loop = asyncio.get_event_loop()
-                most_similar_program = await loop.run_in_executor(
-                    None,
-                    db.get_most_similar_program_thread_safe,
-                    code_embedding,
-                    parent_program.island_idx,
-                )
-
+                # most_similar_program already fetched in the single scan above.
                 if most_similar_program:
                     try:
                         # Read the current proposed code

--- a/shinka/core/novelty_judge.py
+++ b/shinka/core/novelty_judge.py
@@ -85,9 +85,12 @@ class NoveltyJudge:
         }
 
         for attempt in range(self.max_novelty_attempts):
-            # Compute similarities with programs in island
-            similarity_scores = database.compute_similarity(
-                code_embedding, parent_program.island_idx
+            # One island scan yields both the similarity scores and the most
+            # similar program (used below), instead of scanning the island twice.
+            similarity_scores, most_similar_program = (
+                database.compute_similarity_details(
+                    code_embedding, parent_program.island_idx
+                )
             )
 
             if not similarity_scores:
@@ -120,11 +123,7 @@ class NoveltyJudge:
             novelty_cost = 0.0
 
             if self.novelty_llm_client is not None:
-                # Get the most similar program for LLM comparison
-                most_similar_program = database.get_most_similar_program(
-                    code_embedding, parent_program.island_idx
-                )
-
+                # most_similar_program already fetched in the single scan above.
                 if most_similar_program:
                     try:
                         # Read the current proposed code

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -463,6 +463,14 @@ class ProgramDatabase:
             "programs(island_idx)",
             "CREATE INDEX IF NOT EXISTS idx_programs_system_prompt_id ON "
             "programs(system_prompt_id)",
+            # combined_score and correct are the two most-filtered/sorted columns
+            # (top-N, elites, island aggregates). These composite indexes turn
+            # the per-generation "WHERE correct=1 ORDER BY combined_score" scans
+            # into index range scans and cover the island-sampler aggregates.
+            "CREATE INDEX IF NOT EXISTS idx_programs_correct_score ON "
+            "programs(correct, combined_score)",
+            "CREATE INDEX IF NOT EXISTS idx_programs_island_correct_score ON "
+            "programs(island_idx, correct, combined_score)",
         ]
         for cmd in idx_cmds:
             self.cursor.execute(cmd)

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -2514,6 +2514,85 @@ class ProgramDatabase:
         similarity = np.dot(arr1, arr2) / (norm_a * norm_b)
         return float(similarity)
 
+    def _scan_island_similarities(
+        self, cursor, code_embedding: List[float], island_idx: int
+    ) -> Tuple[List[float], Optional[str]]:
+        """Single scan over an island: return (scores, id_of_most_similar).
+
+        Combines what compute_similarity and get_most_similar_program each did
+        with a full independent scan, so the novelty check no longer walks the
+        whole island twice (and re-parses every embedding twice) per candidate.
+        """
+        cursor.execute(
+            "SELECT id, embedding FROM programs WHERE island_idx = ? "
+            "AND embedding IS NOT NULL AND embedding != '[]'",
+            (island_idx,),
+        )
+        rows = cursor.fetchall()
+        scores: List[float] = []
+        best_sim = -1.0
+        best_id: Optional[str] = None
+        for row in rows:
+            rid = row["id"]
+            try:
+                embedding = json.loads(row["embedding"])
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(f"Could not decode embedding for program {rid}")
+                scores.append(0.0)
+                continue
+            sim = self._cosine_similarity(code_embedding, embedding) if embedding else 0.0
+            scores.append(sim)
+            if sim > best_sim:
+                best_sim = sim
+                best_id = rid
+        return scores, best_id
+
+    def compute_similarity_details(
+        self, code_embedding: List[float], island_idx: int
+    ) -> Tuple[List[float], Optional["Program"]]:
+        """Return (similarity_scores, most_similar_program) in one island scan."""
+        if not self.cursor:
+            raise ConnectionError("DB not connected.")
+        if not code_embedding:
+            return [], None
+        scores, best_id = self._scan_island_similarities(
+            self.cursor, code_embedding, island_idx
+        )
+        program = self.get(best_id) if best_id is not None else None
+        return scores, program
+
+    @db_retry()
+    def compute_similarity_details_thread_safe(
+        self, code_embedding: List[float], island_idx: int
+    ) -> Tuple[List[float], Optional["Program"]]:
+        """Thread-safe single-scan returning (scores, most_similar_program).
+
+        Uses one connection for both the island scan and the single-row fetch of
+        the winner, so the async novelty path no longer scans the island twice.
+        """
+        if not code_embedding:
+            return [], None
+        conn = None
+        try:
+            conn = sqlite3.connect(
+                self.config.db_path, check_same_thread=False, timeout=60.0
+            )
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            scores, best_id = self._scan_island_similarities(
+                cursor, code_embedding, island_idx
+            )
+            program = None
+            if best_id is not None:
+                cursor.execute("SELECT * FROM programs WHERE id = ?", (best_id,))
+                row = cursor.fetchone()
+                if row:
+                    program = self._program_from_row(row)
+            return scores, program
+        finally:
+            if conn:
+                conn.close()
+
     @db_retry()
     def compute_similarity_thread_safe(
         self, vec: List[float], island_idx: int

--- a/shinka/database/inspirations.py
+++ b/shinka/database/inspirations.py
@@ -36,6 +36,15 @@ class ContextSelectorStrategy(ABC):
 class ArchiveInspirationSelector(ContextSelectorStrategy):
     """Strategy for selecting archive inspirations."""
 
+    def _row_to_program(self, row: sqlite3.Row) -> Any:
+        """Build a Program from a full row, avoiding a per-id follow-up query.
+
+        Falls back to get_program() only if no row converter was provided.
+        """
+        if self.program_from_row is not None:
+            return self.program_from_row(row)
+        return self.get_program(row["id"])
+
     def sample_context(self, parent: Any, n: int) -> List[Any]:
         """Sample archive inspirations based on elites, best program, and random selection."""
         if n <= 0:
@@ -71,7 +80,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
         if num_elites > 0 and len(inspirations) < n and parent_island_idx is not None:
             self.cursor.execute(
                 """
-                SELECT p.id FROM programs p
+                SELECT p.* FROM programs p
                 JOIN archive a ON p.id = a.program_id
                 WHERE p.island_idx = ? AND p.correct = 1
                 ORDER BY p.combined_score DESC
@@ -82,7 +91,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
             for row in self.cursor.fetchall():
                 if len(inspirations) >= n:
                     break
-                prog = self.get_program(row["id"])
+                prog = self._row_to_program(row)
                 if prog and prog.id not in insp_ids:
                     inspirations.append(prog)
                     insp_ids.add(prog.id)
@@ -93,7 +102,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
             if needed > 0:
                 placeholders_rand = ",".join("?" * len(insp_ids))
                 sql_rand = f"""
-                    SELECT p.id FROM programs p
+                    SELECT p.* FROM programs p
                     JOIN archive a ON p.id = a.program_id
                     WHERE p.island_idx = ? AND p.correct = 1
                     AND p.id NOT IN ({placeholders_rand})
@@ -103,7 +112,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
 
                 self.cursor.execute(sql_rand, params_rand)
                 for row in self.cursor.fetchall():
-                    prog = self.get_program(row["id"])
+                    prog = self._row_to_program(row)
                     if prog:  # id is already not in insp_ids from query
                         inspirations.append(prog)
 
@@ -113,7 +122,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
             needed = n - len(inspirations)
             if needed > 0:
                 placeholders_rand = ",".join("?" * len(insp_ids))
-                sql_rand = f"""SELECT p.id FROM programs p
+                sql_rand = f"""SELECT p.* FROM programs p
                                  JOIN archive a ON p.id = a.program_id
                                  WHERE p.correct = 1
                                  AND p.id NOT IN ({placeholders_rand})
@@ -122,7 +131,7 @@ class ArchiveInspirationSelector(ContextSelectorStrategy):
                 params_rand = list(insp_ids) + [needed]
                 self.cursor.execute(sql_rand, params_rand)
                 for row in self.cursor.fetchall():
-                    prog = self.get_program(row["id"])
+                    prog = self._row_to_program(row)
                     if prog:
                         inspirations.append(prog)
 

--- a/tests/test_db_indexes.py
+++ b/tests/test_db_indexes.py
@@ -1,0 +1,55 @@
+"""Regression tests for the performance indexes on the programs table."""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(pid: str, score: float, correct: bool = True) -> Program:
+    return Program(
+        id=pid,
+        code="def f():\n    return 1\n",
+        correct=correct,
+        combined_score=score,
+        generation=0,
+        island_idx=0,
+    )
+
+
+def test_score_indexes_exist():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "idx.db"
+        ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+
+        conn = sqlite3.connect(str(db_path))
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        conn.close()
+        assert "idx_programs_correct_score" in names
+        assert "idx_programs_island_correct_score" in names
+
+
+def test_top_programs_query_uses_score_index():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "plan.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        for i in range(5):
+            db.add(_program(f"p{i}", float(i)))
+
+        conn = sqlite3.connect(str(db_path))
+        plan = conn.execute(
+            "EXPLAIN QUERY PLAN SELECT id FROM programs "
+            "WHERE combined_score IS NOT NULL AND correct = 1 "
+            "ORDER BY combined_score DESC LIMIT 3"
+        ).fetchall()
+        conn.close()
+        plan_text = " ".join(str(row) for row in plan)
+        # The planner should use an index rather than scanning + sorting.
+        assert "idx_programs_correct_score" in plan_text
+        assert "SCAN programs" not in plan_text

--- a/tests/test_inspiration_nplus1.py
+++ b/tests/test_inspiration_nplus1.py
@@ -1,0 +1,48 @@
+"""Functional test for the single-query archive-inspiration sampling.
+
+The archive/random inspiration loops now fetch full rows (SELECT p.*) and build
+Program objects directly instead of issuing a per-id follow-up query. This
+verifies the sampled inspirations still come back as fully-populated programs.
+"""
+
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(pid: str, score: float, island: int = 0) -> Program:
+    return Program(
+        id=pid,
+        code=f"# code for {pid}\ndef f():\n    return {score}\n",
+        correct=True,
+        combined_score=score,
+        generation=int(score),
+        island_idx=island,
+        embedding=[score, score + 1.0],
+    )
+
+
+def test_sample_returns_fully_populated_inspirations():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "insp.db"
+        config = DatabaseConfig(
+            db_path=str(db_path),
+            num_islands=1,
+            num_archive_inspirations=2,
+            num_top_k_inspirations=1,
+            elite_selection_ratio=0.5,
+            enforce_island_separation=False,
+        )
+        db = ProgramDatabase(config=config)
+        for i in range(6):
+            db.add(_program(f"p{i}", float(i)))
+
+        parent, archive_insp, topk_insp = db.sample()
+
+        # Inspirations must be real, fully-hydrated Program objects (code + id),
+        # proving the SELECT p.* + program_from_row path works end to end.
+        for prog in archive_insp + topk_insp:
+            assert isinstance(prog, Program)
+            assert prog.id
+            assert prog.code and prog.code.startswith("# code for")

--- a/tests/test_novelty_judge.py
+++ b/tests/test_novelty_judge.py
@@ -58,6 +58,11 @@ class DummyDatabase:
             return self._similarity_sequences[0]
         return self._similarity_sequences.pop(0)
 
+    def compute_similarity_details(self, code_embedding, island_idx):
+        return self.compute_similarity(code_embedding, island_idx), (
+            self.most_similar_program
+        )
+
     def get_most_similar_program(self, code_embedding, island_idx):
         return self.most_similar_program
 

--- a/tests/test_similarity_single_scan.py
+++ b/tests/test_similarity_single_scan.py
@@ -1,0 +1,63 @@
+"""The single-pass similarity scan must match the old two-method behavior."""
+
+import tempfile
+from pathlib import Path
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(pid: str, emb, island: int = 0) -> Program:
+    return Program(
+        id=pid,
+        code=f"# {pid}\n",
+        correct=True,
+        combined_score=1.0,
+        generation=0,
+        island_idx=island,
+        embedding=emb,
+    )
+
+
+def test_details_match_legacy_methods():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "sim.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        db.add(_program("a", [1.0, 0.0, 0.0]))
+        db.add(_program("b", [0.9, 0.1, 0.0]))
+        db.add(_program("c", [0.0, 1.0, 0.0]))
+
+        query = [1.0, 0.05, 0.0]
+
+        legacy_scores = db.compute_similarity(query, 0)
+        legacy_best = db.get_most_similar_program(query, 0)
+
+        scores, best = db.compute_similarity_details(query, 0)
+
+        assert scores == legacy_scores
+        assert best is not None and legacy_best is not None
+        assert best.id == legacy_best.id
+        # "a" (unit x-axis) is closest to the query.
+        assert best.id == "a"
+
+
+def test_details_thread_safe_matches():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "sim_ts.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        db.add(_program("a", [1.0, 0.0]))
+        db.add(_program("b", [0.0, 1.0]))
+
+        query = [0.1, 1.0]
+        scores, best = db.compute_similarity_details_thread_safe(query, 0)
+        assert len(scores) == 2
+        assert best is not None and best.id == "b"
+
+
+def test_details_empty_embedding_returns_empty():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "sim_empty.db"
+        db = ProgramDatabase(config=DatabaseConfig(db_path=str(db_path), num_islands=1))
+        db.add(_program("a", [1.0, 0.0]))
+        scores, best = db.compute_similarity_details([], 0)
+        assert scores == []
+        assert best is None


### PR DESCRIPTION
## What changed
- Add focused database indexes.
- Replace repeated generation scans and N+1 lookups with bounded queries.
- Preserve existing selection and persistence behavior with regressions.

## Review scope
Database-only performance extraction from #152. Based directly on #150.

## Verification
- 12 focused database tests
- Ruff and Mypy
- Integrated 876-test gate

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.