### PR TITLE
perf(webui): reduce polling and response work

### DIFF
--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -281,6 +281,39 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         finally:
             conn.close()
 
+    def _failed_proposal_count_and_timestamp(
+        self, cursor
+    ) -> Tuple[int, Optional[float]]:
+        """Aggregate failed-proposal stats for lightweight change detection.
+
+        Returns ``(count, max_timestamp)`` where ``count`` is the number of
+        distinct generations that recorded a failed proposal (mirroring the
+        per-generation dedup in ``_load_failed_proposal_nodes``) and
+        ``max_timestamp`` is the newest ``created_at`` among them. Uses a single
+        aggregate query and never opens failure JSON files from disk, so it is
+        cheap enough for the frequent change-detection poll. A missing
+        ``attempt_log`` table yields ``(0, None)`` instead of an error.
+        """
+        try:
+            cursor.execute(
+                """
+                SELECT COUNT(DISTINCT generation) AS count,
+                       MAX(created_at) AS max_timestamp
+                FROM attempt_log
+                WHERE status = 'failed'
+                  AND json_valid(details)
+                  AND json_extract(details, '$.node_kind') = 'failed_proposal'
+                """
+            )
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return 0, None
+            raise
+        row = cursor.fetchone()
+        if not row:
+            return 0, None
+        return int(row["count"] or 0), row["max_timestamp"]
+
     # Host header values allowed when the server is bound to loopback. Overwritten
     # per-instance via the handler factory when an explicit external host is used.
     allowed_hosts = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
@@ -320,7 +353,12 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         if path == "/get_programs" and "db_path" in query:
             db_path = query["db_path"][0]
-            return self.handle_get_programs(db_path)
+            return self.handle_get_programs(
+                db_path,
+                limit=self._parse_int_param(query, "limit"),
+                offset=self._parse_int_param(query, "offset"),
+                include_code=self._parse_bool_param(query, "include_code", True),
+            )
 
         if path == "/get_programs_summary" and "db_path" in query:
             db_path = query["db_path"][0]
@@ -491,20 +529,91 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         """
         return self._resolve_within_root(db_path)
 
-    def handle_get_programs(self, db_path: str):
-        """Fetch all programs from a given database file."""
+    @staticmethod
+    def _parse_int_param(query: Dict[str, Any], name: str) -> Optional[int]:
+        """Parse an optional integer query param; None if absent or invalid.
+
+        Returning None on absence/parse-failure keeps the default (unpaginated)
+        response behavior unchanged for callers that omit the param.
+        """
+        values = query.get(name)
+        if not values:
+            return None
+        try:
+            return int(values[0])
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _parse_bool_param(query: Dict[str, Any], name: str, default: bool) -> bool:
+        """Parse an optional boolean query param.
+
+        Only explicit false-ish values ('false', '0', 'no', 'off') disable;
+        anything else (including an absent param) keeps ``default``.
+        """
+        values = query.get(name)
+        if not values:
+            return default
+        return values[0].strip().lower() not in ("false", "0", "no", "off")
+
+    @staticmethod
+    def _project_programs(
+        programs: list,
+        limit: Optional[int],
+        offset: Optional[int],
+        include_code: bool,
+    ) -> list:
+        """Apply opt-in pagination/projection to a full programs list.
+
+        With the defaults (no offset, no limit, include_code=True) the input
+        list is returned unchanged, so the default response stays byte-for-byte
+        identical to the pre-pagination behavior. Narrowing produces a new list
+        and never mutates the cached programs.
+        """
+        if offset is None and limit is None and include_code:
+            return programs
+        result = programs
+        if offset is not None or limit is not None:
+            start = max(offset or 0, 0)
+            if limit is None:
+                result = result[start:]
+            else:
+                result = result[start : start + max(limit, 0)]
+        if not include_code:
+            result = [{**program, "code": None} for program in result]
+        return result
+
+    def handle_get_programs(
+        self,
+        db_path: str,
+        *,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include_code: bool = True,
+    ):
+        """Fetch all programs from a given database file.
+
+        The full programs list is always built and cached; ``limit``/``offset``/
+        ``include_code`` only narrow the *response* (opt-in), never the cache.
+        """
         print(f"[SERVER] Fetching programs from DB: {db_path}")
 
         # Handle the case where db_path might have the task name prepended
         # Extract the actual path by removing the task name prefix if present
         actual_db_path = self._get_actual_db_path(db_path)
 
+        # Key the cache on the resolved absolute path (like the summary handler)
+        # so two servers/search-roots sharing a relative db_path can't collide.
+        programs_cache_key = f"programs::{actual_db_path}"
+
         # Check cache first
-        if db_path in db_cache:
-            last_fetch_time, cached_data = db_cache[db_path]
+        if programs_cache_key in db_cache:
+            last_fetch_time, cached_data = db_cache[programs_cache_key]
             if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
                 print(f"[SERVER] Serving from cache for DB: {db_path}")
-                self.send_json_response(cached_data)
+                self.send_json_response(
+                    self._project_programs(cached_data, limit, offset, include_code)
+                )
                 return
 
         # Construct absolute path to the database from search root using actual path
@@ -542,10 +651,15 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     self._load_failed_proposal_nodes(abs_db_path, include_code=False)
                 )
 
-                # Update cache
-                db_cache[db_path] = (time.time(), programs_dict)
+                # Update cache with the full list; narrowing is applied only to
+                # the response so the cached payload stays complete.
+                db_cache[programs_cache_key] = (time.time(), programs_dict)
 
-                self.send_json_response(programs_dict)
+                self.send_json_response(
+                    self._project_programs(
+                        programs_dict, limit, offset, include_code
+                    )
+                )
                 success_msg = (
                     f"[SERVER] Successfully served {len(programs)} "
                     f"programs from {db_path} (attempt {i + 1})"
@@ -605,6 +719,18 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         print(f"[SERVER] Fetching program summaries from DB: {db_path}")
 
         actual_db_path = self._get_actual_db_path(db_path)
+
+        # Same TTL cache as handle_get_programs, but under a distinct namespaced
+        # key so the summary payload never collides with the full-programs entry
+        # cached under the bare db_path.
+        summary_cache_key = f"summary::{actual_db_path}"
+        if summary_cache_key in db_cache:
+            last_fetch_time, cached_data = db_cache[summary_cache_key]
+            if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
+                print(f"[SERVER] Serving summaries from cache for DB: {db_path}")
+                self.send_json_response(cached_data)
+                return
+
         abs_db_path = os.path.join(self.search_root, actual_db_path)
 
         if not os.path.exists(abs_db_path):
@@ -630,6 +756,7 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                 summaries.extend(
                     self._load_failed_proposal_nodes(abs_db_path, include_code=False)
                 )
+                db_cache[summary_cache_key] = (time.time(), summaries)
                 self.send_json_response(summaries)
                 print(
                     f"[SERVER] Successfully served {len(summaries)} "
@@ -697,21 +824,20 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                         pass
 
                 result = db.get_program_count_and_timestamp()
-                failed_nodes = self._load_failed_proposal_nodes(
-                    abs_db_path, include_code=False
+                # Change-detection only: fold in the failed-proposal generations
+                # via a cheap aggregate. Do NOT materialize nodes or read any
+                # failure JSON from disk here — this endpoint is polled every
+                # few seconds, so it must stay lightweight.
+                failed_count, failed_max_ts = (
+                    self._failed_proposal_count_and_timestamp(db.cursor)
                 )
-                if failed_nodes:
-                    result["count"] += len(failed_nodes)
-                    max_failure_timestamp = max(
-                        node["timestamp"]
-                        for node in failed_nodes
-                        if node.get("timestamp") is not None
-                    )
-                    if (
-                        result.get("max_timestamp") is None
-                        or max_failure_timestamp > result["max_timestamp"]
-                    ):
-                        result["max_timestamp"] = max_failure_timestamp
+                if failed_count:
+                    result["count"] += failed_count
+                if failed_max_ts is not None and (
+                    result.get("max_timestamp") is None
+                    or failed_max_ts > result["max_timestamp"]
+                ):
+                    result["max_timestamp"] = failed_max_ts
                 self.send_json_response(result)
                 return
 

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -314,6 +314,18 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
             return 0, None
         return int(row["count"] or 0), row["max_timestamp"]
 
+    def _program_summary_change_token(self, db) -> Tuple[int, Optional[float]]:
+        change = db.get_program_count_and_timestamp()
+        failed_count, failed_max_timestamp = (
+            self._failed_proposal_count_and_timestamp(db.cursor)
+        )
+        max_timestamp = change.get("max_timestamp")
+        if failed_max_timestamp is not None and (
+            max_timestamp is None or failed_max_timestamp > max_timestamp
+        ):
+            max_timestamp = failed_max_timestamp
+        return int(change["count"]) + failed_count, max_timestamp
+
     # Host header values allowed when the server is bound to loopback. Overwritten
     # per-instance via the handler factory when an explicit external host is used.
     allowed_hosts = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
@@ -724,13 +736,6 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
         # key so the summary payload never collides with the full-programs entry
         # cached under the bare db_path.
         summary_cache_key = f"summary::{actual_db_path}"
-        if summary_cache_key in db_cache:
-            last_fetch_time, cached_data = db_cache[summary_cache_key]
-            if time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS:
-                print(f"[SERVER] Serving summaries from cache for DB: {db_path}")
-                self.send_json_response(cached_data)
-                return
-
         abs_db_path = os.path.join(self.search_root, actual_db_path)
 
         if not os.path.exists(abs_db_path):
@@ -752,11 +757,28 @@ class DatabaseRequestHandler(http.server.SimpleHTTPRequestHandler):
                     except sqlite3.OperationalError:
                         pass
 
+                change_token = self._program_summary_change_token(db)
+                if summary_cache_key in db_cache:
+                    last_fetch_time, cached_entry = db_cache[summary_cache_key]
+                    cached_token, cached_data = cached_entry
+                    cache_is_fresh = (
+                        time.time() - last_fetch_time < CACHE_EXPIRATION_SECONDS
+                    )
+                    if cache_is_fresh and cached_token == change_token:
+                        print(
+                            f"[SERVER] Serving summaries from cache for DB: {db_path}"
+                        )
+                        self.send_json_response(cached_data)
+                        return
+
                 summaries = db.get_programs_summary()
                 summaries.extend(
                     self._load_failed_proposal_nodes(abs_db_path, include_code=False)
                 )
-                db_cache[summary_cache_key] = (time.time(), summaries)
+                db_cache[summary_cache_key] = (
+                    time.time(),
+                    (change_token, summaries),
+                )
                 self.send_json_response(summaries)
                 print(
                     f"[SERVER] Successfully served {len(summaries)} "

--- a/shinka/webui/visualization.py
+++ b/shinka/webui/visualization.py
@@ -36,6 +36,11 @@ CACHE_EXPIRATION_SECONDS = 5  # Cache data for 5 seconds
 db_cache: Dict[str, Tuple[float, Any]] = {}
 
 
+class ReusableThreadingTCPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
 class PathValidationError(ValueError):
     """Raised when a user-supplied path escapes the served search root."""
 
@@ -1979,10 +1984,7 @@ def start_server(
     allowed_hosts = ... if _is_loopback_host(host) else None
     handler_factory = create_handler_factory(search_root, allowed_hosts=allowed_hosts)
 
-    class ReusableTCPServer(socketserver.TCPServer):
-        allow_reuse_address = True
-
-    with ReusableTCPServer((host, port), handler_factory) as httpd:
+    with ReusableThreadingTCPServer((host, port), handler_factory) as httpd:
         msg = f"\n[*] Serving http://{host}:{port}  (Ctrl+C to stop)"
         if not _is_loopback_host(host):
             msg += (

--- a/tests/test_webui_perf.py
+++ b/tests/test_webui_perf.py
@@ -180,27 +180,51 @@ def test_program_count_matches_full_program_list_length(server):
 # -------------------------------------------------------------------------- P10
 
 
-def test_programs_summary_is_ttl_cached(server, tmp_path):
+def test_programs_summary_is_ttl_cached(server, monkeypatch):
+    path = f"/get_programs_summary?db_path={_q(server.db_path)}"
+    calls = 0
+    original = ProgramDatabase.get_programs_summary
+
+    def counted(database):
+        nonlocal calls
+        calls += 1
+        return original(database)
+
+    monkeypatch.setattr(ProgramDatabase, "get_programs_summary", counted)
+
+    first, _ = server.get_json(path)
+    second, _ = server.get_json(path)
+
+    assert second == first
+    assert calls == 1
+
+
+def test_summary_cache_invalidates_for_newer_failed_proposal(server, tmp_path):
     path = f"/get_programs_summary?db_path={_q(server.db_path)}"
     first, _ = server.get_json(path)
 
-    # Mutate the DB after the first fetch; a fresh read would see the new row.
     db = ProgramDatabase(
         DatabaseConfig(db_path=str(tmp_path / server.db_path)), read_only=False
     )
     try:
-        db.cursor.execute(
-            "INSERT INTO programs (id, code, language, generation, timestamp) "
-            "VALUES ('extra', 'x', 'python', 99, 999.0)"
+        db.record_attempt_event(
+            5,
+            "proposal",
+            "failed",
+            details={
+                "node_kind": "failed_proposal",
+                "failure_reason": "newer failure",
+                "failure_json_path": "does/not/exist/newer.json",
+            },
         )
-        db.conn.commit()
     finally:
         db.close()
 
-    # Within the TTL the cached (stale) payload is returned, proving the cache.
     second, _ = server.get_json(path)
-    assert second == first
-    assert len(second) == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+
+    assert len(second) == len(first)
+    failed_generation = next(item for item in second if item["generation"] == 5)
+    assert failed_generation["text_feedback"] == "newer failure"
 
 
 def test_summary_cache_does_not_collide_with_programs_cache(server):

--- a/tests/test_webui_perf.py
+++ b/tests/test_webui_perf.py
@@ -44,6 +44,14 @@ DISTINCT_FAILED_GENERATIONS = 2
 FAILURE_REASON = "boom-marker-should-not-be-served"
 
 
+def test_production_server_handles_requests_in_daemon_threads():
+    assert issubclass(
+        visualization.ReusableThreadingTCPServer,
+        socketserver.ThreadingTCPServer,
+    )
+    assert visualization.ReusableThreadingTCPServer.daemon_threads is True
+
+
 def _make_db(root, n_programs=N_PROGRAMS, failed_generations=FAILED_GENERATIONS):
     """Create a real programs.sqlite under ``root/run`` and return its client path.
 

--- a/tests/test_webui_perf.py
+++ b/tests/test_webui_perf.py
@@ -1,0 +1,260 @@
+"""Performance regression tests for the visualization server.
+
+Covers three fixes on the fix/performance branch:
+
+* P9  – /get_program_count is a *lightweight* change detector: it must fold in
+        the failed-proposal generations via a cheap aggregate and must NOT
+        materialize failed nodes or read any failure JSON from disk.
+* P10 – /get_programs_summary is TTL-cached like /get_programs, under a
+        namespaced key that does not collide with the full-programs payload.
+* P11 – /get_programs supports opt-in ``limit`` / ``offset`` / ``include_code``
+        narrowing while the default (no params) response is unchanged.
+
+The server harness mirrors tests/test_webui_security.py: a ThreadingTCPServer
+built from create_handler_factory(root), driven with real http.client requests
+that carry a valid loopback Host header.
+"""
+
+import http.client
+import json
+import socketserver
+import threading
+import urllib.parse
+
+import pytest
+
+from shinka.database import DatabaseConfig, ProgramDatabase
+from shinka.webui import visualization
+from shinka.webui.visualization import create_handler_factory
+
+
+@pytest.fixture(autouse=True)
+def _clear_db_cache():
+    """The server's db_cache is a module global; isolate it between tests."""
+    visualization.db_cache.clear()
+    yield
+    visualization.db_cache.clear()
+
+
+N_PROGRAMS = 4
+# Failed proposals recorded across these generations; the endpoint counts
+# DISTINCT generations, so the duplicate gen 5 must NOT be double-counted.
+FAILED_GENERATIONS = [5, 6, 5]
+DISTINCT_FAILED_GENERATIONS = 2
+FAILURE_REASON = "boom-marker-should-not-be-served"
+
+
+def _make_db(root, n_programs=N_PROGRAMS, failed_generations=FAILED_GENERATIONS):
+    """Create a real programs.sqlite under ``root/run`` and return its client path.
+
+    Programs are inserted with raw SQL (the schema is created by ProgramDatabase)
+    to keep counts deterministic — the ``add()`` path spawns island copies.
+    Failed proposals go through the production ``record_attempt_event`` helper.
+    """
+    run_dir = root / "run"
+    run_dir.mkdir()
+    db_file = run_dir / "programs.sqlite"
+
+    db = ProgramDatabase(DatabaseConfig(db_path=str(db_file)), read_only=False)
+    try:
+        for i in range(n_programs):
+            db.cursor.execute(
+                "INSERT INTO programs (id, code, language, generation, timestamp, "
+                "combined_score, correct, children_count, complexity, embedding, "
+                "public_metrics, private_metrics, metadata) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    f"p{i}",
+                    f"print({i})\n",
+                    "python",
+                    i,
+                    100.0 + i,
+                    float(i),
+                    1,
+                    0,
+                    1.0,
+                    json.dumps([0.1 * i, 0.2 * i]),
+                    "{}",
+                    "{}",
+                    "{}",
+                ),
+            )
+        db.conn.commit()
+        for gen in failed_generations:
+            db.record_attempt_event(
+                gen,
+                "proposal",
+                "failed",
+                details={
+                    "node_kind": "failed_proposal",
+                    "failure_reason": FAILURE_REASON,
+                    "failure_json_path": "does/not/exist/failure.json",
+                },
+            )
+    finally:
+        db.close()
+
+    return "run/programs.sqlite"
+
+
+class _Server:
+    """Direct ThreadingTCPServer for the handler (no start_server chdir)."""
+
+    def __init__(self, search_root):
+        self.httpd = socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0), create_handler_factory(str(search_root))
+        )
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def get(self, path):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        conn.request("GET", path, headers={"Host": f"127.0.0.1:{self.port}"})
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        return resp, body
+
+    def get_json(self, path):
+        resp, body = self.get(path)
+        assert resp.status == 200, (path, resp.status, body[:200])
+        return json.loads(body), body
+
+    def close(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+
+@pytest.fixture
+def server(tmp_path):
+    db_path = _make_db(tmp_path)
+    srv = _Server(tmp_path)
+    srv.db_path = db_path
+    yield srv
+    srv.close()
+
+
+def _q(db_path):
+    return urllib.parse.quote(db_path)
+
+
+# --------------------------------------------------------------------------- P9
+
+
+def test_program_count_shape_and_counts(server):
+    result, body = server.get_json(f"/get_program_count?db_path={_q(server.db_path)}")
+
+    # Only the two keys the client actually consumes.
+    assert set(result.keys()) == {"count", "max_timestamp"}
+    # Programs + DISTINCT failed-proposal generations (dup gen not double-counted).
+    assert result["count"] == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+    # Failed proposals are stamped with time.time(), newer than program ts 100-103.
+    assert result["max_timestamp"] is not None
+    assert result["max_timestamp"] > 103.0
+
+
+def test_program_count_does_not_materialize_failed_nodes(server):
+    _result, body = server.get_json(f"/get_program_count?db_path={_q(server.db_path)}")
+    text = body.decode("utf-8")
+
+    # No per-node failure payload leaks into this lightweight endpoint: no
+    # failure_reason (would require reading the row/details), no synthetic node
+    # id, and no node-only keys. Proves _read_failure_json / node build skipped.
+    assert FAILURE_REASON not in text
+    assert "failure_reason" not in text
+    assert "failed:proposal:" not in text
+    for node_only_key in ("public_metrics", "text_feedback", "embedding"):
+        assert node_only_key not in text
+
+
+def test_program_count_matches_full_program_list_length(server):
+    """The change-detector count must equal treeData length (get_programs)."""
+    count_result, _ = server.get_json(
+        f"/get_program_count?db_path={_q(server.db_path)}"
+    )
+    programs, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    assert count_result["count"] == len(programs)
+
+
+# -------------------------------------------------------------------------- P10
+
+
+def test_programs_summary_is_ttl_cached(server, tmp_path):
+    path = f"/get_programs_summary?db_path={_q(server.db_path)}"
+    first, _ = server.get_json(path)
+
+    # Mutate the DB after the first fetch; a fresh read would see the new row.
+    db = ProgramDatabase(
+        DatabaseConfig(db_path=str(tmp_path / server.db_path)), read_only=False
+    )
+    try:
+        db.cursor.execute(
+            "INSERT INTO programs (id, code, language, generation, timestamp) "
+            "VALUES ('extra', 'x', 'python', 99, 999.0)"
+        )
+        db.conn.commit()
+    finally:
+        db.close()
+
+    # Within the TTL the cached (stale) payload is returned, proving the cache.
+    second, _ = server.get_json(path)
+    assert second == first
+    assert len(second) == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+
+
+def test_summary_cache_does_not_collide_with_programs_cache(server):
+    """Namespaced key: summary and full-programs payloads stay distinct."""
+    summaries, _ = server.get_json(
+        f"/get_programs_summary?db_path={_q(server.db_path)}"
+    )
+    programs, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+
+    # Summaries never ship source code; full programs do.
+    assert all(not s.get("code") for s in summaries)
+    assert any(p.get("code") for p in programs)
+
+
+# -------------------------------------------------------------------------- P11
+
+
+def test_get_programs_default_ships_full_code(server):
+    programs, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    assert len(programs) == N_PROGRAMS + DISTINCT_FAILED_GENERATIONS
+    # At least one real program carries its full source (default = unchanged).
+    assert any(p.get("code") for p in programs)
+
+
+def test_get_programs_limit_returns_fewer_rows(server):
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    limited, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&limit=2"
+    )
+    assert len(limited) == 2
+    assert limited == full[:2]
+
+
+def test_get_programs_offset_paginates(server):
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    page, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&limit=2&offset=1"
+    )
+    assert page == full[1:3]
+
+
+def test_get_programs_include_code_false_strips_code(server):
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    stripped, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&include_code=false"
+    )
+    assert len(stripped) == len(full)
+    assert all(item.get("code") is None for item in stripped)
+
+
+def test_get_programs_ignores_garbage_pagination_params(server):
+    """Non-integer limit/offset are ignored, preserving default behavior."""
+    full, _ = server.get_json(f"/get_programs?db_path={_q(server.db_path)}")
+    same, _ = server.get_json(
+        f"/get_programs?db_path={_q(server.db_path)}&limit=abc&offset=xyz"
+    )
+    assert same == full


### PR DESCRIPTION
## What changed
- Add cheap change polling and cached summaries.
- Make narrow payloads opt-in and invalidate caches on failed-proposal changes.
- Serve independent requests concurrently.

## Review scope
WebUI-only performance extraction from #152. Review after the server-security replacement.

## Verification
- 24 focused WebUI tests
- Ruff and Mypy
- Integrated 876-test gate

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.