### PR TITLE
fix(llm): reconcile provider accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed Anthropic and DeepSeek token/cost accounting parity across synchronous
+  and asynchronous queries, including thinking-token decomposition and safe
+  zero-cost fallback for models missing from the pricing catalog. Runtime
+  models.dev refreshes now preserve pinned embedding-price overrides.
 - Fixed diff insertions (empty SEARCH blocks) splicing the payload directly
   against the EVOLVE-BLOCK-END marker, which corrupted the marker line, let
   consecutive insertions merge code lines into invalid programs, and caused

--- a/shinka/llm/providers/anthropic.py
+++ b/shinka/llm/providers/anthropic.py
@@ -1,7 +1,7 @@
 import backoff
 import anthropic
 from shinka.llm.constants import BACKOFF_MAX_TIME, BACKOFF_MAX_TRIES, BACKOFF_MAX_VALUE
-from .pricing import calculate_cost
+from .pricing import calculate_cost, model_exists
 from .result import QueryResult
 import logging
 
@@ -20,7 +20,16 @@ def get_anthropic_costs(response, model):
     all_out_tokens = response.usage.output_tokens
     # Unclear how to get thinking tokens from Anthropic
     thinking_tokens = 0
-    input_cost, output_cost = calculate_cost(model, input_tokens, all_out_tokens)
+    # Fall back to a zero cost (with a warning) on an unknown model instead of
+    # raising, mirroring openai/local so a pricing-catalog miss never aborts a
+    # completed generation.
+    if model_exists(model):
+        input_cost, output_cost = calculate_cost(model, input_tokens, all_out_tokens)
+    else:
+        logger.warning(
+            "Model '%s' has no pricing entry; defaulting query cost to 0.", model
+        )
+        input_cost, output_cost = 0.0, 0.0
     return {
         "input_tokens": input_tokens,
         "output_tokens": all_out_tokens,
@@ -179,9 +188,7 @@ async def query_anthropic_async(
             ],
         }
     )
-    input_cost, output_cost = calculate_cost(
-        model, response.usage.input_tokens, response.usage.output_tokens
-    )
+    cost_results = get_anthropic_costs(response, model)
     result = QueryResult(
         content=content,
         msg=msg,
@@ -189,11 +196,7 @@ async def query_anthropic_async(
         new_msg_history=new_msg_history,
         model_name=model,
         kwargs=kwargs,
-        input_tokens=response.usage.input_tokens,
-        output_tokens=response.usage.output_tokens,
-        cost=input_cost + output_cost,
-        input_cost=input_cost,
-        output_cost=output_cost,
+        **cost_results,
         thought=thought,
         model_posteriors=model_posteriors,
     )

--- a/shinka/llm/providers/anthropic.py
+++ b/shinka/llm/providers/anthropic.py
@@ -14,12 +14,13 @@ MAX_TIME = BACKOFF_MAX_TIME
 
 
 def get_anthropic_costs(response, model):
-    """Get the costs for the given response and model."""
-    # Get token counts and costs
+    """Return billed costs with thinking separated from visible output."""
     input_tokens = response.usage.input_tokens
     all_out_tokens = response.usage.output_tokens
-    # Unclear how to get thinking tokens from Anthropic
-    thinking_tokens = 0
+    output_details = getattr(response.usage, "output_tokens_details", None)
+    reported_thinking = getattr(output_details, "thinking_tokens", 0) or 0
+    thinking_tokens = min(max(int(reported_thinking), 0), all_out_tokens)
+    output_tokens = all_out_tokens - thinking_tokens
     # Fall back to a zero cost (with a warning) on an unknown model instead of
     # raising, mirroring openai/local so a pricing-catalog miss never aborts a
     # completed generation.
@@ -32,7 +33,7 @@ def get_anthropic_costs(response, model):
         input_cost, output_cost = 0.0, 0.0
     return {
         "input_tokens": input_tokens,
-        "output_tokens": all_out_tokens,
+        "output_tokens": output_tokens,
         "thinking_tokens": thinking_tokens,
         "input_cost": input_cost,
         "output_cost": output_cost,

--- a/shinka/llm/providers/deepseek.py
+++ b/shinka/llm/providers/deepseek.py
@@ -33,10 +33,8 @@ def get_deepseek_costs(response, model):
     """
     in_tokens = response.usage.prompt_tokens
     all_out_tokens = response.usage.completion_tokens
-    try:
-        thinking_tokens = response.usage.completion_tokens_details.reasoning_tokens
-    except Exception:
-        thinking_tokens = 0
+    completion_details = getattr(response.usage, "completion_tokens_details", None)
+    thinking_tokens = getattr(completion_details, "reasoning_tokens", 0) or 0
     out_tokens = all_out_tokens - thinking_tokens
 
     if model_exists(model):

--- a/shinka/llm/providers/deepseek.py
+++ b/shinka/llm/providers/deepseek.py
@@ -1,7 +1,7 @@
 import backoff
 import openai
 from shinka.llm.constants import BACKOFF_MAX_TIME, BACKOFF_MAX_TRIES, BACKOFF_MAX_VALUE
-from .pricing import calculate_cost
+from .pricing import calculate_cost, model_exists
 from .result import QueryResult
 import logging
 
@@ -19,6 +19,42 @@ def backoff_handler(details):
         logger.info(
             f"DeepSeek - Retry {details['tries']} due to error: {exc}. Waiting {details['wait']:0.1f}s..."
         )
+
+
+def get_deepseek_costs(response, model):
+    """Token counts and costs for a DeepSeek response.
+
+    Reasoning ("thinking") tokens are billed within ``completion_tokens`` but
+    must be reported separately, so ``output_tokens`` excludes them. Cost is
+    still computed on the full completion count. An unknown model falls back to
+    a zero cost with a warning instead of raising, mirroring
+    ``openai.get_openai_costs`` / ``local_openai._extract_costs`` so a
+    pricing-catalog miss never aborts a completed generation.
+    """
+    in_tokens = response.usage.prompt_tokens
+    all_out_tokens = response.usage.completion_tokens
+    try:
+        thinking_tokens = response.usage.completion_tokens_details.reasoning_tokens
+    except Exception:
+        thinking_tokens = 0
+    out_tokens = all_out_tokens - thinking_tokens
+
+    if model_exists(model):
+        input_cost, output_cost = calculate_cost(model, in_tokens, all_out_tokens)
+    else:
+        logger.warning(
+            "Model '%s' has no pricing entry; defaulting query cost to 0.", model
+        )
+        input_cost, output_cost = 0.0, 0.0
+
+    return {
+        "input_tokens": in_tokens,
+        "output_tokens": out_tokens,
+        "thinking_tokens": thinking_tokens,
+        "input_cost": input_cost,
+        "output_cost": output_cost,
+        "cost": input_cost + output_cost,
+    }
 
 
 @backoff.on_exception(
@@ -61,19 +97,12 @@ def query_deepseek(
     content = response.choices[0].message.content
     try:
         thought = response.choices[0].message.reasoning_content
-    except:
+    except Exception:
         thought = ""
     new_msg_history.append({"role": "assistant", "content": content})
 
     # Get token counts and costs
-    in_tokens = response.usage.prompt_tokens
-    all_out_tokens = response.usage.completion_tokens
-    try:
-        thinking_tokens = response.usage.completion_tokens_details.reasoning_tokens
-    except Exception:
-        thinking_tokens = 0
-    out_tokens = all_out_tokens - thinking_tokens
-    input_cost, output_cost = calculate_cost(model, in_tokens, all_out_tokens)
+    cost_results = get_deepseek_costs(response, model)
 
     # Collect all results
     result = QueryResult(
@@ -83,12 +112,7 @@ def query_deepseek(
         new_msg_history=new_msg_history,
         model_name=model,
         kwargs=kwargs,
-        input_tokens=in_tokens,
-        output_tokens=out_tokens,
-        thinking_tokens=thinking_tokens,
-        cost=input_cost + output_cost,
-        input_cost=input_cost,
-        output_cost=output_cost,
+        **cost_results,
         thought=thought,
         model_posteriors=model_posteriors,
     )
@@ -135,12 +159,14 @@ async def query_deepseek_async(
     content = response.choices[0].message.content
     try:
         thought = response.choices[0].message.reasoning_content
-    except:
+    except Exception:
         thought = ""
     new_msg_history.append({"role": "assistant", "content": content})
-    input_cost, output_cost = calculate_cost(
-        model, response.usage.prompt_tokens, response.usage.completion_tokens
-    )
+
+    # Get token counts and costs (parity with the sync path: reasoning tokens
+    # are subtracted from output and reported via thinking_tokens).
+    cost_results = get_deepseek_costs(response, model)
+
     return QueryResult(
         content=content,
         msg=msg,
@@ -148,11 +174,7 @@ async def query_deepseek_async(
         new_msg_history=new_msg_history,
         model_name=model,
         kwargs=kwargs,
-        input_tokens=response.usage.prompt_tokens,
-        output_tokens=response.usage.completion_tokens,
-        cost=input_cost + output_cost,
-        input_cost=input_cost,
-        output_cost=output_cost,
+        **cost_results,
         thought=thought,
         model_posteriors=model_posteriors,
     )

--- a/shinka/llm/providers/deepseek.py
+++ b/shinka/llm/providers/deepseek.py
@@ -34,7 +34,8 @@ def get_deepseek_costs(response, model):
     in_tokens = response.usage.prompt_tokens
     all_out_tokens = response.usage.completion_tokens
     completion_details = getattr(response.usage, "completion_tokens_details", None)
-    thinking_tokens = getattr(completion_details, "reasoning_tokens", 0) or 0
+    reported_thinking = getattr(completion_details, "reasoning_tokens", 0) or 0
+    thinking_tokens = min(max(int(reported_thinking), 0), all_out_tokens)
     out_tokens = all_out_tokens - thinking_tokens
 
     if model_exists(model):

--- a/shinka/pricing/normalization.py
+++ b/shinka/pricing/normalization.py
@@ -114,6 +114,7 @@ def _apply_overlay(
     overlay = _read_overlay(overlay_path)
     _add_model_aliases(entries, overlay.get("model_aliases", []))
     _apply_llm_overrides(entries, overlay.get("llm_overrides", []))
+    _apply_embedding_overrides(entries, overlay.get("embedding_overrides", []))
 
 
 def _read_overlay(path: Path) -> dict[str, Any]:
@@ -190,6 +191,33 @@ def _apply_llm_overrides(
         if threshold is not None:
             values["tier_threshold"] = threshold
         entries[key] = ModelPrice(**values)
+
+
+def _apply_embedding_overrides(
+    entries: dict[tuple[ModelKind, str, str], ModelPrice], overrides: Any
+) -> None:
+    """Apply pinned embedding prices at runtime, matching the CSV build.
+
+    Without this, embedding_overrides were applied only when regenerating the
+    bundled CSVs, so a live models.dev refresh silently dropped pinned prices
+    (e.g. gemini-embedding-exp-03-07 -> 0.0) back to the upstream values.
+    """
+    if not isinstance(overrides, list):
+        return
+    for override in overrides:
+        if not isinstance(override, dict):
+            continue
+        provider = override.get("provider")
+        model_name = override.get("model_name")
+        if not isinstance(provider, str) or not isinstance(model_name, str):
+            continue
+        entry = entries.get(("embedding", provider, model_name))
+        if entry is None:
+            continue
+        values = asdict(entry)
+        for field in ("input_price", "output_price"):
+            _apply_price_override(values, override, field)
+        entries[("embedding", provider, model_name)] = ModelPrice(**values)
 
 
 def _apply_price_override(

--- a/shinka/pricing/normalization.py
+++ b/shinka/pricing/normalization.py
@@ -215,8 +215,7 @@ def _apply_embedding_overrides(
         if entry is None:
             continue
         values = asdict(entry)
-        for field in ("input_price", "output_price"):
-            _apply_price_override(values, override, field)
+        _apply_price_override(values, override, "input_price")
         entries[("embedding", provider, model_name)] = ModelPrice(**values)
 
 

--- a/tests/test_anthropic_accounting.py
+++ b/tests/test_anthropic_accounting.py
@@ -1,0 +1,22 @@
+"""Regression tests for Anthropic pricing fallback parity."""
+
+from types import SimpleNamespace
+
+from shinka.llm.providers.anthropic import get_anthropic_costs
+
+
+def test_unknown_model_preserves_tokens_and_defaults_cost_to_zero():
+    response = SimpleNamespace(
+        usage=SimpleNamespace(input_tokens=10, output_tokens=20)
+    )
+
+    costs = get_anthropic_costs(response, "anthropic/not-in-catalog")
+
+    assert costs == {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "thinking_tokens": 0,
+        "input_cost": 0.0,
+        "output_cost": 0.0,
+        "cost": 0.0,
+    }

--- a/tests/test_anthropic_accounting.py
+++ b/tests/test_anthropic_accounting.py
@@ -1,16 +1,50 @@
 """Regression tests for Anthropic pricing fallback parity."""
 
+import asyncio
 from types import SimpleNamespace
 
-from shinka.llm.providers.anthropic import get_anthropic_costs
+import shinka.llm.providers.anthropic as anthropic_provider
+from shinka.llm.providers.anthropic import (
+    get_anthropic_costs,
+    query_anthropic,
+    query_anthropic_async,
+)
+
+
+def _response(
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+    thinking_tokens: int | None = None,
+):
+    details = (
+        None
+        if thinking_tokens is None
+        else SimpleNamespace(thinking_tokens=thinking_tokens)
+    )
+    return SimpleNamespace(
+        content=[SimpleNamespace(text="ok")],
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            output_tokens_details=details,
+        ),
+    )
+
+
+class _Client:
+    def __init__(self, response, *, asynchronous: bool = False):
+        async def create_async(**_kwargs):
+            return response
+
+        def create_sync(**_kwargs):
+            return response
+
+        create = create_async if asynchronous else create_sync
+        self.messages = SimpleNamespace(create=create)
 
 
 def test_unknown_model_preserves_tokens_and_defaults_cost_to_zero():
-    response = SimpleNamespace(
-        usage=SimpleNamespace(input_tokens=10, output_tokens=20)
-    )
-
-    costs = get_anthropic_costs(response, "anthropic/not-in-catalog")
+    costs = get_anthropic_costs(_response(), "anthropic/not-in-catalog")
 
     assert costs == {
         "input_tokens": 10,
@@ -20,3 +54,56 @@ def test_unknown_model_preserves_tokens_and_defaults_cost_to_zero():
         "output_cost": 0.0,
         "cost": 0.0,
     }
+
+
+def test_thinking_tokens_are_separated_but_billed_as_output(monkeypatch):
+    billed_usage = []
+
+    def calculate_cost(model, input_tokens, output_tokens):
+        billed_usage.append((model, input_tokens, output_tokens))
+        return 1.0, 2.0
+
+    monkeypatch.setattr(anthropic_provider, "model_exists", lambda _model: True)
+    monkeypatch.setattr(anthropic_provider, "calculate_cost", calculate_cost)
+
+    costs = get_anthropic_costs(_response(thinking_tokens=7), "claude-test")
+
+    assert costs == {
+        "input_tokens": 10,
+        "output_tokens": 13,
+        "thinking_tokens": 7,
+        "input_cost": 1.0,
+        "output_cost": 2.0,
+        "cost": 3.0,
+    }
+    assert billed_usage == [("claude-test", 10, 20)]
+
+
+def test_thinking_tokens_are_bounded_by_billed_output():
+    costs = get_anthropic_costs(
+        _response(output_tokens=20, thinking_tokens=25),
+        "anthropic/not-in-catalog",
+    )
+
+    assert costs["output_tokens"] == 0
+    assert costs["thinking_tokens"] == 20
+
+
+def test_sync_and_async_share_thinking_accounting():
+    response = _response(thinking_tokens=7)
+    sync_result = query_anthropic(
+        _Client(response), "anthropic/not-in-catalog", "msg", "sys", [], None
+    )
+    async_result = asyncio.run(
+        query_anthropic_async(
+            _Client(response, asynchronous=True),
+            "anthropic/not-in-catalog",
+            "msg",
+            "sys",
+            [],
+            None,
+        )
+    )
+
+    assert sync_result.output_tokens == async_result.output_tokens == 13
+    assert sync_result.thinking_tokens == async_result.thinking_tokens == 7

--- a/tests/test_deepseek_accounting.py
+++ b/tests/test_deepseek_accounting.py
@@ -1,0 +1,66 @@
+"""Regression tests for DeepSeek sync/async token and cost accounting."""
+
+import asyncio
+from types import SimpleNamespace
+
+from shinka.llm.providers.deepseek import (
+    get_deepseek_costs,
+    query_deepseek,
+    query_deepseek_async,
+)
+
+
+def _response(prompt_tokens=10, completion_tokens=30, reasoning_tokens=12):
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+    message = SimpleNamespace(content="ok", reasoning_content="thinking")
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=usage)
+
+
+class _Client:
+    def __init__(self, response, *, asynchronous=False):
+        async def create_async(**kwargs):
+            return response
+
+        def create_sync(**kwargs):
+            return response
+
+        create = create_async if asynchronous else create_sync
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=create))
+
+
+def test_sync_and_async_exclude_reasoning_from_output_tokens():
+    response = _response()
+    sync_result = query_deepseek(
+        _Client(response), "deepseek/not-in-catalog", "msg", "sys", [], None
+    )
+    async_result = asyncio.run(
+        query_deepseek_async(
+            _Client(response, asynchronous=True),
+            "deepseek/not-in-catalog",
+            "msg",
+            "sys",
+            [],
+            None,
+        )
+    )
+
+    assert sync_result.output_tokens == async_result.output_tokens == 18
+    assert sync_result.thinking_tokens == async_result.thinking_tokens == 12
+    assert sync_result.input_tokens == async_result.input_tokens == 10
+
+
+def test_unknown_model_preserves_tokens_and_defaults_cost_to_zero():
+    costs = get_deepseek_costs(_response(5, 15, 5), "deepseek/not-in-catalog")
+
+    assert costs == {
+        "input_tokens": 5,
+        "output_tokens": 10,
+        "thinking_tokens": 5,
+        "input_cost": 0.0,
+        "output_cost": 0.0,
+        "cost": 0.0,
+    }

--- a/tests/test_deepseek_accounting.py
+++ b/tests/test_deepseek_accounting.py
@@ -64,3 +64,24 @@ def test_unknown_model_preserves_tokens_and_defaults_cost_to_zero():
         "output_cost": 0.0,
         "cost": 0.0,
     }
+
+
+def test_sync_and_async_treat_missing_reasoning_count_as_zero():
+    response = _response(reasoning_tokens=None)
+
+    sync_result = query_deepseek(
+        _Client(response), "deepseek/not-in-catalog", "msg", "sys", [], None
+    )
+    async_result = asyncio.run(
+        query_deepseek_async(
+            _Client(response, asynchronous=True),
+            "deepseek/not-in-catalog",
+            "msg",
+            "sys",
+            [],
+            None,
+        )
+    )
+
+    assert sync_result.output_tokens == async_result.output_tokens == 30
+    assert sync_result.thinking_tokens == async_result.thinking_tokens == 0

--- a/tests/test_deepseek_accounting.py
+++ b/tests/test_deepseek_accounting.py
@@ -3,6 +3,7 @@
 import asyncio
 from types import SimpleNamespace
 
+import shinka.llm.providers.deepseek as deepseek_provider
 from shinka.llm.providers.deepseek import (
     get_deepseek_costs,
     query_deepseek,
@@ -66,6 +67,29 @@ def test_unknown_model_preserves_tokens_and_defaults_cost_to_zero():
     }
 
 
+def test_reasoning_tokens_are_separated_but_billed_as_output(monkeypatch):
+    billed_usage = []
+
+    def calculate_cost(model, input_tokens, output_tokens):
+        billed_usage.append((model, input_tokens, output_tokens))
+        return 1.0, 2.0
+
+    monkeypatch.setattr(deepseek_provider, "model_exists", lambda _model: True)
+    monkeypatch.setattr(deepseek_provider, "calculate_cost", calculate_cost)
+
+    costs = get_deepseek_costs(_response(10, 30, 12), "deepseek-test")
+
+    assert costs == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "thinking_tokens": 12,
+        "input_cost": 1.0,
+        "output_cost": 2.0,
+        "cost": 3.0,
+    }
+    assert billed_usage == [("deepseek-test", 10, 30)]
+
+
 def test_sync_and_async_treat_missing_reasoning_count_as_zero():
     response = _response(reasoning_tokens=None)
 
@@ -85,3 +109,13 @@ def test_sync_and_async_treat_missing_reasoning_count_as_zero():
 
     assert sync_result.output_tokens == async_result.output_tokens == 30
     assert sync_result.thinking_tokens == async_result.thinking_tokens == 0
+
+
+def test_reasoning_tokens_are_bounded_by_billed_output():
+    costs = get_deepseek_costs(
+        _response(completion_tokens=15, reasoning_tokens=20),
+        "deepseek/not-in-catalog",
+    )
+
+    assert costs["output_tokens"] == 0
+    assert costs["thinking_tokens"] == 15

--- a/tests/test_models_dev_live.py
+++ b/tests/test_models_dev_live.py
@@ -28,3 +28,11 @@ def test_live_models_dev_catalog_prices_representative_models(tmp_path: Path) ->
 
     embedding = snapshot.catalog.get_by_name("text-embedding-3-small", kind="embedding")
     assert embedding.input_price > 0
+
+    pinned_embedding_prices = {
+        "gemini-embedding-exp-03-07": 0.0,
+        "gemini-embedding-2-preview": 0.2 / 1_000_000,
+    }
+    for model_name, expected_price in pinned_embedding_prices.items():
+        embedding = snapshot.catalog.get_by_name(model_name, kind="embedding")
+        assert embedding.input_price == pytest.approx(expected_price)

--- a/tests/test_pricing_runtime_overlay.py
+++ b/tests/test_pricing_runtime_overlay.py
@@ -1,0 +1,46 @@
+"""Regression tests for runtime embedding-price overlays."""
+
+from shinka.pricing.catalog import ModelPrice
+from shinka.pricing.normalization import MILLION, _apply_embedding_overrides
+
+
+def _embedding_price(input_price: float) -> ModelPrice:
+    return ModelPrice(
+        model_name="gemini-embedding-exp-03-07",
+        api_model_name="gemini-embedding-exp-03-07",
+        provider="google",
+        kind="embedding",
+        input_price=input_price,
+        output_price=0.0,
+    )
+
+
+def test_embedding_overrides_replace_runtime_discovery_price():
+    key = ("embedding", "google", "gemini-embedding-exp-03-07")
+    entries = {key: _embedding_price(input_price=1.5 / MILLION)}
+
+    _apply_embedding_overrides(
+        entries,
+        [
+            {
+                "provider": "google",
+                "model_name": "gemini-embedding-exp-03-07",
+                "input_price": 0.0,
+            }
+        ],
+    )
+
+    assert entries[key].input_price == 0.0
+
+
+def test_embedding_overrides_ignore_unknown_and_malformed_entries():
+    key = ("embedding", "google", "gemini-embedding-exp-03-07")
+    entries = {key: _embedding_price(input_price=2.0 / MILLION)}
+    _apply_embedding_overrides(entries, "not-a-list")
+    _apply_embedding_overrides(entries, [{"provider": "google"}])
+    _apply_embedding_overrides(
+        entries,
+        [{"provider": "unknown", "model_name": "unknown", "input_price": 0.0}],
+    )
+
+    assert entries[key].input_price == 2.0 / MILLION

--- a/tests/test_pricing_runtime_overlay.py
+++ b/tests/test_pricing_runtime_overlay.py
@@ -1,46 +1,61 @@
 """Regression tests for runtime embedding-price overlays."""
 
-from shinka.pricing.catalog import ModelPrice
-from shinka.pricing.normalization import MILLION, _apply_embedding_overrides
+import json
+from pathlib import Path
+
+from shinka.pricing.catalog import catalog_from_models_dev_payload
 
 
-def _embedding_price(input_price: float) -> ModelPrice:
-    return ModelPrice(
-        model_name="gemini-embedding-exp-03-07",
-        api_model_name="gemini-embedding-exp-03-07",
-        provider="google",
-        kind="embedding",
-        input_price=input_price,
-        output_price=0.0,
+MODEL_NAME = "gemini-embedding-exp-03-07"
+
+
+def _runtime_catalog(tmp_path: Path, overrides):
+    overlay_path = tmp_path / "overlay.json"
+    overlay_path.write_text(
+        json.dumps({"embedding_overrides": overrides}), encoding="utf-8"
+    )
+    payload = {
+        "google": {
+            "models": {
+                MODEL_NAME: {
+                    "family": "embedding",
+                    "cost": {"input": 1.5},
+                }
+            }
+        }
+    }
+    return catalog_from_models_dev_payload(
+        payload,
+        overlay_path=overlay_path,
+        include_bundled=False,
     )
 
 
-def test_embedding_overrides_replace_runtime_discovery_price():
-    key = ("embedding", "google", "gemini-embedding-exp-03-07")
-    entries = {key: _embedding_price(input_price=1.5 / MILLION)}
-
-    _apply_embedding_overrides(
-        entries,
+def test_embedding_overrides_replace_runtime_discovery_price(tmp_path: Path):
+    catalog = _runtime_catalog(
+        tmp_path,
         [
             {
                 "provider": "google",
-                "model_name": "gemini-embedding-exp-03-07",
+                "model_name": MODEL_NAME,
                 "input_price": 0.0,
+                "output_price": 999.0,
             }
         ],
     )
 
-    assert entries[key].input_price == 0.0
+    entry = catalog.get("google", MODEL_NAME, kind="embedding")
+    assert entry.input_price == 0.0
+    assert entry.output_price is None
 
 
-def test_embedding_overrides_ignore_unknown_and_malformed_entries():
-    key = ("embedding", "google", "gemini-embedding-exp-03-07")
-    entries = {key: _embedding_price(input_price=2.0 / MILLION)}
-    _apply_embedding_overrides(entries, "not-a-list")
-    _apply_embedding_overrides(entries, [{"provider": "google"}])
-    _apply_embedding_overrides(
-        entries,
-        [{"provider": "unknown", "model_name": "unknown", "input_price": 0.0}],
+def test_embedding_overrides_ignore_unknown_and_malformed_entries(tmp_path: Path):
+    catalog = _runtime_catalog(
+        tmp_path,
+        [
+            {"provider": "google"},
+            {"provider": "unknown", "model_name": "unknown", "input_price": 0.0},
+        ],
     )
 
-    assert entries[key].input_price == 2.0 / MILLION
+    assert catalog.get("google", MODEL_NAME, kind="embedding").input_price == 1.5e-6


### PR DESCRIPTION
## What changed

- Rebuild the provider-accounting extraction directly on current `main`.
- Align DeepSeek sync/async accounting, separating reasoning tokens from visible output while billing the full completion total.
- Align Anthropic sync/async accounting, including current-SDK thinking-token decomposition and zero-cost fallback for uncatalogued models.
- Preserve pinned embedding-price overrides during live models.dev catalog refreshes.
- Add regression coverage for accounting boundaries, sync/async parity, runtime overlays, and live catalog pins.

## Verification

- `uv run ruff check tests --exclude tests/file.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
- `uv run --with pytest-cov pytest -q -m "not requires_secrets and not models_dev_live" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml` — 873 passed, 7 skipped, 2 deselected
- Live models.dev contract test passed.
- DeepSeek live sync/async queries passed with separated reasoning tokens and nonzero cost accounting.
- Anthropic via Bedrock passed with valid token/cost accounting. Direct Anthropic validation was blocked by insufficient account credits.
- Circle Packing baseline/branch smoke runs completed; both databases passed SQLite integrity checks and matched on program counts and best correct score.
- Playwright dashboard/detail smoke passed; only the pre-existing Plotly CDN warning appeared.

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.
