### PR TITLE
fix(llm): reconcile Gemini retry behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Set up stable Rust formatter
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt
+          rustup default stable
+          rustfmt --version
+
       - name: Install project
         run: uv sync --dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed Rust candidate validation on stable toolchains by replacing the
+  nightly-only parser flag with isolated, non-mutating `rustfmt` syntax checks
+  in PR #179. Thanks @Atharva-Kanherkar.
 - Fixed Azure OpenAI LLM client construction to use the v1 base URL contract,
   avoiding doubled `/openai/v1/openai` request paths and 404 responses reported
   in issue #147.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Added native Google Gemini 3.6 Flash support with current pricing and
   level-based thinking controls. Thanks @anantgar.
 - Added optional Weights & Biases logging with resumable run IDs, per-individual
-  scores, timing and cost metrics, and final run summaries in PR #149. Thanks
-  @anantgar.
+  scores, timing and cost metrics, and final run summaries in PR #149. PR #177
+  adds monotonic population/island snapshots and a secured metadata boundary.
+  Thanks @anantgar.
 - Added Verilog/SystemVerilog as a first-class evolution target in PR #137,
   including `.sv` task detection, syntax validation, EVOLVE-BLOCK marker support,
   failure-artifact rendering, and a self-contained RTLLM example. Thanks @Tyronita.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed Gemini retry handling so unsupported structured-output requests fail
+  immediately, synchronous retries are paced, and sync/async calls share the
+  same default thinking budget.
 - Fixed Rust candidate validation on stable toolchains by replacing the
   nightly-only parser flag with isolated, non-mutating `rustfmt` syntax checks
   in PR #179. Thanks @Atharva-Kanherkar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Changed
 
+- Reduced Python complexity-analysis overhead by parsing each candidate AST once
+  while preserving the existing metrics contract. Thanks @dexhunter.
 - Relaxed the exact HTTPX dependency pin to a `>=0.27` compatibility lower
   bound in issue #180. Thanks @htmai-880.
 - Removed the automatic Claude Code Review pull-request workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Added
 
+- Added native Google Gemini 3.7 Flash support at its introductory 2026 price.
 - Added native Google Gemini 3.6 Flash support with current pricing and
   level-based thinking controls. Thanks @anantgar.
 - Added optional Weights & Biases logging with resumable run IDs, per-individual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Changed
 
+- Relaxed the exact HTTPX dependency pin to a `>=0.27` compatibility lower
+  bound in issue #180. Thanks @htmai-880.
 - Removed the automatic Claude Code Review pull-request workflow.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Added
 
+- Added native Google Gemini 3.6 Flash support with current pricing and
+  level-based thinking controls. Thanks @anantgar.
 - Added optional Weights & Biases logging with resumable run IDs, per-individual
   scores, timing and cost metrics, and final run summaries in PR #149. Thanks
   @anantgar.

--- a/README.md
+++ b/README.md
@@ -192,13 +192,31 @@ shinka_run --task-dir examples/circle_packing \
 ```
 
 W&B logging is additive: the existing SQLite database and WebUI logging remain
-enabled. Each evaluated individual logs `score/individual` against `generation`,
-along with compact evaluation, cost, and timing metrics. Resuming the same
-results directory reuses its persisted W&B run ID by default. Online mode uses
-the credentials from `wandb login` or `WANDB_API_KEY`; use `wandb_mode=offline`
-to record locally without uploading. See
+enabled. Population and island snapshots use the monotonic
+`population/evaluated_count` axis for counts, correctness, scores, cumulative
+`cost/*`, and cumulative `timing/*_total`. Raw evaluated candidates use
+`score/individual` and `individual/*` fields without binding those events to a
+generation step. Administrative island copies remain in population/table counts
+but are excluded from evaluated count, candidate history, and costs. The final
+population is available as `population/final_table`, without program code or
+embeddings. Resuming the same results directory reuses its persisted W&B run ID
+by default. Online mode uses credentials from `wandb login` or `WANDB_API_KEY`;
+use `wandb_mode=offline` to record locally without uploading. See
 [Configuration](docs/configuration.md#evolutionconfig-shinkacoreconfigevolutionconfig)
 for all W&B options.
+
+Shinka disables W&B console, Git, code, requirements, machine, and system-stat
+capture. Run configuration contains an explicit allowlist of scalar experiment
+settings plus the recursively redacted `wandb_config` extension. Arbitrary
+`wandb_config` values cross the upload boundary when their keys are not
+recognized as sensitive, so do not put secrets or private data there. Candidate
+telemetry excludes private metrics and logs at most 64 public numeric metrics
+with keys no longer than 128 characters; secret-like metric names are dropped.
+Population snapshots use a dedicated serialized telemetry worker and a compact
+database aggregate, throttled to at most once every five seconds. Overlapping
+requests are coalesced so telemetry cannot stall active job processing. The
+bounded candidate queue drops the newest raw event with a rate-limited warning
+if saturated; population and final snapshots remain authoritative.
 
 <details>
 <summary><strong>EvolutionConfig Parameters</strong> (click to expand)</summary>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,18 +94,37 @@ pip install 'shinka-evolve[wandb]'
 # Authenticate online runs. In CI, provide this through a secret manager.
 export WANDB_API_KEY=<your-api-key>
 
-# Add W&B metrics and a compact individuals table alongside the WebUI database.
+# Add W&B metrics and a compact final table alongside the WebUI database.
 shinka_run --task-dir examples/circle_packing --results_dir results/circle_wandb --num_generations 20 \
   --set evo.enable_wandb_logging=true \
   --set evo.wandb_project=shinka-evolve
 ```
 
-Each evaluated individual logs `score/individual` against `generation`. When a
-results directory is resumed, its `.wandb_run_id` is reused with
-`wandb_resume='allow'` by default. Online mode uses the credentials from
+Population and island snapshots use the monotonic
+`population/evaluated_count` axis. They include counts, correctness, scores,
+cumulative `cost/*`, and cumulative `timing/*_total`. Raw evaluated candidates
+use `score/individual` and `individual/*` fields without binding those events to
+generation. Administrative island copies remain in population/table counts but
+are excluded from evaluated count, candidate history, and costs. The compact
+`population/final_table` omits program code, embeddings, and unrestricted
+metadata. When a results directory is resumed, its `.wandb_run_id` is reused
+with `wandb_resume='allow'` by default. Online mode uses credentials from
 `wandb login` or `WANDB_API_KEY`; set `wandb_mode=offline` to record locally
 without uploading. W&B failures are non-fatal and do not alter the existing
 database or WebUI path.
+
+The integration disables W&B console, Git, code, requirements, machine, and
+system-stat capture. Its run config contains only an explicit allowlist of safe
+scalar experiment settings; `wandb_config` remains an explicit extension and is
+recursively redacted for secret-like keys. Arbitrary `wandb_config` values cross
+the upload boundary when their keys are not recognized as sensitive, so do not
+put secrets or private data there. Candidate events omit private metrics and
+include at most 64 public numeric metrics whose full keys are at most 128
+characters; secret-like keys are discarded. Population snapshots use a compact
+database aggregate on a dedicated serialized telemetry worker, run at most once
+every five seconds, and overlapping refresh requests are coalesced. If the
+bounded raw-candidate queue saturates, the newest candidate event is dropped
+with a rate-limited warning; population and final snapshots remain authoritative.
 
 ### DatabaseConfig (`shinka.database.DatabaseConfig`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ shinka = [
 dev = [
     "pytest>=6.0",
     "pytest-cov",
-    "ruff",
+    "ruff==0.15.6",
     "mypy",
     "black",
     "isort",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-wandb = ["wandb"]
+wandb = ["wandb>=0.19"]
 
 [project.scripts]
 shinka_launch = "shinka.cli.launch:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "adjustText",
     "markdown",
     "aiofiles",
-    "google-genai",
+    "google-genai>=2.13,<3",
     "psutil",
     "httpx>=0.27"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "aiofiles",
     "google-genai",
     "psutil",
-    "httpx==0.27"
+    "httpx>=0.27"
 ]
 
 [project.optional-dependencies]

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -13,7 +13,9 @@ import os
 import math
 import psutil
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Set, Tuple, Union, Iterable
 from dataclasses import dataclass, field
@@ -69,6 +71,7 @@ from shinka.pricing.catalog import (
     write_run_pricing_snapshot,
 )
 from shinka.wandb_logging import ShinkaWandbLogger
+from shinka.wandb_metrics import build_program_log_payload, is_island_copy
 from shinka.utils import (
     get_language_extension,
     parse_time_to_seconds,
@@ -77,6 +80,11 @@ from shinka.utils import (
 from shinka.utils.languages import get_evolve_comment_prefix
 
 logger = logging.getLogger(__name__)
+
+_WANDB_CANDIDATE_QUEUE_SIZE = 256
+_WANDB_DROP_WARNING_INTERVAL_SECONDS = 30.0
+_WANDB_POPULATION_INTERVAL_SECONDS = 5.0
+_WANDB_CANDIDATE_STOP = object()
 
 
 def _print_gradient_logo_and_mirror(
@@ -568,6 +576,17 @@ class ShinkaEvolveRunner:
         self._background_side_effects_busy_count = 0
         self._completed_job_batch_tasks: Set[asyncio.Task] = set()
         self._completed_jobs_pending = 0
+        self._wandb_population_task: Optional[asyncio.Task] = None
+        self._wandb_population_delay_task: Optional[asyncio.Task] = None
+        self._wandb_population_pending = False
+        self._wandb_last_population_snapshot_at: Optional[float] = None
+        self._wandb_population_interval_seconds = _WANDB_POPULATION_INTERVAL_SECONDS
+        self._wandb_executor: Optional[ThreadPoolExecutor] = None
+        self._wandb_candidate_queue: Optional[asyncio.Queue] = None
+        self._wandb_candidate_worker_task: Optional[asyncio.Task] = None
+        self._wandb_candidate_queue_size = _WANDB_CANDIDATE_QUEUE_SIZE
+        self._wandb_dropped_candidate_events = 0
+        self._wandb_last_drop_warning_at: Optional[float] = None
         self._meta_side_effect_lock = asyncio.Lock()
         self._prompt_side_effect_lock = asyncio.Lock()
         self._best_solution_lock = asyncio.Lock()
@@ -1183,12 +1202,14 @@ class ShinkaEvolveRunner:
         if self.evo_config.evolve_prompts:
             await self._setup_prompt_evolution()
 
-        self.wandb_logger.start(
-            evo_config=self.evo_config,
-            db_config=self.db_config,
-            job_config=self.job_config,
-            results_dir=Path(self.results_dir),
-        )
+        if self.wandb_logger.enabled:
+            await self._run_wandb_operation(
+                self.wandb_logger.start,
+                evo_config=self.evo_config,
+                db_config=self.db_config,
+                job_config=self.job_config,
+                results_dir=Path(self.results_dir),
+            )
 
         # Check if we're resuming from an existing database
         resuming_run = db_path.exists() and self.db.last_iteration > 0
@@ -1236,6 +1257,8 @@ class ShinkaEvolveRunner:
                         "generating initial program with LLM..."
                     )
                 await self._generate_initial_program()
+
+        self._log_wandb_population_progress()
 
     async def _setup_prompt_evolution(self):
         """Setup prompt evolution database and components."""
@@ -2125,6 +2148,7 @@ class ShinkaEvolveRunner:
                         await self._process_completed_jobs_safely(completed_jobs)
                         old_completed = self.completed_generations
                         await self._update_completed_generations()
+                        self._log_wandb_population_progress()
 
                         if self.verbose:
                             if self.completed_generations != old_completed:
@@ -4021,6 +4045,7 @@ class ShinkaEvolveRunner:
             )
 
             await self._update_completed_generations()
+            self._log_wandb_population_progress()
             self._record_progress()
             self.slot_available.set()
             self._log_program_to_wandb(program)
@@ -4628,6 +4653,7 @@ class ShinkaEvolveRunner:
                 self._mark_surplus_completed_jobs_for_discard(completed_jobs)
                 await self._process_completed_jobs_safely(completed_jobs)
                 await self._update_completed_generations()
+                self._log_wandb_population_progress()
                 self.slot_available.set()
         finally:
             self._completed_jobs_pending = max(
@@ -4934,6 +4960,7 @@ class ShinkaEvolveRunner:
                     if str(job.job_id) in self.submitted_jobs:
                         del self.submitted_jobs[str(job.job_id)]
                     await self._update_completed_generations()
+                    self._log_wandb_population_progress()
                     self._record_progress()
                     self.slot_available.set()
                     logger.info(
@@ -5524,7 +5551,7 @@ class ShinkaEvolveRunner:
                     logger.warning(f"Failed to recompute prompt percentiles: {e}")
 
             # Cleanup database
-            self._finish_wandb_logging()
+            await self._finish_wandb_logging()
             await self.async_db.close_async()
 
             # Cleanup scheduler
@@ -5535,19 +5562,334 @@ class ShinkaEvolveRunner:
 
     def _log_program_to_wandb(self, program: Program) -> None:
         wandb_logger = getattr(self, "wandb_logger", None)
-        if wandb_logger is not None:
-            wandb_logger.log_program(program)
+        if (
+            wandb_logger is not None
+            and getattr(wandb_logger, "active", True)
+            and not is_island_copy(program)
+            and hasattr(wandb_logger, "log_program_payload")
+        ):
+            self._enqueue_wandb_candidate(
+                wandb_logger.log_program_payload,
+                program.id,
+                build_program_log_payload(program),
+            )
 
-    def _finish_wandb_logging(self) -> None:
+    def _log_wandb_population_progress(self) -> None:
+        wandb_logger = getattr(self, "wandb_logger", None)
+        db = getattr(self, "db", None)
+        if (
+            wandb_logger is None
+            or db is None
+            or getattr(wandb_logger, "active", True) is False
+        ):
+            return
+
+        snapshot_task = getattr(self, "_wandb_population_task", None)
+        delay_task = getattr(self, "_wandb_population_delay_task", None)
+        snapshot_running = snapshot_task is not None and not snapshot_task.done()
+        delay_running = delay_task is not None and not delay_task.done()
+        if snapshot_running or delay_running:
+            self._wandb_population_pending = True
+            return
+
+        loop = asyncio.get_running_loop()
+        last_snapshot_at = getattr(
+            self, "_wandb_last_population_snapshot_at", None
+        )
+        interval = getattr(
+            self,
+            "_wandb_population_interval_seconds",
+            _WANDB_POPULATION_INTERVAL_SECONDS,
+        )
+        delay = (
+            0.0
+            if last_snapshot_at is None
+            else max(0.0, interval - (loop.time() - last_snapshot_at))
+        )
+        if delay:
+            self._wandb_population_pending = True
+            self._wandb_population_delay_task = asyncio.create_task(
+                self._run_delayed_wandb_population_snapshot(delay),
+                name="wandb_population_delay",
+            )
+            return
+        self._start_wandb_population_snapshot(wandb_logger, db)
+
+    def _start_wandb_population_snapshot(
+        self, wandb_logger: Any, db: ProgramDatabase
+    ) -> None:
+        try:
+            population_snapshot = self._capture_wandb_population_snapshot(db)
+        except Exception as exc:
+            logger.warning(
+                "Failed to query in-memory W&B population snapshot: %s", exc
+            )
+            return
+        if population_snapshot is None:
+            if not hasattr(wandb_logger, "log_population_progress"):
+                return
+        elif not hasattr(wandb_logger, "log_population_snapshot"):
+            return
+        else:
+            self._wandb_last_population_snapshot_at = (
+                asyncio.get_running_loop().time()
+            )
+
+        self._wandb_population_pending = False
+        self._wandb_population_task = asyncio.create_task(
+            self._run_wandb_population_snapshot(
+                wandb_logger, db, population_snapshot
+            ),
+            name="wandb_population_snapshot",
+        )
+
+    async def _run_delayed_wandb_population_snapshot(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        finally:
+            self._wandb_population_delay_task = None
+        wandb_logger = getattr(self, "wandb_logger", None)
+        db = getattr(self, "db", None)
+        if (
+            wandb_logger is not None
+            and db is not None
+            and getattr(wandb_logger, "active", True)
+        ):
+            self._start_wandb_population_snapshot(wandb_logger, db)
+
+    async def _run_wandb_population_snapshot(
+        self,
+        wandb_logger: Any,
+        db: ProgramDatabase,
+        population_snapshot: Optional[List[Dict[str, Any]]],
+    ) -> None:
+        try:
+            if population_snapshot is None:
+                await self._run_wandb_operation(
+                    self._log_wandb_population_snapshot,
+                    wandb_logger,
+                    db,
+                )
+            else:
+                await self._run_wandb_operation(
+                    wandb_logger.log_population_snapshot,
+                    population_snapshot,
+                )
+        except Exception as exc:
+            logger.warning("Failed to run background W&B snapshot: %s", exc)
+        finally:
+            if population_snapshot is None:
+                self._wandb_last_population_snapshot_at = (
+                    asyncio.get_running_loop().time()
+                )
+            self._wandb_population_task = None
+        if self._wandb_population_pending:
+            self._wandb_population_pending = False
+            self._log_wandb_population_progress()
+
+    async def _wait_for_wandb_population_progress(self) -> None:
+        while (
+            task := getattr(self, "_wandb_population_task", None)
+            or getattr(self, "_wandb_population_delay_task", None)
+        ) is not None:
+            await asyncio.shield(task)
+
+    async def _skip_delayed_wandb_population_progress(self) -> None:
+        delay_task = getattr(self, "_wandb_population_delay_task", None)
+        if delay_task is not None:
+            delay_task.cancel()
+            try:
+                await delay_task
+            except asyncio.CancelledError:
+                pass
+            self._wandb_population_delay_task = None
+        self._wandb_population_pending = False
+        while (task := getattr(self, "_wandb_population_task", None)) is not None:
+            await asyncio.shield(task)
+
+    @staticmethod
+    def _capture_wandb_population_snapshot(
+        db: ProgramDatabase,
+    ) -> Optional[List[Dict[str, Any]]]:
+        config = getattr(db, "config", None)
+        if config is None or getattr(config, "db_path", None):
+            return None
+        return db.get_population_telemetry()
+
+    @staticmethod
+    def _wandb_snapshot_db(db: ProgramDatabase) -> Tuple[ProgramDatabase, bool]:
+        config = getattr(db, "config", None)
+        db_path = getattr(config, "db_path", None)
+        if not db_path:
+            return db, False
+        return ProgramDatabase(config, read_only=True), True
+
+    @classmethod
+    def _log_wandb_population_snapshot(
+        cls, wandb_logger: Any, db: ProgramDatabase
+    ) -> None:
+        snapshot_db, should_close = cls._wandb_snapshot_db(db)
+        try:
+            wandb_logger.log_population_progress(db=snapshot_db)
+        finally:
+            if should_close:
+                snapshot_db.close()
+
+    @classmethod
+    def _log_final_wandb_snapshot(
+        cls,
+        wandb_logger: Any,
+        db: ProgramDatabase,
+        total_proposals_generated: Optional[int],
+        total_cost: Optional[float],
+    ) -> None:
+        snapshot_db, should_close = cls._wandb_snapshot_db(db)
+        try:
+            wandb_logger.log_final(
+                db=snapshot_db,
+                total_proposals_generated=total_proposals_generated,
+                total_api_cost=total_cost,
+                total_cost=total_cost,
+            )
+        finally:
+            if should_close:
+                snapshot_db.close()
+
+    async def _finish_wandb_logging(self) -> None:
         wandb_logger = getattr(self, "wandb_logger", None)
         if wandb_logger is None:
             return
-        wandb_logger.log_final(
-            db=getattr(self, "db", None),
-            total_proposals_generated=getattr(self, "total_proposals_generated", None),
-            total_api_cost=getattr(self, "total_api_cost", None),
-        )
-        wandb_logger.finish()
+        await self._skip_delayed_wandb_population_progress()
+        await self._drain_wandb_candidate_queue()
+        total_cost = getattr(self, "total_api_cost", None)
+        db = getattr(self, "db", None)
+        if db is not None:
+            try:
+                config = getattr(db, "config", None)
+                if config is not None and not getattr(config, "db_path", None):
+                    programs = db.get_all_programs()
+                    await self._run_wandb_operation(
+                        wandb_logger.log_final_programs,
+                        programs,
+                        total_proposals_generated=getattr(
+                            self, "total_proposals_generated", None
+                        ),
+                        total_api_cost=total_cost,
+                        total_cost=total_cost,
+                    )
+                else:
+                    await self._run_wandb_operation(
+                        self._log_final_wandb_snapshot,
+                        wandb_logger,
+                        db,
+                        getattr(self, "total_proposals_generated", None),
+                        total_cost,
+                    )
+            except Exception as exc:
+                logger.warning("Failed to run final W&B snapshot: %s", exc)
+        try:
+            await self._run_wandb_operation(wandb_logger.finish)
+        finally:
+            await self._stop_wandb_candidate_worker()
+            await self._shutdown_wandb_executor()
+
+    def _wandb_thread_pool(self) -> ThreadPoolExecutor:
+        executor = getattr(self, "_wandb_executor", None)
+        if executor is None:
+            executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="shinka-wandb",
+            )
+            self._wandb_executor = executor
+        return executor
+
+    async def _run_wandb_operation(
+        self, callback: Any, *args: Any, **kwargs: Any
+    ) -> Any:
+        loop = asyncio.get_running_loop()
+        operation = partial(callback, *args, **kwargs)
+        return await loop.run_in_executor(self._wandb_thread_pool(), operation)
+
+    def _wandb_candidate_event_queue(self) -> asyncio.Queue:
+        queue = getattr(self, "_wandb_candidate_queue", None)
+        if queue is None:
+            queue = asyncio.Queue(
+                maxsize=getattr(
+                    self,
+                    "_wandb_candidate_queue_size",
+                    _WANDB_CANDIDATE_QUEUE_SIZE,
+                )
+            )
+            self._wandb_candidate_queue = queue
+        return queue
+
+    def _enqueue_wandb_candidate(
+        self, callback: Any, program_id: str, payload: Dict[str, Any]
+    ) -> None:
+        queue = self._wandb_candidate_event_queue()
+        if queue.full():
+            self._wandb_dropped_candidate_events = (
+                getattr(self, "_wandb_dropped_candidate_events", 0) + 1
+            )
+            now = time.monotonic()
+            last_warning = getattr(self, "_wandb_last_drop_warning_at", None)
+            if (
+                last_warning is None
+                or now - last_warning >= _WANDB_DROP_WARNING_INTERVAL_SECONDS
+            ):
+                logger.warning(
+                    "W&B candidate queue full; dropping newest candidate event. "
+                    "Population and final snapshots remain authoritative."
+                )
+                self._wandb_last_drop_warning_at = now
+            return
+        queue.put_nowait((callback, program_id, payload))
+        worker = getattr(self, "_wandb_candidate_worker_task", None)
+        if worker is None or worker.done():
+            self._wandb_candidate_worker_task = asyncio.create_task(
+                self._run_wandb_candidate_worker(),
+                name="wandb_candidate_worker",
+            )
+
+    async def _run_wandb_candidate_worker(self) -> None:
+        queue = self._wandb_candidate_event_queue()
+        while True:
+            operation = await queue.get()
+            try:
+                if operation is _WANDB_CANDIDATE_STOP:
+                    return
+                callback, program_id, payload = operation
+                try:
+                    await self._run_wandb_operation(
+                        callback, program_id, payload
+                    )
+                except Exception as exc:
+                    logger.warning("Failed W&B candidate operation: %s", exc)
+            finally:
+                queue.task_done()
+
+    async def _drain_wandb_candidate_queue(self) -> None:
+        queue = getattr(self, "_wandb_candidate_queue", None)
+        if queue is not None:
+            await queue.join()
+
+    async def _stop_wandb_candidate_worker(self) -> None:
+        worker = getattr(self, "_wandb_candidate_worker_task", None)
+        if worker is None:
+            return
+        queue = self._wandb_candidate_event_queue()
+        queue.put_nowait(_WANDB_CANDIDATE_STOP)
+        await worker
+        self._wandb_candidate_worker_task = None
+
+    async def _shutdown_wandb_executor(self) -> None:
+        executor = getattr(self, "_wandb_executor", None)
+        if executor is None:
+            return
+        self._wandb_executor = None
+        await asyncio.to_thread(executor.shutdown, True)
 
     async def _print_final_summary(self):
         """Print final evolution summary."""

--- a/shinka/database/complexity.py
+++ b/shinka/database/complexity.py
@@ -1,43 +1,43 @@
 import ast
-from radon.complexity import cc_visit
-from radon.metrics import h_visit
-from radon.raw import analyze
 import math
 import re
+
+from radon.complexity import cc_visit_ast
+from radon.metrics import h_visit_ast
+from radon.raw import analyze
+
+
+class _NestingVisitor(ast.NodeVisitor):
+    """Track the deepest chain of nested control structures."""
+
+    def __init__(self):
+        self.current_depth = 0
+        self.max_depth = 0
+
+    def _visit_nested(self, node):
+        self.current_depth += 1
+        self.max_depth = max(self.max_depth, self.current_depth)
+        self.generic_visit(node)
+        self.current_depth -= 1
+
+    visit_If = _visit_nested
+    visit_For = _visit_nested
+    visit_While = _visit_nested
+    visit_With = _visit_nested
+    visit_Try = _visit_nested
+    visit_FunctionDef = _visit_nested
+    visit_AsyncFunctionDef = _visit_nested
+
+
+def _max_nesting_depth(tree):
+    visitor = _NestingVisitor()
+    visitor.visit(tree)
+    return visitor.max_depth
 
 
 def max_nesting_depth(code_string):
     """Calculate maximum nesting depth for Python code using AST."""
-
-    class NestingVisitor(ast.NodeVisitor):
-        def __init__(self):
-            self.current_depth = 0
-            self.max_depth = 0
-
-        def generic_visit(self, node):
-            if isinstance(
-                node,
-                (
-                    ast.If,
-                    ast.For,
-                    ast.While,
-                    ast.With,
-                    ast.Try,
-                    ast.FunctionDef,
-                    ast.AsyncFunctionDef,
-                ),
-            ):
-                self.current_depth += 1
-                self.max_depth = max(self.max_depth, self.current_depth)
-                super().generic_visit(node)
-                self.current_depth -= 1
-            else:
-                super().generic_visit(node)
-
-    tree = ast.parse(code_string)
-    visitor = NestingVisitor()
-    visitor.visit(tree)
-    return visitor.max_depth
+    return _max_nesting_depth(ast.parse(code_string))
 
 
 def analyze_python_complexity(code_string):
@@ -54,11 +54,13 @@ def analyze_python_complexity(code_string):
     Raises:
         SyntaxError: If the code cannot be parsed as valid Python
     """
-    cc_results = cc_visit(code_string)
+    tree = ast.parse(code_string)
+
+    cc_results = cc_visit_ast(tree)
     total_cc = sum(block.complexity for block in cc_results)
     avg_cc = total_cc / len(cc_results) if cc_results else 0
 
-    h_metrics = h_visit(code_string)
+    h_metrics = h_visit_ast(tree)
     halstead_total = h_metrics.total if h_metrics.total else None
     halstead_volume = halstead_total.volume if halstead_total else 1
     halstead_difficulty = halstead_total.difficulty if halstead_total else 0
@@ -76,7 +78,7 @@ def analyze_python_complexity(code_string):
         - 16.2 * (math.log2(loc) if loc > 0 else 0)
     )
 
-    nesting_depth = max_nesting_depth(code_string)
+    nesting_depth = _max_nesting_depth(tree)
 
     # Normalized scores for aggregation
     norm_cc = total_cc / 10  # Assuming 10 is high complexity

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -1645,6 +1645,136 @@ class ProgramDatabase:
         return best_overall
 
     @db_retry()
+    def get_population_telemetry(self) -> List[Dict[str, Any]]:
+        """Return compact per-island aggregates for progress telemetry.
+
+        The query never selects program code, embeddings, evaluation metrics, or
+        full metadata. Final reporting can still use :meth:`get_all_programs`.
+        """
+        if not self.cursor:
+            raise ConnectionError("DB not connected.")
+        self.cursor.execute(
+            """
+            WITH metadata_source AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    combined_score,
+                    COALESCE(metadata, '{}') AS metadata,
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(COALESCE(metadata, '{}'), '-Infinity', 'null'),
+                            'Infinity', 'null'
+                        ),
+                        'NaN', 'null'
+                    ) AS finite_metadata
+                FROM programs
+            ), source AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    combined_score,
+                    CASE
+                        WHEN json_valid(metadata) THEN metadata
+                        WHEN json_valid(finite_metadata) THEN finite_metadata
+                        ELSE '{}'
+                    END AS metadata
+                FROM metadata_source
+            ), raw AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    CASE WHEN combined_score > -1e999 AND combined_score < 1e999
+                        THEN combined_score END AS combined_score,
+                    CASE WHEN
+                        COALESCE(json_extract(metadata, '$._is_island_copy'), 0) = 1
+                        OR COALESCE(json_extract(metadata, '$._spawned_island'), 0) = 1
+                    THEN 1 ELSE 0 END AS is_copy,
+                    COALESCE(
+                        NULLIF(json_extract(metadata, '$.model_name'), ''),
+                        NULLIF(json_extract(metadata, '$.model'), ''),
+                        NULLIF(json_extract(metadata, '$.llm_result.model_name'), ''),
+                        NULLIF(json_extract(metadata, '$.llm_result.model'), '')
+                    ) AS model_name,
+                    COALESCE(
+                        json_extract(metadata, '$.headless_pricing_unknown'), 0
+                    ) AS pricing_unknown,
+                    CASE WHEN json_type(metadata, '$.api_costs') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.api_costs') ELSE 0 END AS api_cost,
+                    CASE WHEN json_type(metadata, '$.embed_cost') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.embed_cost') ELSE 0 END AS embed_cost,
+                    CASE WHEN json_type(metadata, '$.novelty_cost') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.novelty_cost') ELSE 0 END AS novelty_cost,
+                    CASE WHEN json_type(metadata, '$.meta_cost') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.meta_cost') ELSE 0 END AS meta_cost,
+                    CASE WHEN json_type(metadata, '$.sampling_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.sampling_seconds') ELSE 0 END AS sampling_seconds,
+                    CASE WHEN json_type(metadata, '$.evaluation_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.evaluation_seconds') ELSE 0 END AS evaluation_seconds,
+                    CASE WHEN json_type(metadata, '$.postprocess_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.postprocess_seconds') ELSE 0 END AS postprocess_seconds,
+                    CASE WHEN json_type(metadata, '$.pipeline_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.pipeline_seconds') ELSE 0 END AS pipeline_seconds
+                FROM source
+            ), telemetry AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    combined_score,
+                    is_copy,
+                    model_name,
+                    CASE WHEN api_cost > -1e999 AND api_cost < 1e999
+                        THEN api_cost ELSE 0 END AS api_cost,
+                    CASE WHEN embed_cost > -1e999 AND embed_cost < 1e999
+                        THEN embed_cost ELSE 0 END AS embed_cost,
+                    CASE WHEN novelty_cost > -1e999 AND novelty_cost < 1e999
+                        THEN novelty_cost ELSE 0 END AS novelty_cost,
+                    CASE WHEN meta_cost > -1e999 AND meta_cost < 1e999
+                        THEN meta_cost ELSE 0 END AS meta_cost,
+                    CASE WHEN sampling_seconds > -1e999 AND sampling_seconds < 1e999
+                        THEN sampling_seconds ELSE 0 END AS sampling_seconds,
+                    CASE WHEN evaluation_seconds > -1e999 AND evaluation_seconds < 1e999
+                        THEN evaluation_seconds ELSE 0 END AS evaluation_seconds,
+                    CASE WHEN postprocess_seconds > -1e999 AND postprocess_seconds < 1e999
+                        THEN postprocess_seconds ELSE 0 END AS postprocess_seconds,
+                    CASE WHEN pipeline_seconds > -1e999 AND pipeline_seconds < 1e999
+                        THEN pipeline_seconds ELSE 0 END AS pipeline_seconds,
+                    CASE WHEN model_name GLOB 'headless/*' AND pricing_unknown = 1
+                        THEN 1 ELSE 0 END AS api_cost_unknown
+                FROM raw
+            )
+            SELECT
+                island_idx,
+                COUNT(*) AS count,
+                SUM(CASE WHEN is_copy = 0 THEN 1 ELSE 0 END) AS evaluated_count,
+                SUM(CASE WHEN correct = 1 THEN 1 ELSE 0 END) AS correct_count,
+                COUNT(combined_score) AS score_count,
+                COALESCE(SUM(combined_score), 0) AS score_sum,
+                MAX(combined_score) AS best_score,
+                MAX(CASE WHEN correct = 1 THEN combined_score END) AS best_correct_score,
+                SUM(CASE WHEN is_copy = 0 AND api_cost_unknown = 0
+                    THEN api_cost ELSE 0 END) AS api_cost,
+                SUM(CASE WHEN is_copy = 0 THEN embed_cost ELSE 0 END) AS embed_cost,
+                SUM(CASE WHEN is_copy = 0 THEN novelty_cost ELSE 0 END) AS novelty_cost,
+                SUM(CASE WHEN is_copy = 0 THEN meta_cost ELSE 0 END) AS meta_cost,
+                SUM(CASE WHEN is_copy = 0 AND api_cost_unknown = 1
+                    THEN 1 ELSE 0 END) AS pricing_unknown_count,
+                SUM(CASE WHEN is_copy = 0 THEN sampling_seconds ELSE 0 END)
+                    AS sampling_seconds,
+                SUM(CASE WHEN is_copy = 0 THEN evaluation_seconds ELSE 0 END)
+                    AS evaluation_seconds,
+                SUM(CASE WHEN is_copy = 0 THEN postprocess_seconds ELSE 0 END)
+                    AS postprocess_seconds,
+                SUM(CASE WHEN is_copy = 0 THEN pipeline_seconds ELSE 0 END)
+                    AS pipeline_seconds
+            FROM telemetry
+            GROUP BY island_idx
+            ORDER BY island_idx
+            """
+        )
+        return [dict(row) for row in self.cursor.fetchall()]
+
+    @db_retry()
     def get_all_programs(self) -> List[Program]:
         """Get all programs from the database."""
         if not self.cursor:

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -5,6 +5,7 @@ Provides async versions of patch application and validation.
 
 import asyncio
 import logging
+import shutil
 import tempfile
 from typing import Tuple, Optional
 from pathlib import Path
@@ -110,7 +111,10 @@ async def apply_patch_async(
 
 
 async def validate_code_async(
-    code_path: str, language: str = "python", timeout: int = 30
+    code_path: str,
+    language: str = "python",
+    timeout: int = 30,
+    rust_edition: str = "2015",
 ) -> Tuple[bool, Optional[str]]:
     """Async code validation using subprocess.
 
@@ -118,6 +122,7 @@ async def validate_code_async(
         code_path: Path to code file to validate
         language: Programming language
         timeout: Timeout for validation in seconds
+        rust_edition: Rust edition used when validating Rust source
 
     Returns:
         Tuple of (is_valid, error_message)
@@ -138,26 +143,41 @@ async def validate_code_async(
             )
 
         elif language == "rust":
-            # Use rustc for Rust syntax checking.
+            # Use rustfmt for Rust syntax checking.
             #
             # `-Zparse-only` is gated to the nightly channel: on a stable
             # toolchain rustc rejects the flag and exits non-zero before it
             # parses anything, so every candidate would be reported invalid.
-            # `--emit=dep-info` is the closest stable equivalent that still
-            # skips type checking, so a program with a type error is accepted
-            # here exactly as it was under `-Zparse-only`. The edition is
-            # pinned so the accepted syntax does not shift with the toolchain
-            # default, and dep-info output is written to a temporary directory
-            # instead of the working directory.
-            with tempfile.TemporaryDirectory(prefix="shinka-rustc-") as out_dir:
+            # Stable rustc has no parse-only equivalent. In particular,
+            # `--emit=dep-info` performs name resolution and expands built-in
+            # macros, which both rejects valid dependency-backed code and lets
+            # generated code read host files via `include_str!`. rustfmt parses
+            # the token stream without type checking or macro expansion.
+            # `skip_children` prevents `mod` declarations (including `#[path]`
+            # overrides) from making rustfmt read other host files. A clean
+            # config prevents a project rustfmt.toml from disabling parsing.
+            # Stdout mode also guarantees validation never rewrites the source.
+            if shutil.which("rustfmt") is None:
+                return (
+                    False,
+                    (
+                        "Rust validation requires rustfmt on PATH. Install it with "
+                        "`rustup component add rustfmt`."
+                    ),
+                )
+            with tempfile.TemporaryDirectory(prefix="shinka-rustfmt-") as config_dir:
+                config_path = Path(config_dir) / "rustfmt.toml"
+                config_path.touch()
                 return await _run_validation_subprocess(
-                    "rustc",
+                    "rustfmt",
+                    "--config-path",
+                    str(config_path),
+                    "--emit",
+                    "stdout",
                     "--edition",
-                    "2021",
-                    "--crate-type=lib",
-                    "--emit=dep-info",
-                    "--out-dir",
-                    out_dir,
+                    rust_edition,
+                    "--config",
+                    "skip_children=true",
                     code_path,
                     timeout=timeout,
                 )

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -5,6 +5,7 @@ Provides async versions of patch application and validation.
 
 import asyncio
 import logging
+import tempfile
 from typing import Tuple, Optional
 from pathlib import Path
 from .apply_diff import apply_diff_patch
@@ -137,14 +138,29 @@ async def validate_code_async(
             )
 
         elif language == "rust":
-            # Use rustc for Rust syntax checking
-            return await _run_validation_subprocess(
-                "rustc",
-                "--crate-type=lib",
-                "-Zparse-only",
-                code_path,
-                timeout=timeout,
-            )
+            # Use rustc for Rust syntax checking.
+            #
+            # `-Zparse-only` is gated to the nightly channel: on a stable
+            # toolchain rustc rejects the flag and exits non-zero before it
+            # parses anything, so every candidate would be reported invalid.
+            # `--emit=dep-info` is the closest stable equivalent that still
+            # skips type checking, so a program with a type error is accepted
+            # here exactly as it was under `-Zparse-only`. The edition is
+            # pinned so the accepted syntax does not shift with the toolchain
+            # default, and dep-info output is written to a temporary directory
+            # instead of the working directory.
+            with tempfile.TemporaryDirectory(prefix="shinka-rustc-") as out_dir:
+                return await _run_validation_subprocess(
+                    "rustc",
+                    "--edition",
+                    "2021",
+                    "--crate-type=lib",
+                    "--emit=dep-info",
+                    "--out-dir",
+                    out_dir,
+                    code_path,
+                    timeout=timeout,
+                )
         elif language == "swift":
             # Use swiftc for Swift compilation check
             return await _run_validation_subprocess(

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -32,22 +32,36 @@ async def _run_validation_subprocess(
     """Run a validator subprocess and normalize timeout/error handling."""
     proc = await asyncio.create_subprocess_exec(
         *args,
-        stdout=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
     )
+    communication = asyncio.create_task(proc.communicate())
 
     try:
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        _, stderr = await asyncio.wait_for(
+            asyncio.shield(communication), timeout=timeout
+        )
     except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
+        _kill_validation_process(proc)
+        await communication
         return False, f"Validation timeout after {timeout}s"
+    except asyncio.CancelledError:
+        _kill_validation_process(proc)
+        await asyncio.shield(communication)
+        raise
 
     if proc.returncode == 0:
         return True, None
 
     error_msg = stderr.decode() if stderr else "Unknown compilation error"
     return False, error_msg
+
+
+def _kill_validation_process(proc: asyncio.subprocess.Process) -> None:
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
 
 
 async def apply_patch_async(
@@ -178,6 +192,7 @@ async def validate_code_async(
                     rust_edition,
                     "--config",
                     "skip_children=true",
+                    "--",
                     code_path,
                     timeout=timeout,
                 )

--- a/shinka/llm/client.py
+++ b/shinka/llm/client.py
@@ -8,6 +8,7 @@ from shinka.env import load_shinka_dotenv
 from shinka.google_genai import _google_genai_timeout_ms, build_google_genai_client
 from shinka.local_openai_config import resolve_local_openai_api_key
 from .constants import OPENAI_MAX_RETRIES, TIMEOUT
+from .providers.errors import StructuredOutputNotSupportedError
 from .providers.model_resolver import resolve_model_backend
 
 load_shinka_dotenv()
@@ -71,12 +72,11 @@ def get_client_llm(
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
     elif provider == "google":
-        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
         if structured_output:
-            client = instructor.from_openai(
-                client,
-                mode=instructor.Mode.GEMINI_JSON,
+            raise StructuredOutputNotSupportedError(
+                "Gemini does not support structured output."
             )
+        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
     elif provider == "openrouter":
         client = openai.OpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],
@@ -159,9 +159,11 @@ def get_async_client_llm(
         if structured_output:
             client = instructor.from_openai(client, mode=instructor.Mode.MD_JSON)
     elif provider == "google":
-        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
         if structured_output:
-            raise ValueError("Gemini does not support structured output.")
+            raise StructuredOutputNotSupportedError(
+                "Gemini does not support structured output."
+            )
+        client = build_google_genai_client(timeout_ms=_google_genai_timeout_ms(TIMEOUT))
     elif provider == "openrouter":
         client = openai.AsyncOpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],

--- a/shinka/llm/constants.py
+++ b/shinka/llm/constants.py
@@ -25,3 +25,16 @@ BACKOFF_MAX_TIME = _env_int(
     "SHINKA_LLM_BACKOFF_MAX_TIME",
     TIMEOUT * BACKOFF_MAX_TIME_MULTIPLIER,
 )
+
+GEMINI_THINKING_LEVEL_MODELS = frozenset(
+    {
+        "gemini-3.6-flash",
+    }
+)
+GEMINI_THINKING_LEVEL_BY_EFFORT = {
+    "min": "LOW",
+    "low": "LOW",
+    "medium": "MEDIUM",
+    "high": "HIGH",
+    "max": "HIGH",
+}

--- a/shinka/llm/constants.py
+++ b/shinka/llm/constants.py
@@ -29,6 +29,7 @@ BACKOFF_MAX_TIME = _env_int(
 GEMINI_THINKING_LEVEL_MODELS = frozenset(
     {
         "gemini-3.6-flash",
+        "gemini-3.7-flash",
     }
 )
 GEMINI_THINKING_LEVEL_BY_EFFORT = {

--- a/shinka/llm/kwargs.py
+++ b/shinka/llm/kwargs.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional
+from typing import Any, List, Union, Optional
 import random
 from .providers.pricing import (
     is_reasoning_model,
@@ -6,6 +6,10 @@ from .providers.pricing import (
     requires_reasoning,
 )
 from .providers.model_resolver import resolve_model_backend
+from .constants import (
+    GEMINI_THINKING_LEVEL_BY_EFFORT,
+    GEMINI_THINKING_LEVEL_MODELS,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -22,6 +26,7 @@ NO_TEMPERATURE_MODELS = {
     "claude-opus-4-8",
     "deepseek-v4-flash",
     "deepseek-v4-pro",
+    *GEMINI_THINKING_LEVEL_MODELS,
     "us.anthropic.claude-opus-4-8",
 }
 
@@ -36,7 +41,7 @@ def sample_batch_kwargs(
     unique_filter: bool = False,
 ):
     """Sample a dictionary of kwargs for a given model."""
-    all_kwargs = []
+    all_kwargs: list[dict[str, Any]] = []
     attempts = 0
     max_attempts = num_samples * 10  # Prevent infinite loops
 
@@ -85,7 +90,7 @@ def sample_model_kwargs(
     if isinstance(reasoning_efforts, str):
         reasoning_efforts = [reasoning_efforts]
 
-    kwargs_dict = {}
+    kwargs_dict: dict[str, Any] = {}
 
     # 1. SAMPLE: model name
     if model_sample_probs is not None:
@@ -156,8 +161,12 @@ def sample_model_kwargs(
     # 4.b) SET: max_tokens for Google reasoning effort
     elif provider == "google" and is_reasoning_model(model_name):
         kwargs_dict["max_tokens"] = random.choice(max_tokens)
-        think_bool = r_effort != "disabled"
-        if think_bool:
+        if api_model_name in GEMINI_THINKING_LEVEL_MODELS:
+            if r_effort != "disabled":
+                kwargs_dict["thinking_level"] = GEMINI_THINKING_LEVEL_BY_EFFORT[
+                    r_effort
+                ]
+        elif r_effort != "disabled":
             t = THINKING_TOKENS[r_effort]
             thinking_tokens = t if t < kwargs_dict["max_tokens"] else 1024
             kwargs_dict["thinking_budget"] = thinking_tokens

--- a/shinka/llm/llm.py
+++ b/shinka/llm/llm.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Optional, Sequence, Union
 import re
 import json
 import multiprocessing as mp
@@ -9,10 +9,37 @@ import time
 from .query import query, query_async
 from .kwargs import sample_model_kwargs
 from .providers import QueryResult
+from .providers.errors import NonRetryableLLMError, StructuredOutputNotSupportedError
 from .providers.model_resolver import resolve_model_backend
 from .constants import MAX_RETRIES
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_structured_output_models(
+    output_model: Optional[BaseModel],
+    model_names: Sequence[Optional[str]],
+    model_sample_probs: Optional[List[float]] = None,
+) -> None:
+    if output_model is None:
+        return
+
+    active_models = model_names
+    if model_sample_probs is not None:
+        active_models = [
+            model_name
+            for model_name, probability in zip(model_names, model_sample_probs)
+            if probability > 0
+        ]
+
+    if any(
+        model_name is not None
+        and resolve_model_backend(model_name).provider == "google"
+        for model_name in active_models
+    ):
+        raise StructuredOutputNotSupportedError(
+            "Gemini does not support structured output."
+        )
 
 
 class LLMClient:
@@ -61,6 +88,11 @@ class LLMClient:
             msg (str): The message to query the LLM with.
             system_msg (str): The system message to query the LLM with.
         """
+        _validate_structured_output_models(
+            self.output_model,
+            [kwargs.get("model_name") for kwargs in llm_kwargs],
+        )
+
         # Repeat msg, system_msg, msg_history num_samples times
         if isinstance(msg, str):
             msg = [msg] * num_samples
@@ -100,6 +132,8 @@ class LLMClient:
                 try:
                     idx, result = async_result.get()
                     results.append((idx, result))
+                except NonRetryableLLMError:
+                    raise
                 except Exception as e:
                     logger.error(f"Error in batch query: {str(e)}")
 
@@ -154,6 +188,9 @@ class LLMClient:
             if model_sample_probs is not None
             else self.model_sample_probs
         )
+        _validate_structured_output_models(
+            self.output_model, self.model_names, posterior
+        )
 
         # multiprocess sample_kwargs_query
         num_processes = min(num_samples, mp.cpu_count())
@@ -195,6 +232,8 @@ class LLMClient:
                 try:
                     idx, result = async_result.get()
                     results.append((idx, result))
+                except NonRetryableLLMError:
+                    raise
                 except Exception as e:
                     logger.error(f"Error in batch query: {str(e)}")
 
@@ -322,6 +361,8 @@ class LLMClient:
                 if self.verbose and hasattr(result, "cost") and result.cost is not None:
                     logger.info(f"==> QUERY: API cost: ${result.cost:.4f}")
                 return result
+            except NonRetryableLLMError:
+                raise
             except Exception as e:
                 model_name = llm_kwargs.get("model_name", "<unknown>")
                 logger.error(
@@ -329,6 +370,8 @@ class LLMClient:
                     f"for model={model_name} kwargs={llm_kwargs}: {str(e)}"
                 )
                 try_count += 1
+                if try_count < MAX_RETRIES:
+                    time.sleep(1)
         return None
 
 
@@ -378,6 +421,11 @@ class AsyncLLMClient:
             msg (str): The message to query the LLM with.
             system_msg (str): The system message to query the LLM with.
         """
+        _validate_structured_output_models(
+            self.output_model,
+            [kwargs.get("model_name") for kwargs in llm_kwargs],
+        )
+
         # Repeat msg, system_msg, msg_history num_samples times
         if isinstance(msg, str):
             msg = [msg] * num_samples
@@ -409,6 +457,8 @@ class AsyncLLMClient:
         # Process results and filter out exceptions
         final_results = []
         for i, result in enumerate(results):
+            if isinstance(result, NonRetryableLLMError):
+                raise result
             if isinstance(result, Exception):
                 logger.info(f"Error in batch query task {i}: {str(result)}")
             elif result is not None and len(result) > 1 and result[1] is not None:
@@ -461,6 +511,9 @@ class AsyncLLMClient:
             if model_sample_probs is not None
             else self.model_sample_probs
         )
+        _validate_structured_output_models(
+            self.output_model, self.model_names, posterior
+        )
 
         if self.verbose:
             lines = [f"==> SAMPLING {num_samples} SAMPLES:"]
@@ -490,6 +543,8 @@ class AsyncLLMClient:
         # Process results and filter out exceptions
         final_results = []
         for i, result in enumerate(results):
+            if isinstance(result, NonRetryableLLMError):
+                raise result
             if isinstance(result, Exception):
                 logger.info(f"Error in batch query task {i}: {str(result)}")
             elif result is not None and len(result) > 1 and result[1] is not None:
@@ -615,6 +670,8 @@ class AsyncLLMClient:
                 if self.verbose and hasattr(result, "cost") and result.cost is not None:
                     logger.info(f"==> QUERY: API cost: ${result.cost:.4f}")
                 return result
+            except NonRetryableLLMError:
+                raise
             except Exception as e:
                 logger.info(f"{try_count + 1}/{MAX_RETRIES} Error in query: {str(e)}")
                 try_count += 1
@@ -647,6 +704,8 @@ class AsyncLLMClient:
                     **kwargs,
                 )
                 return idx, result
+            except NonRetryableLLMError:
+                raise
             except Exception as e:
                 logger.info(f"{try_count + 1}/{MAX_RETRIES} Error in query: {str(e)}")
                 try_count += 1
@@ -695,6 +754,8 @@ class AsyncLLMClient:
                     **kwargs,
                 )
                 return idx, result
+            except NonRetryableLLMError:
+                raise
             except Exception as e:
                 logger.info(f"{try_count + 1}/{MAX_RETRIES} Error in query: {str(e)}")
                 try_count += 1
@@ -728,6 +789,8 @@ def query_fn(
                 **kwargs,
             )
             return idx, result
+        except NonRetryableLLMError:
+            raise
         except Exception as e:
             logger.error(f"{try_count + 1}/{MAX_RETRIES} Error in query: {str(e)}")
             try_count += 1
@@ -789,6 +852,8 @@ def sample_kwargs_query_fn(
                 **kwargs,
             )
             return idx, result
+        except NonRetryableLLMError:
+            raise
         except Exception as e:
             logger.error(f"{try_count + 1}/{MAX_RETRIES} Error in query: {str(e)}")
             try_count += 1

--- a/shinka/llm/providers/errors.py
+++ b/shinka/llm/providers/errors.py
@@ -1,0 +1,6 @@
+class NonRetryableLLMError(ValueError):
+    """A deterministic request failure that cannot succeed when retried."""
+
+
+class StructuredOutputNotSupportedError(NonRetryableLLMError):
+    """The selected provider cannot satisfy a structured-output request."""

--- a/shinka/llm/providers/gemini.py
+++ b/shinka/llm/providers/gemini.py
@@ -8,6 +8,7 @@ from shinka.llm.constants import (
     BACKOFF_MAX_VALUE,
     GEMINI_THINKING_LEVEL_MODELS,
 )
+from .errors import NonRetryableLLMError, StructuredOutputNotSupportedError
 from .pricing import calculate_cost
 from .result import QueryResult
 
@@ -17,6 +18,14 @@ logger = logging.getLogger(__name__)
 MAX_TRIES = BACKOFF_MAX_TRIES
 MAX_VALUE = BACKOFF_MAX_VALUE
 MAX_TIME = BACKOFF_MAX_TIME
+DEFAULT_THINKING_BUDGET = 1024
+
+
+GeminiStructuredOutputError = StructuredOutputNotSupportedError
+
+
+def _giveup_gemini(exc: Exception) -> bool:
+    return isinstance(exc, NonRetryableLLMError)
 
 
 def build_gemini_thinking_config(thinking_budget: int):
@@ -202,6 +211,7 @@ def gemini_extract_thoughts_and_content(response):
     max_value=MAX_VALUE,
     max_time=MAX_TIME,
     on_backoff=backoff_handler,
+    giveup=_giveup_gemini,
 )
 def query_gemini(
     client,
@@ -218,7 +228,9 @@ def query_gemini(
     Based on: https://ai.google.dev/gemini-api/docs/text-generation
     """
     if output_model is not None:
-        raise ValueError("Gemini does not support structured output.")
+        raise GeminiStructuredOutputError(
+            "Gemini does not support structured output."
+        )
 
     # Build structured contents
     contents = gemini_build_contents(msg_history, msg)
@@ -227,7 +239,7 @@ def query_gemini(
     temperature = kwargs.get("temperature", 0.8)
     top_p = kwargs.get("top_p", 1.0)
     max_tokens = kwargs.get("max_tokens", 2048)
-    thinking_budget = kwargs.get("thinking_budget", 1024)
+    thinking_budget = kwargs.get("thinking_budget", DEFAULT_THINKING_BUDGET)
 
     generation_config = build_gemini_generation_config(
         model=model,
@@ -279,6 +291,7 @@ def query_gemini(
     max_value=MAX_VALUE,
     max_time=MAX_TIME,
     on_backoff=backoff_handler,
+    giveup=_giveup_gemini,
 )
 async def query_gemini_async(
     client,
@@ -295,7 +308,9 @@ async def query_gemini_async(
     Based on: https://ai.google.dev/gemini-api/docs/text-generation
     """
     if output_model is not None:
-        raise ValueError("Gemini does not support structured output.")
+        raise GeminiStructuredOutputError(
+            "Gemini does not support structured output."
+        )
 
     # Build structured contents
     contents = gemini_build_contents(msg_history, msg)
@@ -304,7 +319,7 @@ async def query_gemini_async(
     temperature = kwargs.get("temperature", 0.8)
     top_p = kwargs.get("top_p", 1.0)
     max_tokens = kwargs.get("max_tokens", 2048)
-    thinking_budget = kwargs.get("thinking_budget", 0)
+    thinking_budget = kwargs.get("thinking_budget", DEFAULT_THINKING_BUDGET)
 
     generation_config = build_gemini_generation_config(
         model=model,

--- a/shinka/llm/providers/gemini.py
+++ b/shinka/llm/providers/gemini.py
@@ -2,7 +2,12 @@ import backoff
 import logging
 from typing import Any, cast
 from google.genai import types
-from shinka.llm.constants import BACKOFF_MAX_TIME, BACKOFF_MAX_TRIES, BACKOFF_MAX_VALUE
+from shinka.llm.constants import (
+    BACKOFF_MAX_TIME,
+    BACKOFF_MAX_TRIES,
+    BACKOFF_MAX_VALUE,
+    GEMINI_THINKING_LEVEL_MODELS,
+)
 from .pricing import calculate_cost
 from .result import QueryResult
 
@@ -32,6 +37,24 @@ def build_gemini_thinking_config(thinking_budget: int):
     return thinking_config_cls(**config_kwargs)
 
 
+def build_gemini_thinking_level_config(thinking_level: str | None):
+    """Build level-based thinking config for current Gemini Flash models."""
+    config_kwargs: dict[str, object] = {"include_thoughts": True}
+    if thinking_level is not None:
+        valid_levels = {
+            "LOW": types.ThinkingLevel.LOW,
+            "MEDIUM": types.ThinkingLevel.MEDIUM,
+            "HIGH": types.ThinkingLevel.HIGH,
+        }
+        try:
+            config_kwargs["thinking_level"] = valid_levels[thinking_level.upper()]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported Gemini thinking level: {thinking_level}") from exc
+
+    thinking_config_cls = cast(Any, types.ThinkingConfig)
+    return thinking_config_cls(**config_kwargs)
+
+
 def build_gemini_afc_config():
     """Build Gemini automatic function-calling config without SDK warnings."""
     model_fields = getattr(types.AutomaticFunctionCallingConfig, "model_fields", {})
@@ -45,6 +68,37 @@ def build_gemini_afc_config():
 
     afc_config_cls = cast(Any, types.AutomaticFunctionCallingConfig)
     return afc_config_cls(**config_kwargs)
+
+
+def build_gemini_generation_config(
+    *,
+    model: str,
+    temperature: float,
+    top_p: float,
+    max_tokens: int,
+    system_instruction: str | None,
+    thinking_budget: int,
+    thinking_level: str | None,
+):
+    """Build a model-compatible config for sync and async requests."""
+    config_kwargs: dict[str, object] = {
+        "max_output_tokens": int(max_tokens),
+        "system_instruction": system_instruction,
+        "automatic_function_calling": build_gemini_afc_config(),
+    }
+    if model in GEMINI_THINKING_LEVEL_MODELS:
+        config_kwargs["thinking_config"] = build_gemini_thinking_level_config(
+            thinking_level
+        )
+    else:
+        config_kwargs.update(
+            temperature=float(temperature),
+            top_p=float(top_p),
+            thinking_config=build_gemini_thinking_config(thinking_budget),
+        )
+
+    generation_config_cls = cast(Any, types.GenerateContentConfig)
+    return generation_config_cls(**config_kwargs)
 
 
 def get_gemini_costs(response, model):
@@ -175,13 +229,14 @@ def query_gemini(
     max_tokens = kwargs.get("max_tokens", 2048)
     thinking_budget = kwargs.get("thinking_budget", 1024)
 
-    generation_config = types.GenerateContentConfig(
-        temperature=float(temperature),
-        top_p=float(top_p),
-        max_output_tokens=int(max_tokens),
+    generation_config = build_gemini_generation_config(
+        model=model,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
         system_instruction=system_msg if system_msg else None,
-        automatic_function_calling=build_gemini_afc_config(),
-        thinking_config=build_gemini_thinking_config(thinking_budget),
+        thinking_budget=thinking_budget,
+        thinking_level=kwargs.get("thinking_level"),
     )
 
     response = client.models.generate_content(
@@ -251,13 +306,14 @@ async def query_gemini_async(
     max_tokens = kwargs.get("max_tokens", 2048)
     thinking_budget = kwargs.get("thinking_budget", 0)
 
-    generation_config = types.GenerateContentConfig(
-        temperature=float(temperature),
-        top_p=float(top_p),
-        max_output_tokens=int(max_tokens),
+    generation_config = build_gemini_generation_config(
+        model=model,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
         system_instruction=system_msg if system_msg else None,
-        automatic_function_calling=build_gemini_afc_config(),
-        thinking_config=build_gemini_thinking_config(thinking_budget),
+        thinking_budget=thinking_budget,
+        thinking_level=kwargs.get("thinking_level"),
     )
 
     response = await client.aio.models.generate_content(

--- a/shinka/llm/providers/pricing.csv
+++ b/shinka/llm/providers/pricing.csv
@@ -54,6 +54,7 @@ deepseek-chat,deepseek,0.14,0.28,,,,False,0,0
 deepseek-reasoner,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-flash,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-pro,deepseek,0.435,0.87,,,,True,0,0
+gemini-3.7-flash,google,0.75,3.75,,,,True,0,0
 gemini-3.6-flash,google,0.75,3.75,,,,True,0,0
 gemini-3.5-flash,google,1.5,9.0,,,,True,0,0
 gemini-3-flash-preview,google,0.5,3.0,,,,True,0,0

--- a/shinka/llm/providers/pricing.csv
+++ b/shinka/llm/providers/pricing.csv
@@ -54,6 +54,7 @@ deepseek-chat,deepseek,0.14,0.28,,,,False,0,0
 deepseek-reasoner,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-flash,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-pro,deepseek,0.435,0.87,,,,True,0,0
+gemini-3.6-flash,google,0.75,3.75,,,,True,0,0
 gemini-3.5-flash,google,1.5,9.0,,,,True,0,0
 gemini-3-flash-preview,google,0.5,3.0,,,,True,0,0
 gemini-3-pro-preview,google,2.0,12.0,4.0,18.0,200000,True,0,0

--- a/shinka/telemetry_safety.py
+++ b/shinka/telemetry_safety.py
@@ -1,0 +1,44 @@
+"""Shared metadata-boundary safety helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_SENSITIVE_WORDS = {
+    "auth",
+    "authorization",
+    "cookie",
+    "code",
+    "credential",
+    "credentials",
+    "embedding",
+    "embeddings",
+    "password",
+    "secret",
+    "token",
+}
+_SENSITIVE_COMPOUNDS = {
+    "accesskey",
+    "accesstoken",
+    "apikey",
+    "authheader",
+    "authorizationheader",
+    "authtoken",
+    "clientsecret",
+    "privatekey",
+    "secretaccesskey",
+    "tasksysmsg",
+}
+
+
+def is_sensitive_telemetry_key(value: Any) -> bool:
+    """Recognize sensitive keys across snake, kebab, camel, and acronym case."""
+    text = str(value).strip()
+    text = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", text)
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", text)
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    joined = "".join(words)
+    return bool(set(words) & _SENSITIVE_WORDS) or any(
+        compound in joined for compound in _SENSITIVE_COMPOUNDS
+    )

--- a/shinka/tools/pricing/models_dev_overlay.json
+++ b/shinka/tools/pricing/models_dev_overlay.json
@@ -84,6 +84,14 @@
   "llm_overrides": [
     {
       "provider": "google",
+      "model_name": "gemini-3.7-flash",
+      "input_price": 0.75,
+      "output_price": 3.75,
+      "is_reasoning": true,
+      "think_temp_fixed": false
+    },
+    {
+      "provider": "google",
       "model_name": "gemini-3.6-flash",
       "input_price": 0.75,
       "output_price": 3.75,

--- a/shinka/tools/pricing/models_dev_overlay.json
+++ b/shinka/tools/pricing/models_dev_overlay.json
@@ -83,6 +83,14 @@
   ],
   "llm_overrides": [
     {
+      "provider": "google",
+      "model_name": "gemini-3.6-flash",
+      "input_price": 0.75,
+      "output_price": 3.75,
+      "is_reasoning": true,
+      "think_temp_fixed": false
+    },
+    {
       "provider": "anthropic",
       "model_name": "claude-3-5-haiku-20241022",
       "input_price": 0.8,

--- a/shinka/wandb_logging.py
+++ b/shinka/wandb_logging.py
@@ -5,44 +5,114 @@ from __future__ import annotations
 import importlib
 import logging
 import math
-import re
 import uuid
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Optional
 
 from shinka.database import Program, ProgramDatabase
+from shinka.telemetry_safety import is_sensitive_telemetry_key
+from shinka.wandb_metrics import (
+    EVALUATED_COUNT_METRIC,
+    GENERATION_METRIC,
+    INDIVIDUAL_SCORE_METRIC,
+    MAX_METRIC_KEY_LENGTH,
+    MAX_PUBLIC_METRICS,
+    PROGRAM_TABLE_COLUMNS,
+    PROGRAM_TABLE_KEY,
+    build_population_progress_payload,
+    build_population_progress_payload_from_telemetry,
+    build_program_log_payload,
+    build_run_summary,
+    flatten_numeric_metrics,
+    is_island_copy,
+    program_costs,
+    program_table_row,
+)
+
+__all__ = [
+    "EVALUATED_COUNT_METRIC",
+    "GENERATION_METRIC",
+    "INDIVIDUAL_SCORE_METRIC",
+    "MAX_METRIC_KEY_LENGTH",
+    "MAX_PUBLIC_METRICS",
+    "PROGRAM_TABLE_COLUMNS",
+    "PROGRAM_TABLE_KEY",
+    "ShinkaWandbLogger",
+    "build_population_progress_payload",
+    "build_population_progress_payload_from_telemetry",
+    "build_program_log_payload",
+    "build_run_summary",
+    "ensure_wandb_run_id",
+    "flatten_numeric_metrics",
+    "is_island_copy",
+    "program_costs",
+    "program_table_row",
+]
 
 logger = logging.getLogger(__name__)
 
-GENERATION_METRIC = "generation"
-INDIVIDUAL_SCORE_METRIC = "score/individual"
-PROGRAM_TABLE_KEY = "individuals"
 WANDB_RUN_ID_FILENAME = ".wandb_run_id"
-PROGRAM_TABLE_COLUMNS = [
-    "id",
-    "generation",
-    "score",
-    "correct",
-    "parent_id",
-    "island_idx",
-    "in_archive",
-    "patch_type",
-    "model_name",
-    "cost",
-]
-
-_COST_KEYS = {
-    "api": "api_costs",
-    "embedding": "embed_cost",
-    "novelty": "novelty_cost",
-    "meta": "meta_cost",
-}
-_TIMING_KEYS = (
-    "sampling_seconds",
-    "evaluation_seconds",
-    "postprocess_seconds",
-    "pipeline_seconds",
+_REDACTED_VALUE = "<redacted>"
+_EVOLUTION_CONFIG_FIELDS = (
+    "num_generations",
+    "max_patch_resamples",
+    "max_patch_attempts",
+    "job_type",
+    "language",
+    "meta_rec_interval",
+    "meta_max_recommendations",
+    "sample_single_meta_rec",
+    "max_novelty_attempts",
+    "code_embed_sim_threshold",
+    "use_text_feedback",
+    "max_api_costs",
+    "enable_controlled_oversubscription",
+    "proposal_target_mode",
+    "proposal_target_min_samples",
+    "proposal_target_ratio_cap",
+    "proposal_buffer_max",
+    "proposal_target_hard_cap",
+    "proposal_target_ewma_alpha",
+    "evolve_prompts",
+    "prompt_evolution_interval",
+    "prompt_archive_size",
+    "prompt_ucb_exploration_constant",
+    "prompt_epsilon",
+    "prompt_evo_top_k_programs",
+    "prompt_percentile_recompute_interval",
+)
+_DATABASE_CONFIG_FIELDS = (
+    "num_islands",
+    "archive_size",
+    "max_stdout_log_chars",
+    "elite_selection_ratio",
+    "num_archive_inspirations",
+    "num_top_k_inspirations",
+    "migration_interval",
+    "migration_rate",
+    "island_elitism",
+    "enforce_island_separation",
+    "island_selection_strategy",
+    "enable_dynamic_islands",
+    "stagnation_threshold",
+    "island_spawn_strategy",
+    "island_spawn_subtree_size",
+    "parent_selection_strategy",
+    "exploitation_alpha",
+    "exploitation_ratio",
+    "parent_selection_lambda",
+    "num_beams",
+    "archive_selection_strategy",
+)
+_JOB_CONFIG_FIELDS = (
+    "eval_verbose",
+    "numeric_threads_per_job",
+    "partition",
+    "time",
+    "cpus",
+    "gpus",
+    "mem",
 )
 
 
@@ -65,121 +135,6 @@ def ensure_wandb_run_id(
     return run_id
 
 
-def build_program_log_payload(program: Program) -> Dict[str, Any]:
-    """Build one compact W&B history event for an evaluated individual."""
-    metadata = program.metadata or {}
-    costs = program_costs(program)
-    individual_score = _finite_float(program.combined_score)
-    payload: Dict[str, Any] = {
-        GENERATION_METRIC: program.generation,
-        INDIVIDUAL_SCORE_METRIC: individual_score,
-        "individual/id": program.id,
-        "individual/parent_id": program.parent_id,
-        "individual/island_idx": program.island_idx,
-        "individual/correct": bool(program.correct),
-        "individual/in_archive": bool(program.in_archive),
-        "individual/patch_type": metadata.get("patch_type"),
-        "individual/model_name": _program_model_name(program),
-        **{f"cost/{name}": value for name, value in costs.items()},
-    }
-
-    for key in _TIMING_KEYS:
-        value = _finite_float(metadata.get(key))
-        if value is not None:
-            payload[f"timing/{key}"] = value
-
-    for prefix, metrics in (
-        ("public_metrics", program.public_metrics),
-        ("private_metrics", program.private_metrics),
-    ):
-        for key, value in flatten_numeric_metrics(metrics, prefix).items():
-            leaf_name = key.rsplit("/", 1)[-1]
-            if leaf_name in {"score", "combined_score"} and value == individual_score:
-                continue
-            payload[key] = value
-    return {key: value for key, value in payload.items() if value is not None}
-
-
-def flatten_numeric_metrics(
-    data: Any,
-    prefix: str,
-    *,
-    max_depth: int = 3,
-) -> Dict[str, float]:
-    """Flatten only numeric evaluation metrics, excluding bulky text and arrays."""
-    flattened: Dict[str, float] = {}
-
-    def visit(value: Any, parts: List[str], depth: int) -> None:
-        if depth > max_depth:
-            return
-        if isinstance(value, dict):
-            for key, child in value.items():
-                visit(child, [*parts, _metric_segment(key)], depth + 1)
-            return
-        numeric_value = _finite_float(value)
-        if numeric_value is not None:
-            flattened["/".join([prefix, *parts])] = numeric_value
-
-    if isinstance(data, dict):
-        for key, value in data.items():
-            visit(value, [_metric_segment(key)], 1)
-    return flattened
-
-
-def program_costs(program: Program) -> Dict[str, float]:
-    """Return the non-duplicated cost breakdown for one individual."""
-    metadata = program.metadata or {}
-    return {
-        name: _finite_float(metadata.get(metadata_key)) or 0.0
-        for name, metadata_key in _COST_KEYS.items()
-    }
-
-
-def program_table_row(program: Program) -> List[Any]:
-    """Return a compact row; detailed program data remains in the WebUI database."""
-    metadata = program.metadata or {}
-    return [
-        program.id,
-        program.generation,
-        _finite_float(program.combined_score),
-        bool(program.correct),
-        program.parent_id,
-        program.island_idx,
-        bool(program.in_archive),
-        metadata.get("patch_type"),
-        _program_model_name(program),
-        sum(program_costs(program).values()),
-    ]
-
-
-def build_run_summary(
-    programs: Sequence[Program],
-    *,
-    total_proposals_generated: Optional[int] = None,
-    total_api_cost: Optional[float] = None,
-) -> Dict[str, Any]:
-    """Build concise final values for the W&B run summary."""
-    correct_programs = [program for program in programs if program.correct]
-    correct_scores = [
-        score
-        for program in correct_programs
-        if (score := _finite_float(program.combined_score)) is not None
-    ]
-    summary = {
-        "run/program_count": len(programs),
-        "run/correct_rate": (
-            len(correct_programs) / len(programs) if programs else 0.0
-        ),
-        "run/max_generation": max(
-            (program.generation for program in programs), default=0
-        ),
-        "run/best_score": max(correct_scores) if correct_scores else None,
-        "run/total_proposals_generated": total_proposals_generated,
-        "run/total_api_cost": _finite_float(total_api_cost),
-    }
-    return {key: value for key, value in summary.items() if value is not None}
-
-
 class ShinkaWandbLogger:
     """Best-effort W&B sink that leaves database/WebUI logging unchanged."""
 
@@ -188,6 +143,7 @@ class ShinkaWandbLogger:
         self._wandb: Optional[Any] = None
         self._run: Optional[Any] = None
         self._logged_program_ids: set[str] = set()
+        self._last_population_evaluated_count: Optional[int] = None
 
     @property
     def active(self) -> bool:
@@ -229,11 +185,19 @@ class ShinkaWandbLogger:
             )
             evo_config.wandb_run_id = run_id
             config = {
-                "evolution": _json_safe(evo_config),
-                "database": _json_safe(db_config),
-                "job": _json_safe(job_config),
+                "evolution": _safe_config_fields(evo_config, _EVOLUTION_CONFIG_FIELDS),
+                "database": _safe_config_fields(db_config, _DATABASE_CONFIG_FIELDS),
+                "job": _safe_config_fields(job_config, _JOB_CONFIG_FIELDS),
             }
             config.update(extra_config)
+            settings = self._wandb.Settings(
+                console="off",
+                disable_git=True,
+                disable_code=True,
+                x_disable_stats=True,
+                x_disable_machine_info=True,
+                x_save_requirements=False,
+            )
             init_kwargs = {
                 "project": getattr(evo_config, "wandb_project", None)
                 or "shinka-evolve",
@@ -247,6 +211,8 @@ class ShinkaWandbLogger:
                 "dir": getattr(evo_config, "wandb_dir", None) or str(results_dir),
                 "id": run_id,
                 "resume": getattr(evo_config, "wandb_resume", "allow"),
+                "save_code": False,
+                "settings": settings,
                 "config": config,
             }
             self._run = self._wandb.init(
@@ -264,13 +230,57 @@ class ShinkaWandbLogger:
             self.enabled = False
 
     def log_program(self, program: Program) -> None:
-        if not self.active or program.id in self._logged_program_ids:
+        if (
+            not self.active
+            or is_island_copy(program)
+            or program.id in self._logged_program_ids
+        ):
+            return
+        self.log_program_payload(program.id, build_program_log_payload(program))
+
+    def log_program_payload(self, program_id: str, payload: dict[str, Any]) -> None:
+        """Log one prebuilt compact candidate payload."""
+        run = self._run
+        if not self.enabled or run is None or program_id in self._logged_program_ids:
             return
         try:
-            self._run.log(build_program_log_payload(program))
-            self._logged_program_ids.add(program.id)
+            run.log(payload)
+            self._logged_program_ids.add(program_id)
         except Exception as exc:
-            logger.warning("Failed to log individual %s to W&B: %s", program.id, exc)
+            logger.warning("Failed to log individual %s to W&B: %s", program_id, exc)
+
+    def log_population_progress(
+        self,
+        *,
+        db: Optional[ProgramDatabase],
+    ) -> None:
+        """Log a snapshot only when the evaluated population advances."""
+        if not self.enabled or self._run is None or db is None:
+            return
+        try:
+            snapshot = db.get_population_telemetry()
+        except Exception as exc:
+            logger.warning("Failed to query W&B population progress: %s", exc)
+            return
+        self.log_population_snapshot(snapshot)
+
+    def log_population_snapshot(self, snapshot: list[dict[str, Any]]) -> None:
+        """Log a precomputed snapshot on the W&B telemetry worker."""
+        run = self._run
+        if not self.enabled or run is None:
+            return
+        try:
+            payload = build_population_progress_payload_from_telemetry(snapshot)
+            evaluated_count = payload[EVALUATED_COUNT_METRIC]
+            if (
+                self._last_population_evaluated_count is not None
+                and evaluated_count <= self._last_population_evaluated_count
+            ):
+                return
+            run.log(payload)
+            self._last_population_evaluated_count = evaluated_count
+        except Exception as exc:
+            logger.warning("Failed to log W&B population progress: %s", exc)
 
     def log_final(
         self,
@@ -278,25 +288,72 @@ class ShinkaWandbLogger:
         db: Optional[ProgramDatabase],
         total_proposals_generated: Optional[int] = None,
         total_api_cost: Optional[float] = None,
+        total_cost: Optional[float] = None,
     ) -> None:
-        if not self.active or db is None:
+        if not self.enabled or self._run is None or self._wandb is None or db is None:
             return
         try:
             programs = db.get_all_programs()
-            self._run.summary.update(
-                build_run_summary(
-                    programs,
-                    total_proposals_generated=total_proposals_generated,
-                    total_api_cost=total_api_cost,
-                )
+        except Exception as exc:
+            logger.warning("Failed to query final W&B programs: %s", exc)
+            return
+        self.log_final_programs(
+            programs,
+            total_proposals_generated=total_proposals_generated,
+            total_api_cost=total_api_cost,
+            total_cost=total_cost,
+        )
+
+    def log_final_programs(
+        self,
+        programs: list[Program],
+        *,
+        total_proposals_generated: Optional[int] = None,
+        total_api_cost: Optional[float] = None,
+        total_cost: Optional[float] = None,
+    ) -> None:
+        """Log final metrics and table from owner-thread materialized programs."""
+        run = self._run
+        wandb = self._wandb
+        if not self.enabled or run is None or wandb is None:
+            return
+        try:
+            final_summary = build_run_summary(
+                programs,
+                total_proposals_generated=total_proposals_generated,
+                total_api_cost=total_api_cost,
+                total_cost=total_cost,
             )
-            table = self._wandb.Table(
+            final_payload = build_population_progress_payload(programs)
+            final_payload.update(final_summary)
+        except Exception as exc:
+            logger.warning("Failed to prepare final W&B metrics: %s", exc)
+            return
+
+        try:
+            run.log(final_payload)
+        except Exception as exc:
+            logger.warning("Failed to log final W&B history: %s", exc)
+        self._last_population_evaluated_count = final_payload[EVALUATED_COUNT_METRIC]
+
+        try:
+            run.summary.update(final_summary)
+        except Exception as exc:
+            logger.warning("Failed to update final W&B summary: %s", exc)
+
+        try:
+            table = wandb.Table(
                 columns=PROGRAM_TABLE_COLUMNS,
                 data=[program_table_row(program) for program in programs],
             )
-            self._run.log({PROGRAM_TABLE_KEY: table})
         except Exception as exc:
-            logger.warning("Failed to log final W&B summary: %s", exc)
+            logger.warning("Failed to construct final W&B table: %s", exc)
+            return
+
+        try:
+            run.log({PROGRAM_TABLE_KEY: table})
+        except Exception as exc:
+            logger.warning("Failed to log final W&B table: %s", exc)
 
     def finish(self) -> None:
         if self._run is None:
@@ -309,53 +366,38 @@ class ShinkaWandbLogger:
             self._run = None
 
     def _define_metrics(self) -> None:
-        if not hasattr(self._run, "define_metric"):
+        run = self._run
+        if run is None or not hasattr(run, "define_metric"):
             return
-        self._run.define_metric(GENERATION_METRIC)
-        self._run.define_metric(
-            INDIVIDUAL_SCORE_METRIC,
-            step_metric=GENERATION_METRIC,
-        )
+        run.define_metric(GENERATION_METRIC)
+        run.define_metric(EVALUATED_COUNT_METRIC)
+        run.define_metric(INDIVIDUAL_SCORE_METRIC)
+        run.define_metric("run/*")
         for metric_glob in (
+            "population/count",
+            "population/correct_count",
+            "population/correct_rate",
+            "population/best_score",
+            "population/best_correct_score",
+            "population/mean_score",
+            "island/*",
             "cost/*",
             "timing/*",
-            "public_metrics/*",
-            "private_metrics/*",
         ):
-            self._run.define_metric(metric_glob, step_metric=GENERATION_METRIC)
-
-
-def _program_model_name(program: Program) -> Optional[str]:
-    metadata = program.metadata or {}
-    llm_result = metadata.get("llm_result")
-    nested_model = llm_result.get("model") if isinstance(llm_result, dict) else None
-    value = metadata.get("model_name") or metadata.get("model") or nested_model
-    return str(value) if value is not None else None
-
-
-def _finite_float(value: Any) -> Optional[float]:
-    if value is None or isinstance(value, (bool, str, bytes)):
-        return None
-    if hasattr(value, "item") and callable(value.item):
-        try:
-            value = value.item()
-        except Exception:
-            return None
-    if not isinstance(value, (int, float)):
-        return None
-    parsed = float(value)
-    return parsed if math.isfinite(parsed) else None
-
-
-def _metric_segment(value: Any) -> str:
-    segment = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip())
-    return segment.strip("_") or "value"
+            run.define_metric(
+                metric_glob,
+                step_metric=EVALUATED_COUNT_METRIC,
+            )
 
 
 def _json_safe(value: Any) -> Any:
     if is_dataclass(value) and not isinstance(value, type):
         return {
-            field.name: _json_safe(getattr(value, field.name))
+            field.name: (
+                _REDACTED_VALUE
+                if _is_sensitive_config_key(field.name)
+                else _json_safe(getattr(value, field.name))
+            )
             for field in fields(value)
         }
     if isinstance(value, Path):
@@ -368,9 +410,33 @@ def _json_safe(value: Any) -> Any:
         try:
             return _json_safe(value.item())
         except Exception:
-            pass
+            return f"<{type(value).__name__}>"
     if isinstance(value, dict):
-        return {str(key): _json_safe(item) for key, item in value.items()}
+        return {
+            str(key): (
+                _REDACTED_VALUE if _is_sensitive_config_key(key) else _json_safe(item)
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, (list, tuple, set)):
         return [_json_safe(item) for item in value]
-    return repr(value)
+    return f"<{type(value).__name__}>"
+
+
+def _safe_config_fields(value: Any, allowed_fields: tuple[str, ...]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    missing = object()
+    for field_name in allowed_fields:
+        if isinstance(value, dict):
+            field_value = value.get(field_name, missing)
+        else:
+            field_value = getattr(value, field_name, missing)
+        if field_value is missing:
+            continue
+        if field_value is None or isinstance(field_value, (bool, int, float, str)):
+            safe[field_name] = _json_safe(field_value)
+    return safe
+
+
+def _is_sensitive_config_key(value: Any) -> bool:
+    return is_sensitive_telemetry_key(value)

--- a/shinka/wandb_metrics.py
+++ b/shinka/wandb_metrics.py
@@ -1,0 +1,408 @@
+"""Safe metric payloads for the optional W&B integration."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from shinka.database import Program
+from shinka.telemetry_safety import is_sensitive_telemetry_key
+
+GENERATION_METRIC = "generation"
+INDIVIDUAL_SCORE_METRIC = "score/individual"
+EVALUATED_COUNT_METRIC = "population/evaluated_count"
+PROGRAM_TABLE_KEY = "population/final_table"
+MAX_PUBLIC_METRICS = 64
+MAX_METRIC_KEY_LENGTH = 128
+PROGRAM_TABLE_COLUMNS = [
+    "id",
+    "generation",
+    "score",
+    "correct",
+    "parent_id",
+    "island_idx",
+    "is_copy",
+    "in_archive",
+    "patch_type",
+    "model_name",
+    "cost",
+]
+
+_COST_KEYS = {
+    "api": "api_costs",
+    "embed": "embed_cost",
+    "novelty": "novelty_cost",
+    "meta": "meta_cost",
+}
+_HEADLESS_MODEL_PREFIX = "headless/"
+_TIMING_KEYS = (
+    "sampling_seconds",
+    "evaluation_seconds",
+    "postprocess_seconds",
+    "pipeline_seconds",
+)
+
+
+def build_program_log_payload(program: Program) -> Dict[str, Any]:
+    """Build one raw W&B history event for an evaluated individual.
+
+    Individual events use W&B's internal history step. They are candidate
+    scatter data, not the run's canonical progress series.
+    """
+    metadata = program.metadata or {}
+    headless_used = _is_headless_program(program)
+    logged_costs = _reported_program_costs(program)
+    individual_score = _finite_float(program.combined_score)
+    payload: Dict[str, Any] = {
+        GENERATION_METRIC: program.generation,
+        INDIVIDUAL_SCORE_METRIC: individual_score,
+        "individual/id": program.id,
+        "individual/parent_id": program.parent_id,
+        "individual/island_idx": program.island_idx,
+        "individual/is_copy": is_island_copy(program),
+        "individual/correct": bool(program.correct),
+        "individual/in_archive": bool(program.in_archive),
+        "individual/patch_type": metadata.get("patch_type"),
+        "individual/model_name": _program_model_name(program),
+        **{f"individual/cost/{name}": value for name, value in logged_costs.items()},
+    }
+    if headless_used:
+        payload.update(
+            {
+                "headless/usage_status": metadata.get("headless_usage_status"),
+                "headless/usage_unknown": metadata.get("headless_usage_unknown"),
+                "headless/pricing_status": metadata.get("headless_pricing_status"),
+                "headless/pricing_unknown": metadata.get("headless_pricing_unknown"),
+                "headless/cost_basis": metadata.get("headless_cost_basis"),
+                "headless/pricing_source": metadata.get("headless_pricing_source"),
+            }
+        )
+
+    for key in _TIMING_KEYS:
+        value = _finite_float(metadata.get(key))
+        if value is not None:
+            payload[f"individual/timing/{key}"] = value
+
+    for key, value in flatten_numeric_metrics(
+        program.public_metrics,
+        "public_metrics",
+        max_metrics=MAX_PUBLIC_METRICS,
+        max_key_length=MAX_METRIC_KEY_LENGTH,
+    ).items():
+        leaf_name = key.rsplit("/", 1)[-1]
+        if leaf_name in {"score", "combined_score"} and value == individual_score:
+            continue
+        payload[key] = value
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def is_island_copy(program: Program) -> bool:
+    """Return whether a DB row is an administrative copy."""
+    metadata = program.metadata or {}
+    return bool(metadata.get("_is_island_copy") or metadata.get("_spawned_island"))
+
+
+def flatten_numeric_metrics(
+    data: Any,
+    prefix: str,
+    *,
+    max_depth: int = 3,
+    max_metrics: int = MAX_PUBLIC_METRICS,
+    max_key_length: int = MAX_METRIC_KEY_LENGTH,
+) -> Dict[str, float]:
+    """Flatten only numeric evaluation metrics, excluding bulky text and arrays."""
+    flattened: Dict[str, float] = {}
+
+    def visit(value: Any, parts: List[str], depth: int) -> None:
+        if depth > max_depth or len(flattened) >= max_metrics:
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if len(flattened) >= max_metrics:
+                    break
+                if len(str(key)) > max_key_length or _is_sensitive_metric_key(key):
+                    continue
+                visit(child, [*parts, _metric_segment(key)], depth + 1)
+            return
+        numeric_value = _finite_float(value)
+        if numeric_value is not None:
+            metric_key = "/".join([prefix, *parts])
+            if len(metric_key) <= max_key_length:
+                flattened[metric_key] = numeric_value
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if len(flattened) >= max_metrics:
+                break
+            if len(str(key)) > max_key_length or _is_sensitive_metric_key(key):
+                continue
+            visit(value, [_metric_segment(key)], 1)
+    return flattened
+
+
+def program_costs(program: Program) -> Dict[str, float]:
+    """Return the non-duplicated cost breakdown for one individual."""
+    metadata = program.metadata or {}
+    return {
+        name: _finite_float(metadata.get(metadata_key)) or 0.0
+        for name, metadata_key in _COST_KEYS.items()
+    }
+
+
+def program_table_row(program: Program) -> List[Any]:
+    """Return a compact row; detailed program data remains in the WebUI database."""
+    metadata = program.metadata or {}
+    return [
+        program.id,
+        program.generation,
+        _finite_float(program.combined_score),
+        bool(program.correct),
+        program.parent_id,
+        program.island_idx,
+        is_island_copy(program),
+        bool(program.in_archive),
+        metadata.get("patch_type"),
+        _program_model_name(program),
+        0.0
+        if is_island_copy(program)
+        else sum(_reported_program_costs(program).values()),
+    ]
+
+
+def build_population_progress_payload(
+    programs: Sequence[Program],
+    *,
+    evaluated_count: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build cumulative population and island metrics for one snapshot.
+
+    Administrative copies remain visible in population counts, while the
+    evaluation axis, costs, and timings describe unique evaluated programs.
+    """
+    all_programs = list(programs)
+    evaluated_programs = [
+        program for program in all_programs if not is_island_copy(program)
+    ]
+    scores = _scores(all_programs)
+    correct_programs = [program for program in all_programs if program.correct]
+    correct_scores = _scores(correct_programs)
+    costs = {
+        name: sum(
+            program_costs(program)[name]
+            for program in evaluated_programs
+            if not _has_unknown_headless_api_cost(program, name)
+        )
+        for name in _COST_KEYS
+    }
+    unknown_pricing_count = sum(
+        1
+        for program in evaluated_programs
+        if _has_unknown_headless_api_cost(program, "api")
+    )
+    payload: Dict[str, Any] = {
+        EVALUATED_COUNT_METRIC: (
+            len(evaluated_programs)
+            if evaluated_count is None
+            else max(0, int(evaluated_count))
+        ),
+        "population/count": len(all_programs),
+        "population/correct_count": len(correct_programs),
+        "population/correct_rate": (
+            len(correct_programs) / len(all_programs) if all_programs else 0.0
+        ),
+        "population/best_score": max(scores) if scores else None,
+        "population/best_correct_score": (
+            max(correct_scores) if correct_scores else None
+        ),
+        "population/mean_score": sum(scores) / len(scores) if scores else None,
+        "cost/api": costs["api"],
+        "cost/embed": costs["embed"],
+        "cost/novelty": costs["novelty"],
+        "cost/meta": costs["meta"],
+        "cost/total": sum(costs.values()),
+        "cost/pricing_unknown_count": unknown_pricing_count,
+    }
+
+    for key in _TIMING_KEYS:
+        payload[f"timing/{key}_total"] = sum(
+            _finite_float((program.metadata or {}).get(key)) or 0.0
+            for program in evaluated_programs
+        )
+
+    islands: Dict[str, List[Program]] = {}
+    for program in all_programs:
+        island_key = (
+            str(program.island_idx) if program.island_idx is not None else "unknown"
+        )
+        islands.setdefault(island_key, []).append(program)
+    for island_key, island_programs in islands.items():
+        payload.update(_island_payload(island_key, island_programs))
+
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def build_population_progress_payload_from_telemetry(
+    telemetry: Sequence[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """Build population metrics from compact database aggregate rows."""
+    rows = list(telemetry)
+    count = sum(int(row["count"]) for row in rows)
+    evaluated_count = sum(int(row["evaluated_count"]) for row in rows)
+    correct_count = sum(int(row["correct_count"]) for row in rows)
+    score_count = sum(int(row["score_count"]) for row in rows)
+    score_sum = sum(float(row["score_sum"]) for row in rows)
+    costs = {
+        name: sum(float(row[f"{name}_cost"]) for row in rows) for name in _COST_KEYS
+    }
+
+    payload: Dict[str, Any] = {
+        EVALUATED_COUNT_METRIC: evaluated_count,
+        "population/count": count,
+        "population/correct_count": correct_count,
+        "population/correct_rate": correct_count / count if count else 0.0,
+        "population/best_score": _maximum_aggregate(rows, "best_score"),
+        "population/best_correct_score": _maximum_aggregate(rows, "best_correct_score"),
+        "population/mean_score": score_sum / score_count if score_count else None,
+        **{f"cost/{name}": value for name, value in costs.items()},
+        "cost/total": sum(costs.values()),
+        "cost/pricing_unknown_count": sum(
+            int(row["pricing_unknown_count"]) for row in rows
+        ),
+    }
+    for key in _TIMING_KEYS:
+        payload[f"timing/{key}_total"] = sum(float(row[key]) for row in rows)
+    for row in rows:
+        island_key = (
+            str(row["island_idx"]) if row["island_idx"] is not None else "unknown"
+        )
+        island_count = int(row["count"])
+        island_score_count = int(row["score_count"])
+        prefix = f"island/{_metric_segment(island_key)}"
+        payload.update(
+            {
+                f"{prefix}/count": island_count,
+                f"{prefix}/evaluated_count": int(row["evaluated_count"]),
+                f"{prefix}/correct_count": int(row["correct_count"]),
+                f"{prefix}/correct_rate": (
+                    int(row["correct_count"]) / island_count if island_count else 0.0
+                ),
+                f"{prefix}/best_score": _finite_float(row["best_score"]),
+                f"{prefix}/mean_score": (
+                    float(row["score_sum"]) / island_score_count
+                    if island_score_count
+                    else None
+                ),
+            }
+        )
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _maximum_aggregate(rows: Sequence[Mapping[str, Any]], key: str) -> Optional[float]:
+    values = [value for row in rows if (value := _finite_float(row[key])) is not None]
+    return max(values) if values else None
+
+
+def build_run_summary(
+    programs: Sequence[Program],
+    *,
+    total_proposals_generated: Optional[int] = None,
+    total_api_cost: Optional[float] = None,
+    total_cost: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build concise final values for the W&B run summary."""
+    population = build_population_progress_payload(programs)
+    correct_scores = _scores([program for program in programs if program.correct])
+    summary = {
+        "run/program_count": len(programs),
+        "run/evaluated_count": population[EVALUATED_COUNT_METRIC],
+        "run/correct_rate": population["population/correct_rate"],
+        "run/max_generation": max(
+            (program.generation for program in programs), default=0
+        ),
+        "run/best_score": max(correct_scores) if correct_scores else None,
+        "run/total_proposals_generated": total_proposals_generated,
+        "run/total_api_cost": _finite_float(total_api_cost),
+        "run/total_cost": _finite_float(
+            total_cost if total_cost is not None else total_api_cost
+        ),
+    }
+    return {key: value for key, value in summary.items() if value is not None}
+
+
+def _island_payload(island_key: str, programs: Sequence[Program]) -> Dict[str, Any]:
+    scores = _scores(programs)
+    correct_count = sum(1 for program in programs if program.correct)
+    prefix = f"island/{_metric_segment(island_key)}"
+    return {
+        f"{prefix}/count": len(programs),
+        f"{prefix}/evaluated_count": sum(
+            1 for program in programs if not is_island_copy(program)
+        ),
+        f"{prefix}/correct_count": correct_count,
+        f"{prefix}/correct_rate": correct_count / len(programs) if programs else 0.0,
+        f"{prefix}/best_score": max(scores) if scores else None,
+        f"{prefix}/mean_score": sum(scores) / len(scores) if scores else None,
+    }
+
+
+def _scores(programs: Sequence[Program]) -> List[float]:
+    return [
+        score
+        for program in programs
+        if (score := _finite_float(program.combined_score)) is not None
+    ]
+
+
+def _has_unknown_headless_api_cost(program: Program, cost_name: str) -> bool:
+    return (
+        cost_name == "api"
+        and _is_headless_program(program)
+        and (program.metadata or {}).get("headless_pricing_unknown") is True
+    )
+
+
+def _reported_program_costs(program: Program) -> Dict[str, float]:
+    return {
+        name: value
+        for name, value in program_costs(program).items()
+        if not _has_unknown_headless_api_cost(program, name)
+    }
+
+
+def _program_model_name(program: Program) -> Optional[str]:
+    metadata = program.metadata or {}
+    llm_result = metadata.get("llm_result")
+    nested_model = None
+    if isinstance(llm_result, dict):
+        nested_model = llm_result.get("model_name") or llm_result.get("model")
+    value = metadata.get("model_name") or metadata.get("model") or nested_model
+    return str(value) if value is not None else None
+
+
+def _is_headless_program(program: Program) -> bool:
+    model_name = _program_model_name(program)
+    return model_name is not None and model_name.startswith(_HEADLESS_MODEL_PREFIX)
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, (bool, str, bytes)):
+        return None
+    if hasattr(value, "item") and callable(value.item):
+        try:
+            value = value.item()
+        except Exception:
+            return None
+    if not isinstance(value, (int, float)):
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def _metric_segment(value: Any) -> str:
+    segment = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip())
+    return segment.strip("_") or "value"
+
+
+def _is_sensitive_metric_key(value: Any) -> bool:
+    return is_sensitive_telemetry_key(value)

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -20,8 +20,10 @@ class _FakeProcess:
         self._stderr = stderr
         self.kill_called = False
         self.wait_called = False
+        self.communicate_calls = 0
 
     async def communicate(self) -> tuple[bytes, bytes]:
+        self.communicate_calls += 1
         return self._stdout, self._stderr
 
     def kill(self) -> None:
@@ -63,7 +65,7 @@ def test_run_validation_subprocess_success(monkeypatch: pytest.MonkeyPatch) -> N
     assert is_valid is True
     assert error is None
     assert recorded["args"] == ("python", "-m", "py_compile", "candidate.py")
-    assert recorded["stdout"] == asyncio.subprocess.PIPE
+    assert recorded["stdout"] == asyncio.subprocess.DEVNULL
     assert recorded["stderr"] == asyncio.subprocess.PIPE
 
 
@@ -125,7 +127,41 @@ def test_run_validation_subprocess_timeout_kills_process(
     assert is_valid is False
     assert error == "Validation timeout after 3s"
     assert proc.kill_called is True
-    assert proc.wait_called is True
+    assert proc.communicate_calls == 1
+
+
+def test_run_validation_subprocess_cancellation_kills_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc = _FakeProcess()
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> _FakeProcess:
+        return proc
+
+    async def fake_wait_for(awaitable: object, timeout: int) -> object:
+        del awaitable, timeout
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        async_apply.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(async_apply.asyncio, "wait_for", fake_wait_for)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            async_apply._run_validation_subprocess(
+                "rustfmt", "candidate.rs", timeout=3
+            )
+        )
+
+    assert proc.kill_called is True
+    assert proc.communicate_calls == 1
 
 
 def test_validate_code_async_python_delegates_to_helper(
@@ -194,6 +230,7 @@ def test_validate_code_async_rust_delegates_to_rustfmt(
     args = recorded["args"]
     assert isinstance(args, tuple)
     assert args[0] == "rustfmt"
+    assert args[-2] == "--"
     assert args[-1] == str(tmp_path / "candidate.rs")
     assert "--config-path" in args
     assert "--emit" in args
@@ -307,6 +344,24 @@ def test_validate_code_async_rust_rejects_broken_program_on_real_rustfmt(
     assert is_valid is False
     assert error is not None
     assert "nightly" not in error
+    assert "error" in error.lower()
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_rejects_option_shaped_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    candidate = Path("--version")
+    candidate.write_text("pub fn broken( -> {\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is False
+    assert error is not None
     assert "error" in error.lower()
 
 

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -158,11 +158,11 @@ def test_validate_code_async_python_delegates_to_helper(
     assert recorded["timeout"] == 11
 
 
-def test_validate_code_async_rust_delegates_to_rustc(
+def test_validate_code_async_rust_delegates_to_rustfmt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Rust validation must stay on stable-channel rustc flags.
+    """Rust validation must use stable, non-mutating rustfmt flags.
 
     `-Zparse-only` is nightly-only, so a stable toolchain rejects the flag
     before parsing and reports every candidate invalid.
@@ -172,8 +172,13 @@ def test_validate_code_async_rust_delegates_to_rustc(
     async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
         recorded["args"] = args
         recorded["timeout"] = timeout
+        config_path = Path(args[args.index("--config-path") + 1])
+        recorded["config_path"] = config_path
+        recorded["config_existed"] = config_path.is_file()
+        recorded["config_contents"] = config_path.read_text(encoding="utf-8")
         return True, None
 
+    monkeypatch.setattr(async_apply.shutil, "which", lambda _name: "/usr/bin/rustfmt")
     monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
 
     is_valid, error = asyncio.run(
@@ -188,53 +193,80 @@ def test_validate_code_async_rust_delegates_to_rustc(
 
     args = recorded["args"]
     assert isinstance(args, tuple)
-    assert args[0] == "rustc"
+    assert args[0] == "rustfmt"
     assert args[-1] == str(tmp_path / "candidate.rs")
+    assert "--config-path" in args
+    assert "--emit" in args
+    assert args[args.index("--emit") + 1] == "stdout"
     assert "--edition" in args
-    assert args[args.index("--edition") + 1] == "2021"
-    assert "--crate-type=lib" in args
-    assert "--emit=dep-info" in args
-    assert "--out-dir" in args
-    # No nightly-gated flag may be reintroduced: any `-Z` option makes stable
-    # rustc exit before it parses the candidate.
+    assert args[args.index("--edition") + 1] == "2015"
+    assert "--config" in args
+    assert args[args.index("--config") + 1] == "skip_children=true"
+    # No nightly-gated flag may be reintroduced: stable Rust tooling rejects
+    # `-Z` options before it parses the candidate.
     assert not any(arg.startswith("-Z") for arg in args)
+    assert recorded["config_existed"] is True
+    assert recorded["config_contents"] == ""
+    config_path = recorded["config_path"]
+    assert isinstance(config_path, Path)
+    assert config_path.exists() is False
 
 
-def test_validate_code_async_rust_discards_dep_info_output(
+def test_validate_code_async_rust_reports_missing_rustfmt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """dep-info output goes to a temporary directory that is then removed.
+    """A minimal Rust toolchain gets an actionable dependency error."""
 
-    Without an explicit `--out-dir` rustc writes the dependency file into the
-    working directory, which would leave artifacts beside the evolved program.
-    """
-    observed: dict[str, object] = {}
+    async def fail_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        raise AssertionError(f"unexpected validator invocation: {args}")
 
-    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
-        out_dir = Path(args[args.index("--out-dir") + 1])
-        observed["out_dir"] = out_dir
-        observed["existed_during_call"] = out_dir.is_dir()
-        return True, None
+    monkeypatch.setattr(async_apply.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fail_helper)
 
-    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
-
-    asyncio.run(
+    is_valid, error = asyncio.run(
         async_apply.validate_code_async(
             str(tmp_path / "candidate.rs"), language="rust", timeout=5
         )
     )
 
-    out_dir = observed["out_dir"]
-    assert isinstance(out_dir, Path)
-    assert observed["existed_during_call"] is True
-    assert out_dir.is_dir() is False
-    assert out_dir != tmp_path
-    assert list(tmp_path.iterdir()) == []
+    assert is_valid is False
+    assert error == (
+        "Rust validation requires rustfmt on PATH. Install it with "
+        "`rustup component add rustfmt`."
+    )
 
 
-@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
-def test_validate_code_async_rust_accepts_valid_program_on_real_rustc(
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_does_not_read_host_files(
+    tmp_path: Path,
+) -> None:
+    """Syntax validation must not read files through macros or modules."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("host-secret-must-not-leak !!!", encoding="utf-8")
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text(
+        f'#[path = r"{secret}"]\n'
+        "mod secret;\n"
+        f'compile_error!(include_str!(r"{secret}"));\n',
+        encoding="utf-8",
+    )
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is True, error
+    assert error is None
+    assert candidate.read_text(encoding="utf-8") == (
+        f'#[path = r"{secret}"]\n'
+        "mod secret;\n"
+        f'compile_error!(include_str!(r"{secret}"));\n'
+    )
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_accepts_valid_program_on_real_rustfmt(
     tmp_path: Path,
 ) -> None:
     """End-to-end guard against the nightly-flag regression."""
@@ -260,8 +292,8 @@ def test_validate_code_async_rust_accepts_valid_program_on_real_rustc(
     assert error is None
 
 
-@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
-def test_validate_code_async_rust_rejects_broken_program_on_real_rustc(
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_rejects_broken_program_on_real_rustfmt(
     tmp_path: Path,
 ) -> None:
     """A syntax error must be reported as a rust error, not a flag error."""
@@ -276,6 +308,67 @@ def test_validate_code_async_rust_rejects_broken_program_on_real_rustc(
     assert error is not None
     assert "nightly" not in error
     assert "error" in error.lower()
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_ignores_project_config_that_disables_parsing(
+    tmp_path: Path,
+) -> None:
+    """An ambient rustfmt.toml cannot make malformed Rust pass validation."""
+    (tmp_path / "rustfmt.toml").write_text(
+        "disable_all_formatting = true\n",
+        encoding="utf-8",
+    )
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text("pub fn broken( -> {\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is False
+    assert error is not None
+    assert "error" in error.lower()
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_accepts_type_errors(
+    tmp_path: Path,
+) -> None:
+    """Validation remains syntax-only and does not run the type checker."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text(
+        'pub fn wrong_type() -> u32 { "not a number" }\n',
+        encoding="utf-8",
+    )
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is True, error
+    assert error is None
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_honors_configured_edition(
+    tmp_path: Path,
+) -> None:
+    """Projects can override the default for edition-sensitive syntax."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text("pub async fn modern() {}\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(
+            str(candidate),
+            language="rust",
+            timeout=60,
+            rust_edition="2021",
+        )
+    )
+
+    assert is_valid is True, error
+    assert error is None
 
 
 def test_validate_code_async_fortran_delegates_to_gfortran(

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -1,4 +1,5 @@
 import asyncio
+import shutil
 from pathlib import Path
 
 import pytest
@@ -155,6 +156,126 @@ def test_validate_code_async_python_delegates_to_helper(
         str(tmp_path / "candidate.py"),
     )
     assert recorded["timeout"] == 11
+
+
+def test_validate_code_async_rust_delegates_to_rustc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Rust validation must stay on stable-channel rustc flags.
+
+    `-Zparse-only` is nightly-only, so a stable toolchain rejects the flag
+    before parsing and reports every candidate invalid.
+    """
+    recorded: dict[str, object] = {}
+
+    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        recorded["args"] = args
+        recorded["timeout"] = timeout
+        return True, None
+
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(
+            str(tmp_path / "candidate.rs"), language="rust", timeout=23
+        )
+    )
+
+    assert is_valid is True
+    assert error is None
+    assert recorded["timeout"] == 23
+
+    args = recorded["args"]
+    assert isinstance(args, tuple)
+    assert args[0] == "rustc"
+    assert args[-1] == str(tmp_path / "candidate.rs")
+    assert "--edition" in args
+    assert args[args.index("--edition") + 1] == "2021"
+    assert "--crate-type=lib" in args
+    assert "--emit=dep-info" in args
+    assert "--out-dir" in args
+    # No nightly-gated flag may be reintroduced: any `-Z` option makes stable
+    # rustc exit before it parses the candidate.
+    assert not any(arg.startswith("-Z") for arg in args)
+
+
+def test_validate_code_async_rust_discards_dep_info_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """dep-info output goes to a temporary directory that is then removed.
+
+    Without an explicit `--out-dir` rustc writes the dependency file into the
+    working directory, which would leave artifacts beside the evolved program.
+    """
+    observed: dict[str, object] = {}
+
+    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        out_dir = Path(args[args.index("--out-dir") + 1])
+        observed["out_dir"] = out_dir
+        observed["existed_during_call"] = out_dir.is_dir()
+        return True, None
+
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
+
+    asyncio.run(
+        async_apply.validate_code_async(
+            str(tmp_path / "candidate.rs"), language="rust", timeout=5
+        )
+    )
+
+    out_dir = observed["out_dir"]
+    assert isinstance(out_dir, Path)
+    assert observed["existed_during_call"] is True
+    assert out_dir.is_dir() is False
+    assert out_dir != tmp_path
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
+def test_validate_code_async_rust_accepts_valid_program_on_real_rustc(
+    tmp_path: Path,
+) -> None:
+    """End-to-end guard against the nightly-flag regression."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text(
+        "pub fn collatz_steps(n: u64) -> u32 {\n"
+        "    let mut steps = 0u32;\n"
+        "    let mut value = n;\n"
+        "    while value != 1 {\n"
+        "        value = if value % 2 == 0 { value / 2 } else { 3 * value + 1 };\n"
+        "        steps += 1;\n"
+        "    }\n"
+        "    steps\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is True, error
+    assert error is None
+
+
+@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
+def test_validate_code_async_rust_rejects_broken_program_on_real_rustc(
+    tmp_path: Path,
+) -> None:
+    """A syntax error must be reported as a rust error, not a flag error."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text("pub fn broken( -> { let mut\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is False
+    assert error is not None
+    assert "nightly" not in error
+    assert "error" in error.lower()
 
 
 def test_validate_code_async_fortran_delegates_to_gfortran(

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ from shinka.core.async_runner import (
     ShinkaEvolveRunner,
 )
 from shinka.core.runtime_slots import LogicalSlotPool
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
 
 
 class _FakeAsyncDB:
@@ -1541,6 +1543,13 @@ def test_job_monitor_processes_completed_jobs_inline():
         runner._retry_failed_db_jobs = lambda: asyncio.sleep(0, result=None)
         runner._record_progress = lambda: None
         runner._mark_surplus_completed_jobs_for_discard = lambda jobs: None
+        lifecycle = []
+
+        async def update_completed_generations():
+            lifecycle.append("updated")
+
+        runner._update_completed_generations = update_completed_generations
+        runner._log_wandb_population_progress = lambda: lifecycle.append("wandb")
 
         batch_started = asyncio.Event()
         allow_finish = asyncio.Event()
@@ -1581,5 +1590,70 @@ def test_job_monitor_processes_completed_jobs_inline():
         runner.should_stop.set()
         allow_finish.set()
         await asyncio.wait_for(monitor_task, timeout=0.2)
+
+        assert lifecycle == ["updated", "wandb"]
+
+    asyncio.run(_run())
+
+
+def test_wandb_population_snapshots_are_offloaded_and_coalesced():
+    async def _run():
+        runner = _build_runner()
+        runner._wandb_population_interval_seconds = 0.0
+        first_started = asyncio.Event()
+        release_first = threading.Event()
+        loop_thread = threading.get_ident()
+        call_threads = []
+        active = 0
+        max_active = 0
+
+        class Logger:
+            def log_population_progress(self, *, db):
+                nonlocal active, max_active
+                call_threads.append(threading.get_ident())
+                active += 1
+                max_active = max(max_active, active)
+                if len(call_threads) == 1:
+                    loop.call_soon_threadsafe(first_started.set)
+                    release_first.wait(timeout=1)
+                active -= 1
+
+        loop = asyncio.get_running_loop()
+        runner.wandb_logger = Logger()
+        runner._log_wandb_population_progress()
+        await asyncio.wait_for(first_started.wait(), timeout=0.2)
+
+        runner._log_wandb_population_progress()
+        runner._log_wandb_population_progress()
+        await asyncio.sleep(0)
+        release_first.set()
+        await runner._wait_for_wandb_population_progress()
+
+        assert len(call_threads) == 2
+        assert all(thread_id != loop_thread for thread_id in call_threads)
+        assert max_active == 1
+
+    asyncio.run(_run())
+
+
+def test_wandb_population_snapshot_uses_worker_owned_database_connection(tmp_path):
+    async def _run():
+        db = ProgramDatabase(
+            DatabaseConfig(db_path=str(tmp_path / "programs.sqlite"))
+        )
+        db.add(Program(id="program", code="pass"), defer_maintenance=True)
+        observed_ids = []
+
+        class Logger:
+            def log_population_progress(self, *, db):
+                observed_ids.extend(program.id for program in db.get_all_programs())
+
+        runner = _build_runner(db=db)
+        runner.wandb_logger = Logger()
+        runner._log_wandb_population_progress()
+        await runner._wait_for_wandb_population_progress()
+        db.close()
+
+        assert observed_ids == ["program"]
 
     asyncio.run(_run())

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -12,6 +11,17 @@ def test_public_ci_excludes_secret_backed_tests() -> None:
     workflow = _read(".github/workflows/ci.yml")
 
     assert 'pytest -q -m "not requires_secrets and not models_dev_live"' in workflow
+
+
+def test_public_ci_installs_stable_rustfmt() -> None:
+    workflow = _read(".github/workflows/ci.yml")
+
+    assert (
+        "rustup toolchain install stable --profile minimal --component rustfmt"
+        in workflow
+    )
+    assert "rustup default stable" in workflow
+    assert "rustfmt --version" in workflow
 
 
 def test_integration_workflow_exists_for_secret_backed_tests() -> None:

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,9 +1,19 @@
+import ast
+from unittest.mock import patch
+
 from shinka.database.complexity import analyze_code_metrics
 
 
-def test_go_uses_regex_complexity_analysis():
-    metrics = analyze_code_metrics(
-        """
+PYTHON_PROGRAM = """\
+def classify(values):
+    total = 0
+    for value in values:
+        if value > 0:
+            total += value
+    return total
+"""
+
+GO_PROGRAM = """\
 package main
 
 func score(xs []int) int {
@@ -15,8 +25,59 @@ func score(xs []int) int {
     }
     return total
 }
-""",
-        language="go",
-    )
+"""
 
-    assert metrics["cyclomatic_complexity"] > 1
+
+def test_python_complexity_metrics_contract():
+    assert analyze_code_metrics(PYTHON_PROGRAM) == {
+        "cyclomatic_complexity": 3,
+        "average_cyclomatic_complexity": 3.0,
+        "halstead_volume": 13.931568569324174,
+        "halstead_difficulty": 1.3333333333333333,
+        "halstead_effort": 18.575424759098897,
+        "lines_of_code": 6,
+        "logical_lines_of_code": 6,
+        "comments": 0,
+        "maintainability_index": 108.67212134673596,
+        "max_nesting_depth": 3,
+        "complexity_score": 0.364,
+    }
+
+
+def test_invalid_python_preserves_cpp_fallback_metrics():
+    assert analyze_code_metrics("def broken(:\n    pass\n") == {
+        "cyclomatic_complexity": 1,
+        "average_cyclomatic_complexity": 1,
+        "halstead_volume": 1,
+        "halstead_difficulty": 1.0,
+        "halstead_effort": 1,
+        "lines_of_code": 3,
+        "logical_lines_of_code": 2,
+        "comments": 0,
+        "maintainability_index": 145.09360748831728,
+        "max_nesting_depth": 0,
+        "complexity_score": 0.1,
+    }
+
+
+def test_python_complexity_parses_ast_once():
+    with patch("shinka.database.complexity.ast.parse", wraps=ast.parse) as parse:
+        analyze_code_metrics(PYTHON_PROGRAM)
+
+    assert parse.call_count == 1
+
+
+def test_go_uses_regex_complexity_analysis():
+    assert analyze_code_metrics(GO_PROGRAM, language="go") == {
+        "cyclomatic_complexity": 3,
+        "average_cyclomatic_complexity": 3,
+        "halstead_volume": 15.84962500721156,
+        "halstead_difficulty": 1.0,
+        "halstead_effort": 15.84962500721156,
+        "lines_of_code": 12,
+        "logical_lines_of_code": 10,
+        "comments": 0,
+        "maintainability_index": 91.50444811614277,
+        "max_nesting_depth": 3,
+        "complexity_score": 0.38,
+    }

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,3 +1,10 @@
+import asyncio
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+from google.genai import types
+
 from shinka.llm.providers import gemini
 
 
@@ -57,3 +64,220 @@ def test_build_gemini_afc_config_sets_max_remote_calls_none(monkeypatch):
     gemini.build_gemini_afc_config()
 
     assert captured == {"disable": True, "maximum_remote_calls": None}
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [
+        ("LOW", types.ThinkingLevel.LOW),
+        ("low", types.ThinkingLevel.LOW),
+        ("MEDIUM", types.ThinkingLevel.MEDIUM),
+        ("medium", types.ThinkingLevel.MEDIUM),
+        ("HIGH", types.ThinkingLevel.HIGH),
+        ("high", types.ThinkingLevel.HIGH),
+        (None, None),
+    ],
+)
+def test_build_gemini_thinking_level_config_uses_sdk_enum(
+    monkeypatch,
+    level: str | None,
+    expected: types.ThinkingLevel | None,
+):
+    captured = {}
+
+    class ThinkingConfig:
+        model_fields: ClassVar[dict[str, object]] = {
+            "include_thoughts": object(),
+            "thinking_level": object(),
+        }
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(gemini.types, "ThinkingConfig", ThinkingConfig)
+
+    gemini.build_gemini_thinking_level_config(level)
+
+    assert captured["include_thoughts"] is True
+    if expected is None:
+        assert "thinking_level" not in captured
+    else:
+        assert captured["thinking_level"] == expected
+
+
+def test_build_gemini_thinking_level_config_rejects_unknown_level():
+    with pytest.raises(ValueError, match="NOT_A_LEVEL"):
+        gemini.build_gemini_thinking_level_config("NOT_A_LEVEL")
+
+
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+def test_latest_gemini_generation_config_omits_unsupported_fields(
+    monkeypatch,
+    model_name: str,
+):
+    captured = {}
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        gemini.types,
+        "GenerateContentConfig",
+        GenerateContentConfig,
+    )
+    monkeypatch.setattr(gemini, "build_gemini_afc_config", lambda: "afc")
+    monkeypatch.setattr(
+        gemini,
+        "build_gemini_thinking_level_config",
+        lambda level: {"thinking_level": level},
+    )
+
+    gemini.build_gemini_generation_config(
+        model=model_name,
+        temperature=0.25,
+        top_p=0.9,
+        max_tokens=4096,
+        system_instruction="system",
+        thinking_budget=1024,
+        thinking_level="MEDIUM",
+    )
+
+    assert captured == {
+        "max_output_tokens": 4096,
+        "system_instruction": "system",
+        "automatic_function_calling": "afc",
+        "thinking_config": {"thinking_level": "MEDIUM"},
+    }
+    for unsupported_field in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "candidate_count",
+        "thinking_budget",
+    ):
+        assert unsupported_field not in captured
+
+
+def test_legacy_gemini_generation_config_keeps_sampling_and_budget(monkeypatch):
+    captured = {}
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        gemini.types,
+        "GenerateContentConfig",
+        GenerateContentConfig,
+    )
+    monkeypatch.setattr(gemini, "build_gemini_afc_config", lambda: "afc")
+    monkeypatch.setattr(
+        gemini,
+        "build_gemini_thinking_config",
+        lambda budget: {"thinking_budget": budget},
+    )
+
+    gemini.build_gemini_generation_config(
+        model="gemini-2.5-flash",
+        temperature=0.25,
+        top_p=0.9,
+        max_tokens=4096,
+        system_instruction="system",
+        thinking_budget=1024,
+        thinking_level=None,
+    )
+
+    assert captured == {
+        "temperature": 0.25,
+        "top_p": 0.9,
+        "max_output_tokens": 4096,
+        "system_instruction": "system",
+        "automatic_function_calling": "afc",
+        "thinking_config": {"thinking_budget": 1024},
+    }
+
+
+def test_sync_query_uses_shared_generation_config_builder(monkeypatch):
+    captured = {}
+    response = SimpleNamespace(candidates=[], text="answer", usage_metadata=None)
+
+    class Models:
+        def generate_content(self, **kwargs):
+            captured["request"] = kwargs
+            return response
+
+    def build_config(**kwargs):
+        captured["config_kwargs"] = kwargs
+        return "config"
+
+    monkeypatch.setattr(gemini, "build_gemini_generation_config", build_config)
+
+    result = gemini.query_gemini(
+        SimpleNamespace(models=Models()),
+        "gemini-3.6-flash",
+        "prompt",
+        "system",
+        [],
+        None,
+        temperature=0.25,
+        top_p=0.9,
+        top_k=40,
+        candidate_count=2,
+        max_tokens=4096,
+        thinking_budget=2048,
+        thinking_level="HIGH",
+    )
+
+    assert result.content == "answer"
+    assert captured["config_kwargs"] == {
+        "model": "gemini-3.6-flash",
+        "temperature": 0.25,
+        "top_p": 0.9,
+        "max_tokens": 4096,
+        "system_instruction": "system",
+        "thinking_budget": 2048,
+        "thinking_level": "HIGH",
+    }
+    assert captured["request"]["config"] == "config"
+
+
+def test_async_query_uses_shared_generation_config_builder(monkeypatch):
+    captured = {}
+    response = SimpleNamespace(candidates=[], text="answer", usage_metadata=None)
+
+    class Models:
+        async def generate_content(self, **kwargs):
+            captured["request"] = kwargs
+            return response
+
+    def build_config(**kwargs):
+        captured["config_kwargs"] = kwargs
+        return "config"
+
+    monkeypatch.setattr(gemini, "build_gemini_generation_config", build_config)
+
+    result = asyncio.run(
+        gemini.query_gemini_async(
+            SimpleNamespace(aio=SimpleNamespace(models=Models())),
+            "gemini-3.6-flash",
+            "prompt",
+            "system",
+            [],
+            None,
+            max_tokens=4096,
+            thinking_level="LOW",
+        )
+    )
+
+    assert result.content == "answer"
+    assert captured["config_kwargs"] == {
+        "model": "gemini-3.6-flash",
+        "temperature": 0.8,
+        "top_p": 1.0,
+        "max_tokens": 4096,
+        "system_instruction": "system",
+        "thinking_budget": 0,
+        "thinking_level": "LOW",
+    }
+    assert captured["request"]["config"] == "config"

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -110,7 +110,7 @@ def test_build_gemini_thinking_level_config_rejects_unknown_level():
         gemini.build_gemini_thinking_level_config("NOT_A_LEVEL")
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 def test_latest_gemini_generation_config_omits_unsupported_fields(
     monkeypatch,
     model_name: str,

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -277,7 +277,7 @@ def test_async_query_uses_shared_generation_config_builder(monkeypatch):
         "top_p": 1.0,
         "max_tokens": 4096,
         "system_instruction": "system",
-        "thinking_budget": 0,
+        "thinking_budget": 1024,
         "thinking_level": "LOW",
     }
     assert captured["request"]["config"] == "config"

--- a/tests/test_gemini_retry_policy.py
+++ b/tests/test_gemini_retry_policy.py
@@ -1,0 +1,391 @@
+"""Regression tests for Gemini sync/async defaults and retry policy."""
+
+import asyncio
+from types import SimpleNamespace
+
+from google.genai import types
+import pytest
+
+import shinka.llm.client as client_module
+import shinka.llm.llm as llm_module
+from shinka.llm.llm import AsyncLLMClient, LLMClient
+from shinka.llm.providers.errors import (
+    NonRetryableLLMError,
+    StructuredOutputNotSupportedError,
+)
+from shinka.llm.providers.gemini import (
+    DEFAULT_THINKING_BUDGET,
+    GeminiStructuredOutputError,
+    _giveup_gemini,
+    query_gemini,
+    query_gemini_async,
+)
+
+
+def _response():
+    part = SimpleNamespace(text="hi", thought=False)
+    content = SimpleNamespace(parts=[part])
+    candidate = SimpleNamespace(content=content, finish_reason=types.FinishReason.STOP)
+    return SimpleNamespace(candidates=[candidate], text=None, usage_metadata=None)
+
+
+class _SyncClient:
+    def __init__(self):
+        self.calls = 0
+        self.models = self
+
+    def generate_content(self, **kwargs):
+        self.calls += 1
+        return _response()
+
+
+class _AsyncClient:
+    def __init__(self):
+        self.calls = 0
+        self.aio = SimpleNamespace(models=self)
+
+    async def generate_content(self, **kwargs):
+        self.calls += 1
+        return _response()
+
+
+def test_default_thinking_budget_matches_across_sync_and_async(monkeypatch):
+    from shinka.llm.providers import gemini as gemini_module
+
+    budgets = []
+
+    def record_budget(thinking_budget):
+        budgets.append(thinking_budget)
+        return None
+
+    monkeypatch.setattr(gemini_module, "build_gemini_thinking_config", record_budget)
+
+    query_gemini(_SyncClient(), "gemini-2.5-flash", "msg", "sys", [], None)
+    asyncio.run(
+        query_gemini_async(
+            _AsyncClient(), "gemini-2.5-flash", "msg", "sys", [], None
+        )
+    )
+
+    assert budgets == [DEFAULT_THINKING_BUDGET, DEFAULT_THINKING_BUDGET]
+    assert DEFAULT_THINKING_BUDGET == 1024
+
+
+def test_latest_gemini_thinking_level_config_is_unchanged(monkeypatch):
+    from shinka.llm.providers import gemini as gemini_module
+
+    captured = []
+
+    def record_level(level):
+        captured.append(level)
+        return None
+
+    monkeypatch.setattr(
+        gemini_module, "build_gemini_thinking_level_config", record_level
+    )
+
+    query_gemini(
+        _SyncClient(),
+        "gemini-3.7-flash",
+        "msg",
+        "sys",
+        [],
+        None,
+        thinking_level="HIGH",
+    )
+
+    assert captured == ["HIGH"]
+
+
+def test_giveup_targets_non_retryable_errors():
+    assert _giveup_gemini(GeminiStructuredOutputError("unsupported")) is True
+    assert _giveup_gemini(NonRetryableLLMError("deterministic")) is True
+    assert _giveup_gemini(ValueError("empty response")) is False
+    assert _giveup_gemini(RuntimeError("transient")) is False
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+def test_structured_output_error_is_not_retried(monkeypatch, is_async):
+    client = _AsyncClient() if is_async else _SyncClient()
+    sleeps = []
+
+    async def record_async_sleep(seconds):
+        sleeps.append(seconds)
+
+    if is_async:
+        monkeypatch.setattr(asyncio, "sleep", record_async_sleep)
+    else:
+        monkeypatch.setattr("time.sleep", lambda seconds: sleeps.append(seconds))
+
+    with pytest.raises(StructuredOutputNotSupportedError, match="structured output"):
+        if is_async:
+            asyncio.run(
+                query_gemini_async(
+                    client,
+                    "gemini-2.5-flash",
+                    "msg",
+                    "sys",
+                    [],
+                    object(),
+                )
+            )
+        else:
+            query_gemini(
+                client,
+                "gemini-2.5-flash",
+                "msg",
+                "sys",
+                [],
+                object(),
+            )
+
+    assert client.calls == 0
+    assert sleeps == []
+
+
+def test_sync_llm_client_does_not_retry_structured_output_error(monkeypatch):
+    calls = 0
+    sleeps = []
+
+    def unsupported(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise GeminiStructuredOutputError("unsupported")
+
+    monkeypatch.setattr(llm_module, "query", unsupported)
+    monkeypatch.setattr(llm_module.time, "sleep", lambda seconds: sleeps.append(seconds))
+    client = LLMClient(model_names="gemini-2.5-flash", verbose=False)
+
+    with pytest.raises(GeminiStructuredOutputError):
+        client.query("msg", "sys", llm_kwargs={"model_name": "gemini-2.5-flash"})
+
+    assert calls == 1
+    assert sleeps == []
+
+
+def test_async_llm_client_does_not_retry_structured_output_error(monkeypatch):
+    calls = 0
+    sleeps = []
+
+    async def unsupported(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise GeminiStructuredOutputError("unsupported")
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(llm_module, "query_async", unsupported)
+    monkeypatch.setattr(llm_module.asyncio, "sleep", record_sleep)
+    client = AsyncLLMClient(model_names="gemini-2.5-flash", verbose=False)
+
+    with pytest.raises(GeminiStructuredOutputError):
+        asyncio.run(
+            client.query(
+                "msg", "sys", llm_kwargs={"model_name": "gemini-2.5-flash"}
+            )
+        )
+
+    assert calls == 1
+    assert sleeps == []
+
+
+@pytest.mark.parametrize("client_factory", [LLMClient, AsyncLLMClient])
+def test_public_client_rejects_structured_output_before_construction(
+    monkeypatch, client_factory
+):
+    builder_calls = 0
+    sleeps = []
+
+    def unexpected_build(**kwargs):
+        nonlocal builder_calls
+        builder_calls += 1
+        raise AssertionError("Gemini client must not be built")
+
+    async def record_async_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(client_module, "build_google_genai_client", unexpected_build)
+    monkeypatch.setattr(llm_module.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(llm_module.asyncio, "sleep", record_async_sleep)
+    client = client_factory(
+        model_names="gemini-2.5-flash", output_model=object(), verbose=False
+    )
+
+    with pytest.raises(StructuredOutputNotSupportedError):
+        result = client.query(
+            "msg", "sys", llm_kwargs={"model_name": "gemini-2.5-flash"}
+        )
+        if asyncio.iscoroutine(result):
+            asyncio.run(result)
+
+    assert builder_calls == 0
+    assert sleeps == []
+
+
+@pytest.mark.parametrize("helper_name", ["query_fn", "sample_kwargs_query_fn"])
+def test_sync_batch_helpers_do_not_retry_structured_output_error(
+    monkeypatch, helper_name
+):
+    calls = 0
+    sleeps = []
+
+    def unsupported(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise GeminiStructuredOutputError("unsupported")
+
+    monkeypatch.setattr(llm_module, "query", unsupported)
+    monkeypatch.setattr(llm_module.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    helper = getattr(llm_module, helper_name)
+    helper_kwargs = {
+        "idx": 0,
+        "msg": "msg",
+        "system_msg": "sys",
+        "output_model": object(),
+    }
+    if helper_name == "query_fn":
+        helper_kwargs["kwargs"] = {"model_name": "gemini-2.5-flash"}
+    else:
+        helper_kwargs["model_names"] = "gemini-2.5-flash"
+
+    with pytest.raises(GeminiStructuredOutputError):
+        helper(**helper_kwargs)
+
+    assert calls == 1
+    assert sleeps == []
+
+
+@pytest.mark.parametrize(
+    "helper_name",
+    ["_query_async_with_retry", "_sample_kwargs_query_async_with_retry"],
+)
+def test_async_batch_helpers_do_not_retry_structured_output_error(
+    monkeypatch, helper_name
+):
+    calls = 0
+    sleeps = []
+
+    async def unsupported(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise GeminiStructuredOutputError("unsupported")
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(llm_module, "query_async", unsupported)
+    monkeypatch.setattr(llm_module.asyncio, "sleep", record_sleep)
+    client = AsyncLLMClient(
+        model_names="gemini-2.5-flash",
+        output_model=object(),
+        verbose=False,
+    )
+    helper = getattr(client, helper_name)
+    helper_kwargs = {"idx": 0, "msg": "msg", "system_msg": "sys"}
+    if helper_name == "_query_async_with_retry":
+        helper_kwargs["kwargs"] = {"model_name": "gemini-2.5-flash"}
+
+    with pytest.raises(GeminiStructuredOutputError):
+        asyncio.run(helper(**helper_kwargs))
+
+    assert calls == 1
+    assert sleeps == []
+
+
+class _FailedAsyncResult:
+    def get(self):
+        raise GeminiStructuredOutputError("unsupported")
+
+
+class _FailedPool:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def apply_async(self, *args, **kwargs):
+        return _FailedAsyncResult()
+
+
+@pytest.mark.parametrize("method_name", ["batch_query", "batch_kwargs_query"])
+def test_sync_public_batch_propagates_structured_output_error(
+    monkeypatch, method_name
+):
+    monkeypatch.setattr(llm_module.mp, "Pool", lambda **kwargs: _FailedPool())
+    client = LLMClient(model_names="gemini-2.5-flash", verbose=False)
+    method = getattr(client, method_name)
+    kwargs = {"num_samples": 1, "msg": "msg", "system_msg": "sys"}
+    if method_name == "batch_query":
+        kwargs["llm_kwargs"] = [{"model_name": "gemini-2.5-flash"}]
+
+    with pytest.raises(GeminiStructuredOutputError):
+        method(**kwargs)
+
+
+@pytest.mark.parametrize("method_name", ["batch_query", "batch_kwargs_query"])
+def test_async_public_batch_propagates_structured_output_error(
+    monkeypatch, method_name
+):
+    client = AsyncLLMClient(model_names="gemini-2.5-flash", verbose=False)
+    helper_name = (
+        "_query_async_with_retry"
+        if method_name == "batch_query"
+        else "_sample_kwargs_query_async_with_retry"
+    )
+
+    async def unsupported(*args, **kwargs):
+        raise GeminiStructuredOutputError("unsupported")
+
+    monkeypatch.setattr(client, helper_name, unsupported)
+    method = getattr(client, method_name)
+    kwargs = {"num_samples": 1, "msg": "msg", "system_msg": "sys"}
+    if method_name == "batch_query":
+        kwargs["llm_kwargs"] = [{"model_name": "gemini-2.5-flash"}]
+
+    with pytest.raises(GeminiStructuredOutputError):
+        asyncio.run(method(**kwargs))
+
+
+@pytest.mark.parametrize("client_factory", [LLMClient, AsyncLLMClient])
+@pytest.mark.parametrize("method_name", ["batch_query", "batch_kwargs_query"])
+def test_public_batch_rejects_gemini_before_start(
+    monkeypatch, client_factory, method_name
+):
+    work_started = 0
+
+    def unexpected_pool(**kwargs):
+        nonlocal work_started
+        work_started += 1
+        raise AssertionError("batch work must not start")
+
+    async def unexpected_helper(*args, **kwargs):
+        nonlocal work_started
+        work_started += 1
+        raise AssertionError("batch work must not start")
+
+    monkeypatch.setattr(llm_module.mp, "Pool", unexpected_pool)
+    client = client_factory(
+        model_names="gemini-2.5-flash", output_model=object(), verbose=False
+    )
+    helper_name = (
+        "_query_async_with_retry"
+        if method_name == "batch_query"
+        else "_sample_kwargs_query_async_with_retry"
+    )
+    if isinstance(client, AsyncLLMClient):
+        monkeypatch.setattr(client, helper_name, unexpected_helper)
+
+    method = getattr(client, method_name)
+    kwargs = {"num_samples": 1, "msg": "msg", "system_msg": "sys"}
+    if method_name == "batch_query":
+        kwargs["llm_kwargs"] = [{"model_name": "gemini-2.5-flash"}]
+
+    with pytest.raises(GeminiStructuredOutputError):
+        result = method(**kwargs)
+        if asyncio.iscoroutine(result):
+            asyncio.run(result)
+
+    assert work_started == 0

--- a/tests/test_llm_kwargs.py
+++ b/tests/test_llm_kwargs.py
@@ -1,3 +1,5 @@
+import pytest
+
 from shinka.llm.kwargs import sample_model_kwargs
 from shinka.llm.providers.pricing import is_reasoning_model, requires_reasoning
 
@@ -44,6 +46,74 @@ def test_gpt5_mini_pricing_metadata_enables_reasoning_kwargs_without_temperature
     assert "temperature" not in kwargs
     assert kwargs["max_output_tokens"] == 8192
     assert kwargs["reasoning"] == {"effort": "minimal", "summary": "auto"}
+
+
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_level"),
+    [
+        ("min", "LOW"),
+        ("low", "LOW"),
+        ("medium", "MEDIUM"),
+        ("high", "HIGH"),
+        ("max", "HIGH"),
+    ],
+)
+def test_latest_gemini_flash_maps_reasoning_effort_to_thinking_level(
+    model_name: str,
+    reasoning_effort: str,
+    expected_level: str,
+):
+    kwargs = sample_model_kwargs(
+        model_names=[model_name],
+        temperatures=[0.25],
+        max_tokens=[4096],
+        reasoning_efforts=[reasoning_effort],
+    )
+
+    assert kwargs == {
+        "model_name": model_name,
+        "max_tokens": 4096,
+        "thinking_level": expected_level,
+    }
+
+
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+def test_latest_gemini_flash_disabled_reasoning_omits_thinking_controls(
+    model_name: str,
+):
+    kwargs = sample_model_kwargs(
+        model_names=[model_name],
+        temperatures=[0.25],
+        max_tokens=[4096],
+        reasoning_efforts=["disabled"],
+    )
+
+    assert kwargs == {"model_name": model_name, "max_tokens": 4096}
+    for unsupported_kwarg in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "candidate_count",
+        "thinking_budget",
+    ):
+        assert unsupported_kwarg not in kwargs
+
+
+def test_legacy_gemini_keeps_token_budget_reasoning():
+    kwargs = sample_model_kwargs(
+        model_names=["gemini-2.5-flash"],
+        temperatures=[0.25],
+        max_tokens=[4096],
+        reasoning_efforts=["medium"],
+    )
+
+    assert kwargs == {
+        "model_name": "gemini-2.5-flash",
+        "temperature": 0.25,
+        "max_tokens": 4096,
+        "thinking_budget": 1024,
+    }
 
 
 def test_deepseek_v4_reasoning_kwargs_enable_thinking_mode():

--- a/tests/test_llm_kwargs.py
+++ b/tests/test_llm_kwargs.py
@@ -48,7 +48,7 @@ def test_gpt5_mini_pricing_metadata_enables_reasoning_kwargs_without_temperature
     assert kwargs["reasoning"] == {"effort": "minimal", "summary": "auto"}
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_level"),
     [
@@ -78,7 +78,7 @@ def test_latest_gemini_flash_maps_reasoning_effort_to_thinking_level(
     }
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 def test_latest_gemini_flash_disabled_reasoning_omits_thinking_controls(
     model_name: str,
 ):

--- a/tests/test_llm_retry_policy.py
+++ b/tests/test_llm_retry_policy.py
@@ -1,0 +1,52 @@
+"""Regression tests for top-level LLM retry pacing."""
+
+import asyncio
+
+import shinka.llm.llm as llm_module
+from shinka.llm.constants import MAX_RETRIES
+from shinka.llm.llm import AsyncLLMClient, LLMClient
+
+
+def test_sync_query_sleeps_between_transient_failures(monkeypatch):
+    calls = 0
+    sleeps = []
+
+    def always_fails(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("transient failure")
+
+    monkeypatch.setattr(llm_module, "query", always_fails)
+    monkeypatch.setattr(llm_module.time, "sleep", lambda seconds: sleeps.append(seconds))
+    client = LLMClient(model_names="test-model", verbose=False)
+
+    result = client.query("msg", "sys", llm_kwargs={"model_name": "test-model"})
+
+    assert result is None
+    assert calls == MAX_RETRIES
+    assert sleeps == [1] * (MAX_RETRIES - 1)
+
+
+def test_async_query_sleeps_between_transient_failures(monkeypatch):
+    calls = 0
+    sleeps = []
+
+    async def always_fails(**kwargs):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("transient failure")
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(llm_module, "query_async", always_fails)
+    monkeypatch.setattr(llm_module.asyncio, "sleep", record_sleep)
+    client = AsyncLLMClient(model_names="test-model", verbose=False)
+
+    result = asyncio.run(
+        client.query("msg", "sys", llm_kwargs={"model_name": "test-model"})
+    )
+
+    assert result is None
+    assert calls == MAX_RETRIES
+    assert sleeps == [1] * (MAX_RETRIES - 1)

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -59,7 +59,7 @@ def test_claude_opus_keeps_standard_pricing_across_context_window(
 
 @pytest.mark.parametrize(
     "model_name",
-    ["gemini-3.6-flash"],
+    ["gemini-3.6-flash", "gemini-3.7-flash"],
 )
 def test_latest_gemini_flash_pricing_is_registered(model_name: str):
     resolved = resolve_model_backend(model_name)

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -57,12 +57,25 @@ def test_claude_opus_keeps_standard_pricing_across_context_window(
     }
 
 
-def test_gemini_3_5_flash_pricing_is_registered():
-    resolved = resolve_model_backend("gemini-3.5-flash")
+@pytest.mark.parametrize(
+    "model_name",
+    ["gemini-3.6-flash"],
+)
+def test_latest_gemini_flash_pricing_is_registered(model_name: str):
+    resolved = resolve_model_backend(model_name)
     assert resolved.provider == "google"
-    assert resolved.api_model_name == "gemini-3.5-flash"
+    assert resolved.api_model_name == model_name
 
+    prices = get_model_prices(model_name)
+    assert prices == {
+        "input_price": 0.75 / 1_000_000,
+        "output_price": 3.75 / 1_000_000,
+    }
+
+
+def test_gemini_3_5_flash_pricing_is_registered():
     prices = get_model_prices("gemini-3.5-flash")
+
     assert prices == {
         "input_price": 1.5 / 1_000_000,
         "output_price": 9.0 / 1_000_000,

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -76,6 +76,12 @@ def test_project_metadata_targets_pypi_release():
     }
 
 
+def test_httpx_dependency_allows_compatible_updates() -> None:
+    dependencies = _read_pyproject()["project"]["dependencies"]
+
+    assert "httpx>=0.27" in dependencies
+
+
 def test_readme_documents_package_install():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -82,6 +82,12 @@ def test_httpx_dependency_allows_compatible_updates() -> None:
     assert "httpx>=0.27" in dependencies
 
 
+def test_google_genai_dependency_supports_thinking_levels() -> None:
+    dependencies = _read_pyproject()["project"]["dependencies"]
+
+    assert "google-genai>=2.13,<3" in dependencies
+
+
 def test_readme_documents_package_install():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 

--- a/tests/test_pricing_csv_generation.py
+++ b/tests/test_pricing_csv_generation.py
@@ -164,7 +164,7 @@ def test_generate_embedding_rows_maps_azure_alias_and_manual_google_entry():
     ]
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 def test_generate_latest_gemini_flash_from_manual_overlay(model_name: str):
     rows = generate_llm_rows(
         _payload(),

--- a/tests/test_pricing_csv_generation.py
+++ b/tests/test_pricing_csv_generation.py
@@ -164,6 +164,29 @@ def test_generate_embedding_rows_maps_azure_alias_and_manual_google_entry():
     ]
 
 
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+def test_generate_latest_gemini_flash_from_manual_overlay(model_name: str):
+    rows = generate_llm_rows(
+        _payload(),
+        [TargetModel("llm", model_name, "google")],
+    )
+
+    assert rows == [
+        {
+            "model_name": model_name,
+            "provider": "google",
+            "input_price": "0.75",
+            "output_price": "3.75",
+            "input_price_tier2": "",
+            "output_price_tier2": "",
+            "tier_threshold": "",
+            "is_reasoning": "True",
+            "think_temp_fixed": "0",
+            "requires_reasoning": "0",
+        }
+    ]
+
+
 def test_load_models_dev_payload_uses_browser_safe_user_agent(monkeypatch):
     captured = {}
 

--- a/tests/test_wandb_database.py
+++ b/tests/test_wandb_database.py
@@ -1,0 +1,339 @@
+import threading
+from types import SimpleNamespace
+
+from shinka.core.async_runner import ShinkaEvolveRunner
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.wandb_logging import ShinkaWandbLogger
+from shinka.wandb_metrics import (
+    build_population_progress_payload,
+    build_population_progress_payload_from_telemetry,
+)
+from wandb_test_utils import make_db
+
+
+def test_population_progress_uses_aggregate_query_without_heavy_fields(
+    tmp_path, monkeypatch
+):
+    db, _, _ = make_db(tmp_path)
+    statements = []
+    db.conn.set_trace_callback(statements.append)
+    monkeypatch.setattr(
+        db,
+        "get_all_programs",
+        lambda: (_ for _ in ()).throw(AssertionError("full rows were materialized")),
+    )
+    logged = []
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(log=logged.append)
+
+    logger.log_population_progress(db=db)
+
+    select = next(
+        statement for statement in statements if "WITH metadata_source AS" in statement
+    )
+    assert " code" not in select.lower()
+    assert "embedding" not in select.lower()
+    assert "private_metrics" not in select.lower()
+    assert "public_metrics" not in select.lower()
+    assert logged[0]["population/count"] == 2
+    assert logged[0]["population/evaluated_count"] == 2
+
+
+def test_population_aggregate_matches_full_program_metric_semantics(tmp_path):
+    db, _, _ = make_db(tmp_path)
+    db.add(
+        Program(
+            id="copy",
+            code="pass",
+            combined_score=1.0,
+            correct=True,
+            island_idx=2,
+            metadata={"_is_island_copy": True, "api_costs": 99.0},
+        ),
+        defer_maintenance=True,
+    )
+    db.add(
+        Program(
+            id="non-finite",
+            code="pass",
+            combined_score=float("inf"),
+            metadata={
+                "api_costs": 2.0,
+                "meta_cost": float("inf"),
+                "pipeline_seconds": float("inf"),
+            },
+        ),
+        defer_maintenance=True,
+    )
+    db.add(
+        Program(
+            id="uppercase-headless",
+            code="pass",
+            metadata={
+                "model_name": "HEADLESS/codex",
+                "headless_pricing_unknown": True,
+                "api_costs": 12.0,
+            },
+        ),
+        defer_maintenance=True,
+    )
+
+    aggregate_payload = build_population_progress_payload_from_telemetry(
+        db.get_population_telemetry()
+    )
+    full_payload = build_population_progress_payload(db.get_all_programs())
+
+    assert aggregate_payload == full_payload
+
+
+def _make_runner(db, logger):
+    runner = object.__new__(ShinkaEvolveRunner)
+    runner.db = db
+    runner.wandb_logger = logger
+    runner.total_api_cost = 0.5
+    runner.total_proposals_generated = 3
+    runner._wandb_population_task = None
+    runner._wandb_population_delay_task = None
+    runner._wandb_population_pending = False
+    runner._wandb_last_population_snapshot_at = None
+    runner._wandb_population_interval_seconds = 5.0
+    runner._wandb_executor = None
+    runner._wandb_candidate_queue = None
+    runner._wandb_candidate_worker_task = None
+    runner._wandb_dropped_candidate_events = 0
+    runner._wandb_last_drop_warning_at = None
+    return runner
+
+
+def test_in_memory_snapshots_read_sqlite_on_owner_thread():
+    async def run():
+        owner_thread = threading.get_ident()
+        db = ProgramDatabase(DatabaseConfig())
+        db.add(Program(id="program", code="pass"), defer_maintenance=True)
+        observed = []
+
+        class Logger:
+            active = True
+
+            def log_population_snapshot(self, snapshot):
+                observed.append(("population", snapshot, threading.get_ident()))
+
+            def log_final_programs(self, programs, **kwargs):
+                observed.append(
+                    (
+                        "final",
+                        [program.id for program in programs],
+                        threading.get_ident(),
+                    )
+                )
+
+            def finish(self):
+                observed.append(("finish", None, threading.get_ident()))
+
+        runner = _make_runner(db, Logger())
+        runner._log_wandb_population_progress()
+        await runner._finish_wandb_logging()
+        db.close()
+
+        assert observed[0][0] == "population"
+        assert observed[0][1][0]["count"] == 1
+        assert observed[1][0:2] == ("final", ["program"])
+        assert all(thread_id != owner_thread for _, _, thread_id in observed)
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_wandb_sdk_operations_share_one_nonblocking_worker():
+    async def run():
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        owner_thread = threading.get_ident()
+        first_started = asyncio.Event()
+        release_first = threading.Event()
+        operation_lock = threading.Lock()
+        calls = []
+
+        class Database:
+            config = SimpleNamespace(db_path=None)
+
+            def get_population_telemetry(self):
+                assert threading.get_ident() == owner_thread
+                return []
+
+            def get_all_programs(self):
+                assert threading.get_ident() == owner_thread
+                return []
+
+        class Logger:
+            active = True
+
+            def _record(self, name, *, wait=False):
+                assert operation_lock.acquire(blocking=False), "overlapping W&B call"
+                try:
+                    calls.append((name, threading.get_ident()))
+                    if wait:
+                        loop.call_soon_threadsafe(first_started.set)
+                        release_first.wait(timeout=1)
+                finally:
+                    operation_lock.release()
+
+            def log_program_payload(self, program_id, payload):
+                self._record("candidate", wait=True)
+
+            def log_population_snapshot(self, snapshot):
+                self._record("population")
+
+            def log_final_programs(self, programs, **kwargs):
+                self._record("final")
+
+            def finish(self):
+                self._record("finish")
+
+        runner = _make_runner(Database(), Logger())
+        runner._log_program_to_wandb(Program(id="candidate", code="pass"))
+        await asyncio.wait_for(first_started.wait(), timeout=0.2)
+        runner._log_wandb_population_progress()
+        finish_task = asyncio.create_task(runner._finish_wandb_logging())
+        await asyncio.sleep(0)
+        release_first.set()
+        await finish_task
+
+        assert [name for name, _ in calls] == [
+            "candidate",
+            "population",
+            "final",
+            "finish",
+        ]
+        worker_threads = {thread_id for _, thread_id in calls}
+        assert len(worker_threads) == 1
+        assert owner_thread not in worker_threads
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_wandb_candidate_queue_is_bounded_compact_and_rate_limited(caplog):
+    async def run():
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        first_started = asyncio.Event()
+        release_first = threading.Event()
+        logged_ids = []
+
+        class Logger:
+            active = True
+
+            def log_program_payload(self, program_id, payload):
+                logged_ids.append(program_id)
+                if len(logged_ids) == 1:
+                    loop.call_soon_threadsafe(first_started.set)
+                    release_first.wait(timeout=1)
+
+        runner = _make_runner(SimpleNamespace(), Logger())
+        runner._wandb_candidate_queue_size = 2
+        runner._log_program_to_wandb(
+            Program(id="first", code="unique-private-code-first")
+        )
+        await asyncio.wait_for(first_started.wait(), timeout=0.2)
+
+        for program_id in ("second", "third", "fourth", "fifth"):
+            runner._log_program_to_wandb(
+                Program(id=program_id, code=f"unique-private-code-{program_id}")
+            )
+
+        queue = runner._wandb_candidate_queue
+        assert queue.maxsize == 2
+        assert queue.qsize() == 2
+        assert "unique-private-code" not in repr(list(queue._queue))
+        assert "Program(" not in repr(list(queue._queue))
+        assert runner._wandb_dropped_candidate_events == 2
+        assert caplog.text.count("W&B candidate queue full") == 1
+
+        release_first.set()
+        await runner._drain_wandb_candidate_queue()
+        await runner._stop_wandb_candidate_worker()
+        await runner._shutdown_wandb_executor()
+
+        assert logged_ids == ["first", "second", "third"]
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_wandb_population_queries_are_time_throttled_and_final_skips_delay():
+    async def run():
+        import asyncio
+
+        query_count = 0
+
+        class Database:
+            config = SimpleNamespace(db_path=None)
+
+            def get_population_telemetry(self):
+                nonlocal query_count
+                query_count += 1
+                return []
+
+            def get_all_programs(self):
+                return []
+
+        class Logger:
+            active = True
+
+            def log_population_snapshot(self, snapshot):
+                pass
+
+            def log_final_programs(self, programs, **kwargs):
+                pass
+
+            def finish(self):
+                pass
+
+        runner = _make_runner(Database(), Logger())
+        runner._wandb_population_interval_seconds = 60.0
+        runner._log_wandb_population_progress()
+        await runner._wait_for_wandb_population_progress()
+
+        runner._log_wandb_population_progress()
+        runner._log_wandb_population_progress()
+        runner._log_wandb_population_progress()
+        await asyncio.sleep(0)
+
+        assert query_count == 1
+        assert runner._wandb_population_delay_task is not None
+
+        await runner._finish_wandb_logging()
+
+        assert query_count == 1
+        assert runner._wandb_population_delay_task is None
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_in_memory_population_query_failure_is_non_fatal(caplog):
+    class Database:
+        config = SimpleNamespace(db_path=None)
+
+        def get_population_telemetry(self):
+            raise RuntimeError("telemetry query failed")
+
+    logger = SimpleNamespace(active=True, log_population_snapshot=lambda snapshot: None)
+    runner = _make_runner(Database(), logger)
+
+    async def run():
+        runner._log_wandb_population_progress()
+
+    import asyncio
+
+    asyncio.run(run())
+
+    assert runner._wandb_population_task is None
+    assert "Failed to query in-memory W&B population snapshot" in caplog.text

--- a/tests/test_wandb_logging.py
+++ b/tests/test_wandb_logging.py
@@ -4,63 +4,17 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from shinka.core.config import EvolutionConfig
-from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.database import DatabaseConfig, Program
+from shinka.launch.scheduler import LocalJobConfig
 from shinka.wandb_logging import (
+    EVALUATED_COUNT_METRIC,
     INDIVIDUAL_SCORE_METRIC,
     PROGRAM_TABLE_COLUMNS,
     PROGRAM_TABLE_KEY,
     ShinkaWandbLogger,
-    build_program_log_payload,
-    build_run_summary,
     ensure_wandb_run_id,
 )
-
-
-def _make_db(tmp_path):
-    db = ProgramDatabase(DatabaseConfig(db_path=str(tmp_path / "programs.sqlite")))
-    first = Program(
-        id="p0",
-        code="print(0)",
-        generation=0,
-        correct=True,
-        combined_score=1.0,
-        public_metrics={
-            "score": 1.0,
-            "nested": {"accuracy": 0.5},
-            "bulky_text": "not a chart metric",
-        },
-        private_metrics={"hidden": 2.0},
-        metadata={
-            "api_costs": 0.10,
-            "embed_cost": 0.01,
-            "novelty_cost": 0.02,
-            "meta_cost": 0.03,
-            "patch_type": "init",
-            "pipeline_seconds": 2.0,
-            "evaluation_seconds": 1.5,
-            "model_name": "test-model",
-        },
-    )
-    second = Program(
-        id="p1",
-        code="print(1)",
-        generation=1,
-        parent_id="p0",
-        correct=False,
-        combined_score=0.25,
-        public_metrics={"score": 0.25},
-        metadata={
-            "api_costs": 0.20,
-            "embed_cost": 0.02,
-            "novelty_cost": 0.03,
-            "meta_cost": 0.04,
-            "patch_type": "diff",
-            "llm_result": {"model": "fallback-model"},
-        },
-    )
-    db.add(first, defer_maintenance=True)
-    db.add(second, defer_maintenance=True)
-    return db, first, second
+from wandb_test_utils import make_db
 
 
 def test_wandb_logging_is_opt_in_and_does_not_configure_webui():
@@ -83,50 +37,6 @@ def test_wandb_run_id_is_reused_and_can_be_overridden(tmp_path):
     )
 
 
-def test_program_payload_logs_one_compact_event_per_individual(tmp_path):
-    _, _, second = _make_db(tmp_path)
-
-    payload = build_program_log_payload(second)
-
-    assert payload["generation"] == 1
-    assert payload[INDIVIDUAL_SCORE_METRIC] == 0.25
-    assert payload["individual/model_name"] == "fallback-model"
-    assert "public_metrics/score" not in payload
-    assert payload["cost/api"] == pytest.approx(0.20)
-    assert "program/combined_score" not in payload
-    assert not any(key.startswith("metadata/") for key in payload)
-    assert not any("latest" in key for key in payload)
-
-
-def test_program_payload_skips_bulky_values_and_duplicate_timing(tmp_path):
-    _, first, _ = _make_db(tmp_path)
-
-    payload = build_program_log_payload(first)
-
-    assert payload["public_metrics/nested/accuracy"] == 0.5
-    assert payload["private_metrics/hidden"] == 2.0
-    assert "public_metrics/bulky_text" not in payload
-    assert payload["timing/pipeline_seconds"] == 2.0
-    assert "metadata/pipeline_seconds" not in payload
-
-
-def test_run_summary_uses_correct_programs_for_best_score(tmp_path):
-    db, _, _ = _make_db(tmp_path)
-
-    summary = build_run_summary(
-        db.get_all_programs(),
-        total_proposals_generated=2,
-        total_api_cost=0.5,
-    )
-
-    assert summary["run/program_count"] == 2
-    assert summary["run/correct_rate"] == 0.5
-    assert summary["run/best_score"] == 1.0
-    assert summary["run/max_generation"] == 1
-    assert summary["run/total_proposals_generated"] == 2
-    assert summary["run/total_api_cost"] == 0.5
-
-
 def test_invalid_wandb_config_is_non_fatal(tmp_path, monkeypatch, caplog):
     fake_wandb = ModuleType("wandb")
     fake_wandb.init = lambda **kwargs: pytest.fail("wandb.init should not be called")
@@ -144,8 +54,119 @@ def test_invalid_wandb_config_is_non_fatal(tmp_path, monkeypatch, caplog):
     assert "Failed to initialize W&B logging" in caplog.text
 
 
+def test_wandb_history_failure_is_non_fatal_and_retryable(tmp_path, caplog):
+    _, first, _ = make_db(tmp_path)
+
+    class FlakyRun:
+        def __init__(self):
+            self.calls = 0
+
+        def log(self, _payload):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary telemetry failure")
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = FlakyRun()
+
+    logger.log_program(first)
+    logger.log_program(first)
+
+    assert logger._run.calls == 2
+    assert "Failed to log individual p0 to W&B" in caplog.text
+
+
+@pytest.mark.parametrize("copy_marker", ["_is_island_copy", "_spawned_island"])
+def test_wandb_history_skips_administrative_copies(copy_marker):
+    logged_payloads = []
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(log=logged_payloads.append)
+    copy = Program(id="copy", code="pass", metadata={copy_marker: True})
+
+    logger.log_program(copy)
+
+    assert logged_payloads == []
+
+
+def test_final_history_failure_does_not_suppress_summary_or_table(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    logged = []
+
+    class Run:
+        summary = {}
+
+        def log(self, payload):
+            if not logged:
+                logged.append("history-failed")
+                raise RuntimeError("history")
+            logged.append(payload)
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = Run()
+    logger._wandb = SimpleNamespace(Table=lambda **kwargs: SimpleNamespace(**kwargs))
+
+    logger.log_final(db=db, total_api_cost=0.4, total_cost=0.5)
+
+    assert logger._run.summary["run/total_api_cost"] == 0.4
+    assert PROGRAM_TABLE_KEY in logged[-1]
+    assert "final W&B history" in caplog.text
+
+
+def test_final_summary_failure_does_not_suppress_table(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    logged = []
+
+    class BrokenSummary(dict):
+        def update(self, values):
+            raise RuntimeError("summary")
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(summary=BrokenSummary(), log=logged.append)
+    logger._wandb = SimpleNamespace(Table=lambda **kwargs: SimpleNamespace(**kwargs))
+
+    logger.log_final(db=db, total_api_cost=0.4)
+
+    assert PROGRAM_TABLE_KEY in logged[-1]
+    assert "final W&B summary" in caplog.text
+
+
+def test_final_table_construction_failure_keeps_history_and_summary(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    logged = []
+    summary = {}
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(summary=summary, log=logged.append)
+    logger._wandb = SimpleNamespace(
+        Table=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("table"))
+    )
+
+    logger.log_final(db=db, total_api_cost=0.4)
+
+    assert logged[0]["run/total_api_cost"] == 0.4
+    assert summary["run/total_api_cost"] == 0.4
+    assert "final W&B table" in caplog.text
+
+
+def test_final_table_log_failure_is_non_fatal(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    summary = {}
+
+    def log(payload):
+        if PROGRAM_TABLE_KEY in payload:
+            raise RuntimeError("table log")
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(summary=summary, log=log)
+    logger._wandb = SimpleNamespace(Table=lambda **kwargs: SimpleNamespace(**kwargs))
+
+    logger.log_final(db=db, total_api_cost=0.4)
+
+    assert summary["run/total_api_cost"] == 0.4
+    assert "log final W&B table" in caplog.text
+
+
 def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
-    db, first, second = _make_db(tmp_path)
+    db, first, second = make_db(tmp_path)
     logged_payloads = []
     init_kwargs = {}
 
@@ -169,6 +190,10 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
             self.columns = columns
             self.data = data
 
+    class FakeSettings:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
     fake_run = FakeRun()
     fake_wandb = ModuleType("wandb")
 
@@ -178,44 +203,91 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
 
     fake_wandb.init = fake_init
     fake_wandb.Table = FakeTable
+    fake_wandb.Settings = FakeSettings
     monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
 
     evo_config = EvolutionConfig(
         wandb_project="project",
         wandb_name="name",
         wandb_mode="offline",
+        task_sys_msg="private task instructions",
+        wandb_config={
+            "nested": {
+                "api_key": "wandb-extra-secret",
+                "apiKey": "camel-api-secret",
+                "accessToken": "camel-access-secret",
+                "clientSecret": "camel-client-secret",
+                "AuthorizationHeader": "camel-authorization-secret",
+                "aws_secret_access_key": "aws-secret",
+                "Authorization": "Bearer auth-secret",
+                "safe_value": 2,
+            }
+        },
     )
     logger = ShinkaWandbLogger(enabled=True)
     logger.start(
         evo_config=evo_config,
         db_config=SimpleNamespace(),
-        job_config=SimpleNamespace(),
+        job_config=LocalJobConfig(
+            extra_cmd_args={"access_token": "job-secret", "workers": 2}
+        ),
         results_dir=tmp_path,
     )
     logger.log_program(first)
     logger.log_program(first)
     logger.log_program(second)
+    logger.log_population_progress(db=db)
+    logger.log_population_progress(db=db)
     logger.log_final(
         db=db,
         total_proposals_generated=2,
-        total_api_cost=0.5,
+        total_cost=0.5,
     )
     logger.finish()
 
     assert init_kwargs["project"] == "project"
     assert init_kwargs["mode"] == "offline"
+    assert init_kwargs["save_code"] is False
+    assert init_kwargs["settings"].kwargs == {
+        "console": "off",
+        "disable_git": True,
+        "disable_code": True,
+        "x_disable_stats": True,
+        "x_disable_machine_info": True,
+        "x_save_requirements": False,
+    }
     assert init_kwargs["id"]
     assert init_kwargs["resume"] == "allow"
     assert (tmp_path / ".wandb_run_id").read_text(encoding="utf-8").strip() == (
         init_kwargs["id"]
     )
-    assert init_kwargs["config"]["evolution"]["wandb_run_id"] == init_kwargs["id"]
+    assert "private task instructions" not in repr(init_kwargs["config"])
+    assert "wandb-extra-secret" not in repr(init_kwargs["config"])
+    assert "camel-api-secret" not in repr(init_kwargs["config"])
+    assert "camel-access-secret" not in repr(init_kwargs["config"])
+    assert "camel-client-secret" not in repr(init_kwargs["config"])
+    assert "camel-authorization-secret" not in repr(init_kwargs["config"])
+    assert "aws-secret" not in repr(init_kwargs["config"])
+    assert "auth-secret" not in repr(init_kwargs["config"])
+    assert "job-secret" not in repr(init_kwargs["config"])
+    assert init_kwargs["config"]["nested"]["safe_value"] == 2
+    assert "task_sys_msg" not in init_kwargs["config"]["evolution"]
+    assert "init_program_path" not in init_kwargs["config"]["evolution"]
+    assert "llm_kwargs" not in init_kwargs["config"]["evolution"]
+    assert "db_path" not in init_kwargs["config"]["database"]
+    assert "extra_cmd_args" not in init_kwargs["config"]["job"]
     assert fake_run.finished is True
     assert [payload[INDIVIDUAL_SCORE_METRIC] for payload in logged_payloads[:2]] == [
         1.0,
         0.25,
     ]
-    assert len(logged_payloads) == 3
+    assert len(logged_payloads) == 5
+    assert logged_payloads[2][EVALUATED_COUNT_METRIC] == 2
+    assert logged_payloads[3][EVALUATED_COUNT_METRIC] == 2
+    assert logged_payloads[3]["cost/embed"] == pytest.approx(0.03)
+    assert logged_payloads[3]["cost/total"] == pytest.approx(0.35)
+    assert logged_payloads[3]["run/evaluated_count"] == 2
+    assert logged_payloads[3]["run/total_cost"] == 0.5
     table = logged_payloads[-1][PROGRAM_TABLE_KEY]
     assert isinstance(table, FakeTable)
     assert table.columns == PROGRAM_TABLE_COLUMNS
@@ -223,10 +295,16 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
     assert "code" not in table.columns
     assert "embedding" not in table.columns
     assert fake_run.summary["run/best_score"] == 1.0
+    assert fake_run.summary["run/evaluated_count"] == 2
+    assert fake_run.summary["run/total_cost"] == 0.5
     score_definition = next(
         item for item in fake_run.defined if item[0] == (INDIVIDUAL_SCORE_METRIC,)
     )
-    assert score_definition[1] == {"step_metric": "generation"}
+    assert score_definition[1] == {}
+    population_definition = next(
+        item for item in fake_run.defined if item[0] == ("population/count",)
+    )
+    assert population_definition[1] == {"step_metric": EVALUATED_COUNT_METRIC}
 
     first_run_id = init_kwargs["id"]
     resumed_config = EvolutionConfig(
@@ -252,7 +330,7 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
 def test_wandb_online_logging_with_authenticated_sdk(tmp_path, monkeypatch, caplog):
     import wandb
 
-    db, first, second = _make_db(tmp_path)
+    db, first, second = make_db(tmp_path)
     monkeypatch.delenv("WANDB_MODE", raising=False)
     wandb.login(verify=True)
 
@@ -278,7 +356,7 @@ def test_wandb_online_logging_with_authenticated_sdk(tmp_path, monkeypatch, capl
         logger.log_final(
             db=db,
             total_proposals_generated=2,
-            total_api_cost=0.5,
+            total_cost=0.5,
         )
     finally:
         logger.finish()

--- a/tests/test_wandb_metrics.py
+++ b/tests/test_wandb_metrics.py
@@ -1,0 +1,198 @@
+import pytest
+
+from shinka.database import Program
+from shinka.wandb_logging import (
+    EVALUATED_COUNT_METRIC,
+    INDIVIDUAL_SCORE_METRIC,
+    MAX_METRIC_KEY_LENGTH,
+    MAX_PUBLIC_METRICS,
+    PROGRAM_TABLE_COLUMNS,
+    build_population_progress_payload,
+    build_program_log_payload,
+    build_run_summary,
+    program_table_row,
+)
+from wandb_test_utils import make_db
+
+
+def test_program_payload_logs_one_compact_event_per_individual(tmp_path):
+    _, _, second = make_db(tmp_path)
+
+    payload = build_program_log_payload(second)
+
+    assert payload["generation"] == 1
+    assert payload[INDIVIDUAL_SCORE_METRIC] == 0.25
+    assert payload["individual/model_name"] == "fallback-model"
+    assert payload["individual/is_copy"] is False
+    assert "public_metrics/score" not in payload
+    assert payload["individual/cost/api"] == pytest.approx(0.20)
+    assert not any(key.startswith("headless/") for key in payload)
+    assert "cost/api" not in payload
+    assert "program/combined_score" not in payload
+    assert not any(key.startswith("metadata/") for key in payload)
+    assert not any("latest" in key for key in payload)
+    assert "print(1)" not in repr(payload)
+    assert "[1.0, 2.0]" not in repr(payload)
+
+
+def test_program_payload_skips_bulky_values_and_duplicate_timing(tmp_path):
+    _, first, _ = make_db(tmp_path)
+
+    payload = build_program_log_payload(first)
+
+    assert payload["public_metrics/nested/accuracy"] == 0.5
+    assert "private_metrics/hidden" not in payload
+    assert "public_metrics/bulky_text" not in payload
+    assert payload["individual/timing/pipeline_seconds"] == 2.0
+    assert payload["headless/usage_status"] == "reported"
+    assert payload["headless/usage_unknown"] is False
+    assert payload["headless/pricing_status"] == "missing"
+    assert payload["headless/pricing_unknown"] is True
+    assert "headless/cost_basis" not in payload
+    assert "individual/cost/api" not in payload
+    assert "metadata/pipeline_seconds" not in payload
+    assert "must-not-leak" not in repr(payload)
+
+
+@pytest.mark.parametrize("copy_marker", ["_is_island_copy", "_spawned_island"])
+def test_population_progress_counts_copies_but_excludes_their_costs(
+    tmp_path, copy_marker
+):
+    db, _, _ = make_db(tmp_path)
+    copy = Program(
+        id="copy-1",
+        code="# Copy\n",
+        generation=0,
+        correct=True,
+        combined_score=1.0,
+        island_idx=1,
+        metadata={copy_marker: True, "embed_cost": 9.0},
+    )
+    db.add(copy, defer_maintenance=True)
+
+    payload = build_population_progress_payload(db.get_all_programs())
+
+    assert payload[EVALUATED_COUNT_METRIC] == 2
+    assert payload["population/count"] == 3
+    assert payload["population/correct_count"] == 2
+    assert payload["population/best_score"] == 1.0
+    assert payload["cost/embed"] == pytest.approx(0.03)
+    assert payload["cost/total"] == pytest.approx(0.35)
+    assert payload["island/0/evaluated_count"] == 2
+    assert payload["island/1/evaluated_count"] == 0
+    assert payload["island/1/count"] == 1
+    assert program_table_row(copy)[PROGRAM_TABLE_COLUMNS.index("cost")] == 0.0
+
+
+def test_actual_headless_unknown_pricing_suppresses_only_api_cost():
+    program = Program(
+        id="headless",
+        code="pass",
+        metadata={
+            "model_name": "headless/codex",
+            "headless_pricing_unknown": True,
+            "api_costs": 12.0,
+            "embed_cost": 0.2,
+        },
+    )
+
+    individual = build_program_log_payload(program)
+    population = build_population_progress_payload([program])
+
+    assert "individual/cost/api" not in individual
+    assert individual["individual/cost/embed"] == pytest.approx(0.2)
+    assert population["cost/api"] == 0.0
+    assert population["cost/embed"] == pytest.approx(0.2)
+    assert population["cost/pricing_unknown_count"] == 1
+    assert program_table_row(program)[PROGRAM_TABLE_COLUMNS.index("cost")] == 0.2
+
+
+def test_stale_headless_prompt_path_does_not_suppress_api_cost():
+    program = Program(
+        id="headless-path",
+        code="pass",
+        metadata={
+            "model_name": "codex",
+            "headless_prompt_path": "/redacted/prompt.md",
+            "headless_pricing_unknown": True,
+            "api_costs": 12.0,
+        },
+    )
+
+    payload = build_program_log_payload(program)
+
+    assert payload["individual/cost/api"] == 12.0
+    assert "/redacted/prompt.md" not in repr(payload)
+
+
+def test_program_payload_bounds_public_metrics_and_omits_private_metrics():
+    public_metrics = {f"metric_{idx}": idx for idx in range(MAX_PUBLIC_METRICS + 10)}
+    public_metrics["x" * (MAX_METRIC_KEY_LENGTH + 1)] = 1.0
+    public_metrics["aws_secret_access_key"] = 2.0
+    program = Program(
+        id="bounded",
+        code="pass",
+        public_metrics=public_metrics,
+        private_metrics={"hidden_score": 99.0},
+    )
+
+    payload = build_program_log_payload(program)
+    logged_public = {
+        key: value
+        for key, value in payload.items()
+        if key.startswith("public_metrics/")
+    }
+
+    assert len(logged_public) == MAX_PUBLIC_METRICS
+    assert all(len(key) <= MAX_METRIC_KEY_LENGTH for key in logged_public)
+    assert not any(key.startswith("private_metrics/") for key in payload)
+    assert "aws_secret_access_key" not in repr(payload)
+
+
+@pytest.mark.parametrize(
+    "sensitive_key",
+    ["apiKey", "accessToken", "clientSecret", "AuthorizationHeader"],
+)
+def test_program_payload_omits_compound_sensitive_metric_keys(sensitive_key):
+    program = Program(
+        id="sensitive-metric",
+        code="pass",
+        public_metrics={sensitive_key: 123.0, "safeScore": 0.5},
+    )
+
+    payload = build_program_log_payload(program)
+
+    assert sensitive_key not in repr(payload)
+    assert payload["public_metrics/safeScore"] == 0.5
+
+
+def test_run_summary_uses_correct_programs_for_best_score(tmp_path):
+    db, _, _ = make_db(tmp_path)
+
+    summary = build_run_summary(
+        db.get_all_programs(),
+        total_proposals_generated=2,
+        total_cost=0.5,
+    )
+
+    assert summary["run/program_count"] == 2
+    assert summary["run/correct_rate"] == 0.5
+    assert summary["run/best_score"] == 1.0
+    assert summary["run/max_generation"] == 1
+    assert summary["run/total_proposals_generated"] == 2
+    assert summary["run/evaluated_count"] == 2
+    assert summary["run/total_cost"] == 0.5
+
+
+def test_run_summary_preserves_legacy_api_cost_and_prefers_explicit_total(tmp_path):
+    db, _, _ = make_db(tmp_path)
+
+    explicit = build_run_summary(
+        db.get_all_programs(), total_api_cost=0.4, total_cost=0.7
+    )
+    legacy_only = build_run_summary(db.get_all_programs(), total_api_cost=0.4)
+
+    assert explicit["run/total_api_cost"] == 0.4
+    assert explicit["run/total_cost"] == 0.7
+    assert legacy_only["run/total_api_cost"] == 0.4
+    assert legacy_only["run/total_cost"] == 0.4

--- a/tests/wandb_test_utils.py
+++ b/tests/wandb_test_utils.py
@@ -1,0 +1,63 @@
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def make_programs():
+    first = Program(
+        id="p0",
+        code="print(0)",
+        generation=0,
+        correct=True,
+        combined_score=1.0,
+        public_metrics={
+            "score": 1.0,
+            "nested": {"accuracy": 0.5},
+            "bulky_text": "not a chart metric",
+        },
+        private_metrics={"hidden": 2.0},
+        metadata={
+            "api_costs": 0.10,
+            "embed_cost": 0.01,
+            "novelty_cost": 0.02,
+            "meta_cost": 0.03,
+            "patch_type": "init",
+            "pipeline_seconds": 2.0,
+            "evaluation_seconds": 1.5,
+            "model_name": "headless/test-agent",
+            "headless_usage_status": "reported",
+            "headless_usage_unknown": False,
+            "headless_pricing_status": "missing",
+            "headless_pricing_unknown": True,
+            "headless_cost_basis": None,
+            "headless_pricing_source": None,
+            "secret_token": "must-not-leak",
+        },
+    )
+    second = Program(
+        id="p1",
+        code="print(1)",
+        generation=1,
+        parent_id="p0",
+        correct=False,
+        combined_score=0.25,
+        public_metrics={"score": 0.25},
+        metadata={
+            "api_costs": 0.20,
+            "embed_cost": 0.02,
+            "novelty_cost": 0.03,
+            "meta_cost": 0.04,
+            "patch_type": "diff",
+            "llm_result": {"model": "fallback-model"},
+            "headless_usage_status": "stale",
+            "headless_pricing_unknown": True,
+            "embedding": [1.0, 2.0],
+        },
+    )
+    return first, second
+
+
+def make_db(tmp_path):
+    db = ProgramDatabase(DatabaseConfig(db_path=str(tmp_path / "programs.sqlite")))
+    first, second = make_programs()
+    db.add(first, defer_maintenance=True)
+    db.add(second, defer_maintenance=True)
+    return db, first, second


### PR DESCRIPTION
## What changed

- Add a shared `NonRetryableLLMError` contract and a structured-output subtype that remains compatible with `ValueError` handlers.
- Reject unsupported Gemini structured-output requests before client construction or batch work starts, and propagate the typed error through sync/async single and batch APIs without retries.
- Make Gemini's provider backoff give up on all typed non-retryable failures while preserving transient retry budgets.
- Pace synchronous outer retries by one second and align the legacy Gemini sync/async default thinking budget at 1024.
- Preserve Gemini 3.6/3.7 level-based thinking configuration and document the behavior in the changelog.

## Compatibility and rollback

Unsupported Gemini structured-output calls now raise immediately instead of retrying and eventually returning `None` or an empty batch. The exception remains a `ValueError` subtype. Legacy async Gemini calls that omit `thinking_budget` now use 1024, matching sync behavior; this can increase thinking-token usage compared with the previous async default of zero. Roll back by reverting `1428b3a`.

This branch was rebuilt on current `main`; it no longer contains the closed #150 ancestry. PR #164 can continue to consume the shared error contract after this merges.

## Verification

- Focused retry/provider/client suite: 76 passed.
- CI-equivalent local gate: Ruff clean; Mypy clean; 811 passed, 7 skipped, 2 deselected. Five existing bandit warnings only.
- Read-only intent, security, and reliability review passes: no remaining material findings.
- Secret review: `.env` remains ignored; no Gemini key or credential-like value appears in the diff or logs.

## Live provider and integration evidence

Commit: `1428b3af9403bf8506f4af1e6d858d13fb6358af`

- Direct `gemini-2.5-flash` sync/async smoke, omitted `thinking_budget`: both returned content with 15 input, 1 output, and 10 thinking tokens; cost $0.000032 each.
- Circle Packing command for both baseline and branch:

  `uv run shinka_run --task-dir examples/circle_packing --results_dir <isolated-dir> --num_generations 2 --max-evaluation-jobs 1 --max-proposal-jobs 1 --set evo.llm_models='["gemini-2.5-flash"]'`

| Metric | `main` | PR #163 |
| --- | ---: | ---: |
| Completed generations | 2 | 2 |
| Persisted rows | 3 | 3 |
| Correct programs | 2 | 2 |
| Missing generations | 0 | 0 |
| Best score | 0.959764 | 0.959764 |
| API cost | $0.0020 | $0.0016 |
| Runtime | 14.02s | 10.86s |

Both SQLite databases passed `PRAGMA integrity_check`. The branch WebUI served its tree page and returned the expected 3-program/2-generation summary. A rendered Playwright screenshot was host-blocked because Chrome is absent and bundled Firefox cannot load `libasound.so.2`; HTTP/UI data-path validation passed.
