### PR TITLE
fix(database): reconcile serialization drift

### DIFF
--- a/shinka/database/async_dbase.py
+++ b/shinka/database/async_dbase.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Tuple, Dict, Any
 from concurrent.futures import ThreadPoolExecutor
 
 from .complexity import analyze_code_metrics
-from .dbase import Program, ProgramDatabase
+from .dbase import Program, ProgramDatabase, clean_nan_values
 
 logger = logging.getLogger(__name__)
 
@@ -915,7 +915,11 @@ class AsyncProgramDatabase:
                     if details is not None:
                         import json
 
-                        payload = json.dumps(details, sort_keys=True)
+                        # Match the sync event log: strip NaN/Inf so the stored
+                        # JSON is valid and round-trips through a strict parser.
+                        payload = json.dumps(
+                            clean_nan_values(details), sort_keys=True
+                        )
                     conn.execute(
                         """
                         INSERT INTO attempt_log (
@@ -968,7 +972,11 @@ class AsyncProgramDatabase:
                     if details is not None:
                         import json
 
-                        payload = json.dumps(details, sort_keys=True)
+                        # Match the sync event log: strip NaN/Inf so the stored
+                        # JSON is valid and round-trips through a strict parser.
+                        payload = json.dumps(
+                            clean_nan_values(details), sort_keys=True
+                        )
                     conn.execute(
                         """
                         INSERT INTO generation_event_log (

--- a/shinka/database/parents.py
+++ b/shinka/database/parents.py
@@ -300,51 +300,36 @@ class WeightedSamplingStrategy(ParentSamplingStrategy):
             logger.warning("No suitable parent found for weighted sampling")
             return None
 
+        def _safe_json(raw: Any, default: Any) -> Any:
+            """Parse a JSON column, tolerating a corrupt/malformed cell."""
+            if not raw:
+                return default
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Could not decode JSON column during parent sampling")
+                return default
+
         eligible_programs = []
         for row in archive_rows:
             p_dict = dict(row)
 
-            # Parse JSON fields
-            p_dict["public_metrics"] = (
-                json.loads(p_dict["public_metrics"])
-                if p_dict.get("public_metrics")
-                else {}
+            # Parse JSON fields defensively so one corrupt cell cannot abort
+            # selection from otherwise valid archive rows.
+            p_dict["public_metrics"] = _safe_json(p_dict.get("public_metrics"), {})
+            p_dict["private_metrics"] = _safe_json(p_dict.get("private_metrics"), {})
+            p_dict["metadata"] = _safe_json(p_dict.get("metadata"), {})
+            p_dict["archive_inspiration_ids"] = _safe_json(
+                p_dict.get("archive_inspiration_ids"), []
             )
-            p_dict["private_metrics"] = (
-                json.loads(p_dict["private_metrics"])
-                if p_dict.get("private_metrics")
-                else {}
+            p_dict["top_k_inspiration_ids"] = _safe_json(
+                p_dict.get("top_k_inspiration_ids"), []
             )
-            p_dict["metadata"] = (
-                json.loads(p_dict["metadata"]) if p_dict.get("metadata") else {}
-            )
-            p_dict["archive_inspiration_ids"] = (
-                json.loads(p_dict["archive_inspiration_ids"])
-                if p_dict.get("archive_inspiration_ids")
-                else []
-            )
-            p_dict["top_k_inspiration_ids"] = (
-                json.loads(p_dict["top_k_inspiration_ids"])
-                if p_dict.get("top_k_inspiration_ids")
-                else []
-            )
-            p_dict["embedding"] = (
-                json.loads(p_dict["embedding"]) if p_dict.get("embedding") else []
-            )
-            p_dict["embedding_pca_2d"] = (
-                json.loads(p_dict["embedding_pca_2d"])
-                if p_dict.get("embedding_pca_2d")
-                else []
-            )
-            p_dict["embedding_pca_3d"] = (
-                json.loads(p_dict["embedding_pca_3d"])
-                if p_dict.get("embedding_pca_3d")
-                else []
-            )
-            p_dict["migration_history"] = (
-                json.loads(p_dict["migration_history"])
-                if p_dict.get("migration_history")
-                else []
+            p_dict["embedding"] = _safe_json(p_dict.get("embedding"), [])
+            p_dict["embedding_pca_2d"] = _safe_json(p_dict.get("embedding_pca_2d"), [])
+            p_dict["embedding_pca_3d"] = _safe_json(p_dict.get("embedding_pca_3d"), [])
+            p_dict["migration_history"] = _safe_json(
+                p_dict.get("migration_history"), []
             )
 
             # Create a simple dataclass-like object from the dict to avoid circular imports

--- a/tests/test_async_database_drift.py
+++ b/tests/test_async_database_drift.py
@@ -1,0 +1,46 @@
+"""Regression tests for async database serialization parity."""
+
+import asyncio
+import json
+import sqlite3
+
+import pytest
+
+from shinka.database import DatabaseConfig, ProgramDatabase
+from shinka.database.async_dbase import AsyncProgramDatabase
+
+
+def _reject_nonstandard_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant: {value}")
+
+
+@pytest.mark.parametrize(
+    ("record_event", "table"),
+    [
+        ("record_attempt_event_async", "attempt_log"),
+        ("record_generation_event_async", "generation_event_log"),
+    ],
+)
+def test_async_event_details_are_strict_json(tmp_path, record_event, table):
+    db_path = tmp_path / "events.db"
+    sync_db = ProgramDatabase(
+        config=DatabaseConfig(db_path=str(db_path), num_islands=1)
+    )
+    async_db = AsyncProgramDatabase(sync_db, max_workers=1)
+
+    async def record() -> None:
+        method = getattr(async_db, record_event)
+        kwargs = {"generation": 1, "status": "failed"}
+        if record_event == "record_attempt_event_async":
+            kwargs["stage"] = "proposal"
+        await method(details={"nan": float("nan"), "inf": float("inf"), "ok": 1.0}, **kwargs)
+
+    try:
+        asyncio.run(record())
+        with sqlite3.connect(db_path) as connection:
+            payload = connection.execute(f"SELECT details FROM {table}").fetchone()[0]
+        parsed = json.loads(payload, parse_constant=_reject_nonstandard_constant)
+        assert parsed == {"inf": None, "nan": None, "ok": 1.0}
+    finally:
+        asyncio.run(async_db.close_async())
+        sync_db.close()

--- a/tests/test_parent_sampling_drift.py
+++ b/tests/test_parent_sampling_drift.py
@@ -1,0 +1,40 @@
+"""Regression tests for defensive weighted-parent deserialization."""
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.database.parents import WeightedSamplingStrategy
+
+
+def test_weighted_sampling_tolerates_corrupt_json_cell(tmp_path):
+    db = ProgramDatabase(
+        config=DatabaseConfig(db_path=str(tmp_path / "corrupt.db"), num_islands=1)
+    )
+    db.add(
+        Program(
+            id="good",
+            code="def f():\n    return 1\n",
+            correct=True,
+            combined_score=1.0,
+            generation=0,
+            island_idx=0,
+            embedding=[0.1, 0.2],
+        )
+    )
+    db.cursor.execute(
+        "UPDATE programs SET metadata = ? WHERE id = ?",
+        ("{not valid json", "good"),
+    )
+    db.conn.commit()
+
+    selector = WeightedSamplingStrategy(
+        cursor=db.cursor,
+        conn=db.conn,
+        config=db.config,
+        get_program_func=db.get,
+        island_idx=0,
+    )
+
+    try:
+        selected = selector.sample_parent()
+        assert selected is None or selected.id == "good"
+    finally:
+        db.close()


### PR DESCRIPTION
## What changed
- Align sync and async JSON serialization behavior.
- Handle corrupt parent metadata consistently.
- Add focused parity regressions.

## Review scope
Database-drift extraction from #153. Based directly on #150.

## Verification
- Focused database parity tests
- Ruff and Mypy
- Integrated 876-test gate

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.