### PR TITLE
fix(core): reconcile async behavior

### DIFF
--- a/shinka/core/async_novelty_judge.py
+++ b/shinka/core/async_novelty_judge.py
@@ -214,6 +214,7 @@ class AsyncNoveltyJudge:
             response = await self.async_llm_client.query(
                 msg=user_msg,
                 system_msg=NOVELTY_SYSTEM_MSG,
+                llm_kwargs=self.async_llm_client.get_kwargs(),
             )
 
             if response is None or response.content is None:
@@ -289,4 +290,3 @@ class AsyncNoveltyJudge:
     def __getattr__(self, name):
         """Delegate unknown methods to sync novelty judge."""
         return getattr(self.sync_judge, name)
-

--- a/shinka/core/async_novelty_judge.py
+++ b/shinka/core/async_novelty_judge.py
@@ -239,40 +239,6 @@ class AsyncNoveltyJudge:
             logger.error(f"Error in novelty LLM check: {e}")
             return True, f"Error in novelty check: {e}", 0.0
 
-    async def _single_novelty_check_async(
-        self, code_content: str, similar_program: Program, parent_program: Program
-    ) -> Tuple[bool, float, str]:
-        """Perform a single async novelty check against a similar program.
-
-        Returns:
-            Tuple of (is_novel, cost, explanation)
-        """
-        try:
-            # Construct novelty prompt
-            novelty_prompt = self._construct_novelty_prompt(
-                code_content, similar_program, parent_program
-            )
-
-            # Query LLM asynchronously
-            response = await self.async_llm_client.query(
-                msg=novelty_prompt,
-                system_msg="You are a code novelty assessor. Determine if the new code is sufficiently different from the existing code.",
-            )
-
-            if not response or not response.content:
-                # Fail CLOSED on empty response (is_novel=False => reject).
-                return False, 0.0, "No response from LLM (failing closed)"
-
-            # Parse response for novelty decision
-            is_novel = self._parse_novelty_response(response.content)
-            cost = response.cost if hasattr(response, "cost") else 0.0
-
-            return is_novel, cost, response.content[:200]  # Truncate explanation
-
-        except Exception as e:
-            logger.warning(f"Single novelty check failed: {e}")
-            return True, 0.0, f"Error: {str(e)}"
-
     def _read_code_file(self, exec_fname: str) -> Optional[str]:
         """Read code file content."""
         try:

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -3622,8 +3622,10 @@ class ShinkaEvolveRunner:
             meta_patch_data = {
                 "api_costs": total_costs,
                 "patch_type": patch_type,
-                "patch_name": patch_name,
-                "patch_description": patch_description,
+                "patch_name": patch_name if "patch_name" in locals() else None,
+                "patch_description": patch_description
+                if "patch_description" in locals()
+                else None,
                 "num_applied": 0,
                 "error_attempt": "Max fix attempts reached without success.",
                 "last_error_msg": error_str if "error_str" in locals() else None,
@@ -3631,7 +3633,9 @@ class ShinkaEvolveRunner:
                 "resample_attempt": resample_attempt,
                 "patch_attempt": self.evo_config.max_patch_attempts,
                 **llm_kwargs,  # Spread llm_kwargs like _run_patch_async
-                "llm_result": response.to_dict() if response else None,
+                "llm_result": response.to_dict()
+                if "response" in locals() and response
+                else None,
             }
 
             return None, meta_patch_data, False

--- a/shinka/core/async_summarizer.py
+++ b/shinka/core/async_summarizer.py
@@ -249,6 +249,7 @@ class AsyncMetaSummarizer:
         response = await self.async_llm_client.query(
             msg=user_msg,
             system_msg=META_STEP2_SYSTEM_MSG,
+            llm_kwargs=self.async_llm_client.get_kwargs(),
         )
 
         if response is None:
@@ -290,6 +291,7 @@ class AsyncMetaSummarizer:
         response = await self.async_llm_client.query(
             msg=user_msg,
             system_msg=META_STEP3_SYSTEM_MSG,
+            llm_kwargs=self.async_llm_client.get_kwargs(),
         )
 
         if response is None:

--- a/shinka/core/prompt_evolver.py
+++ b/shinka/core/prompt_evolver.py
@@ -591,12 +591,10 @@ class AsyncSystemPromptEvolver:
         )
 
         try:
-            # Pass None if llm_kwargs is empty to let client sample params
-            kwargs = self.llm_kwargs if self.llm_kwargs else None
             response = await self.llm_client.query(
                 msg=user_msg,
                 system_msg=system_msg,
-                llm_kwargs=kwargs,
+                llm_kwargs=self.llm_kwargs,
             )
 
             if response is None or not response.content:
@@ -638,12 +636,10 @@ class AsyncSystemPromptEvolver:
         )
 
         try:
-            # Pass None if llm_kwargs is empty to let client sample params
-            kwargs = self.llm_kwargs if self.llm_kwargs else None
             response = await self.llm_client.query(
                 msg=user_msg,
                 system_msg=system_msg,
-                llm_kwargs=kwargs,
+                llm_kwargs=self.llm_kwargs,
             )
 
             if response is None or not response.content:

--- a/shinka/core/prompt_evolver.py
+++ b/shinka/core/prompt_evolver.py
@@ -192,13 +192,14 @@ class SystemPromptEvolver:
         """
         self.llm_client = llm_client
 
-        for p in patch_types:
-            if p not in ["diff", "full"]:
-                raise ValueError(f"Invalid patch type: {p}")
         if patch_types is None:
             patch_types = ["diff", "full"]
         if patch_type_probs is None:
             patch_type_probs = [0.7, 0.3]
+
+        for p in patch_types:
+            if p not in ["diff", "full"]:
+                raise ValueError(f"Invalid patch type: {p}")
 
         # Normalize probabilities
         prob_sum = sum(patch_type_probs)
@@ -462,6 +463,10 @@ class AsyncSystemPromptEvolver:
             patch_types = ["diff", "full"]
         if patch_type_probs is None:
             patch_type_probs = [0.7, 0.3]
+
+        for p in patch_types:
+            if p not in ["diff", "full"]:
+                raise ValueError(f"Invalid patch type: {p}")
 
         # Normalize probabilities
         prob_sum = sum(patch_type_probs)

--- a/tests/test_async_novelty_parity.py
+++ b/tests/test_async_novelty_parity.py
@@ -1,0 +1,53 @@
+"""Regression tests for async novelty-judge parity and dead-code removal."""
+
+import asyncio
+from dataclasses import dataclass
+
+from shinka.core.async_novelty_judge import AsyncNoveltyJudge
+from shinka.core.novelty_judge import NoveltyJudge
+from shinka.database import Program
+
+
+SENTINEL_KWARGS = {"model_name": "sentinel-model", "temperature": 0.123}
+
+
+@dataclass
+class _Response:
+    content: str
+    cost: float = 0.1
+
+
+class _RecordingAsyncLLM:
+    def __init__(self):
+        self.kwargs_log = []
+
+    def get_kwargs(self):
+        return dict(SENTINEL_KWARGS)
+
+    async def query(self, msg, system_msg, llm_kwargs=None):
+        self.kwargs_log.append(llm_kwargs)
+        return _Response("NOVEL - meaningfully different implementation.")
+
+
+def test_llm_novelty_forwards_sampled_llm_kwargs():
+    llm = _RecordingAsyncLLM()
+    judge = AsyncNoveltyJudge(NoveltyJudge(language="python"), async_llm_client=llm)
+    similar = Program(
+        id="similar-1",
+        code="def existing():\n    return 1\n",
+        language="python",
+        generation=1,
+    )
+
+    is_novel, _explanation, _cost = asyncio.run(
+        judge._check_llm_novelty_async("def proposed():\n    return 2\n", similar)
+    )
+
+    assert is_novel is True
+    assert llm.kwargs_log == [SENTINEL_KWARGS]
+
+
+def test_dead_single_novelty_check_is_removed():
+    assert "_single_novelty_check_async" not in vars(AsyncNoveltyJudge)
+    assert not hasattr(AsyncNoveltyJudge, "_construct_novelty_prompt")
+    assert not hasattr(AsyncNoveltyJudge, "_parse_novelty_response")

--- a/tests/test_async_prompt_evolver_parity.py
+++ b/tests/test_async_prompt_evolver_parity.py
@@ -1,0 +1,57 @@
+"""Regression tests for prompt-evolver defaults and async LLM kwargs."""
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from shinka.core.prompt_evolver import AsyncSystemPromptEvolver
+from shinka.database.prompt_dbase import create_system_prompt
+
+
+SENTINEL_KWARGS = {"model_name": "sentinel-model", "temperature": 0.123}
+
+
+@dataclass
+class _Response:
+    content: str
+    cost: float = 0.1
+
+
+class _RecordingAsyncLLM:
+    def __init__(self):
+        self.kwargs_log = []
+
+    async def query(self, msg, system_msg, llm_kwargs=None):
+        self.kwargs_log.append(llm_kwargs)
+        return _Response(
+            "<PROMPT>You are a rigorous engineer who writes precise code.</PROMPT>"
+        )
+
+
+def _parent_prompt():
+    return create_system_prompt(
+        prompt_text="You are an expert programmer.",
+        generation=0,
+        patch_type="init",
+    )
+
+
+@pytest.mark.parametrize("method_name", ["_diff_mutate_async", "_full_rewrite_async"])
+def test_async_mutation_forwards_configured_llm_kwargs(method_name):
+    llm = _RecordingAsyncLLM()
+    evolver = AsyncSystemPromptEvolver(llm, llm_kwargs=dict(SENTINEL_KWARGS))
+
+    asyncio.run(getattr(evolver, method_name)(_parent_prompt(), top_programs=[]))
+
+    assert llm.kwargs_log == [SENTINEL_KWARGS]
+
+
+@pytest.mark.parametrize("method_name", ["_diff_mutate_async", "_full_rewrite_async"])
+def test_async_mutation_forwards_empty_kwargs_as_mapping(method_name):
+    llm = _RecordingAsyncLLM()
+    evolver = AsyncSystemPromptEvolver(llm)
+
+    asyncio.run(getattr(evolver, method_name)(_parent_prompt(), top_programs=[]))
+
+    assert llm.kwargs_log == [{}]

--- a/tests/test_async_runner_fix_recovery.py
+++ b/tests/test_async_runner_fix_recovery.py
@@ -1,0 +1,58 @@
+"""Regression tests for async fix-patch terminal recovery."""
+
+import asyncio
+from types import SimpleNamespace
+
+from shinka.core.async_runner import ShinkaEvolveRunner
+
+
+class _FirstNoneAsyncLLM:
+    def __init__(self):
+        self.query_calls = 0
+
+    def get_kwargs(self, model_sample_probs=None):
+        return {"model_name": "fix-model", "temperature": 0.5}
+
+    async def query(self, **kwargs):
+        self.query_calls += 1
+        return None
+
+
+def _runner(llm):
+    runner = object.__new__(ShinkaEvolveRunner)
+    runner.prompt_sampler = SimpleNamespace(
+        sample_fix=lambda **kwargs: ("fix system", "fix message", "full")
+    )
+    runner.verbose = False
+    runner.evo_config = SimpleNamespace(max_patch_attempts=1)
+    runner.llm = llm
+    runner.llm_selection = None
+
+    async def save_patch_attempt(**kwargs):
+        return None
+
+    runner._save_patch_attempt_async = save_patch_attempt
+    return runner
+
+
+def test_first_empty_response_returns_complete_failure_metadata():
+    llm = _FirstNoneAsyncLLM()
+
+    patch_text, metadata, success = asyncio.run(
+        _runner(llm)._run_fix_patch_async(
+            incorrect_program=SimpleNamespace(
+                id="ip-1", code="def broken():\n    missing_name\n"
+            ),
+            ancestor_inspirations=[],
+            generation=4,
+        )
+    )
+
+    assert llm.query_calls == 1
+    assert patch_text is None
+    assert success is False
+    assert metadata["error_attempt"] == "Max fix attempts reached without success."
+    assert metadata["patch_name"] is None
+    assert metadata["patch_description"] is None
+    assert metadata["llm_result"] is None
+    assert metadata["model_name"] == "fix-model"

--- a/tests/test_async_summarizer_parity.py
+++ b/tests/test_async_summarizer_parity.py
@@ -1,0 +1,57 @@
+"""Regression tests for async meta-summarizer LLM argument parity."""
+
+import asyncio
+from dataclasses import dataclass
+
+from shinka.core.async_summarizer import AsyncMetaSummarizer
+from shinka.core.summarizer import MetaSummarizer
+
+
+SENTINEL_KWARGS = {"model_name": "sentinel-model", "temperature": 0.123}
+
+
+@dataclass
+class _Response:
+    content: str
+    cost: float = 0.1
+
+
+class _RecordingAsyncLLM:
+    def __init__(self, content):
+        self.content = content
+        self.kwargs_log = []
+
+    def get_kwargs(self):
+        return dict(SENTINEL_KWARGS)
+
+    async def query(self, msg, system_msg, llm_kwargs=None):
+        self.kwargs_log.append(llm_kwargs)
+        return _Response(self.content)
+
+
+def _summarizer(content):
+    sync = MetaSummarizer(meta_llm_client=None, max_recommendations=3)
+    llm = _RecordingAsyncLLM(content)
+    return AsyncMetaSummarizer(sync, async_llm_client=llm), llm
+
+
+def test_step2_forwards_sampled_llm_kwargs():
+    summarizer, llm = _summarizer("Global insight block")
+
+    result, _cost = asyncio.run(
+        summarizer._step2_global_insights_async("individual summaries")
+    )
+
+    assert result == "Global insight block"
+    assert llm.kwargs_log == [SENTINEL_KWARGS]
+
+
+def test_step3_forwards_sampled_llm_kwargs():
+    summarizer, llm = _summarizer("1. Recommendation A")
+
+    result, _cost = asyncio.run(
+        summarizer._step3_generate_recommendations_async("global insights")
+    )
+
+    assert result == "1. Recommendation A"
+    assert llm.kwargs_log == [SENTINEL_KWARGS]

--- a/tests/test_prompt_evolver_defaults.py
+++ b/tests/test_prompt_evolver_defaults.py
@@ -1,0 +1,19 @@
+"""Regression tests for prompt-evolver constructor defaults."""
+
+import pytest
+
+from shinka.core.prompt_evolver import AsyncSystemPromptEvolver, SystemPromptEvolver
+
+
+@pytest.mark.parametrize("evolver_class", [SystemPromptEvolver, AsyncSystemPromptEvolver])
+def test_constructor_accepts_default_patch_types(evolver_class):
+    evolver = evolver_class(llm_client=object())
+
+    assert evolver.patch_types == ["diff", "full"]
+    assert sum(evolver.patch_type_probs) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("evolver_class", [SystemPromptEvolver, AsyncSystemPromptEvolver])
+def test_constructor_rejects_invalid_patch_types(evolver_class):
+    with pytest.raises(ValueError, match="Invalid patch type"):
+        evolver_class(llm_client=object(), patch_types=["bogus"])

--- a/tests/test_provider_correctness.py
+++ b/tests/test_provider_correctness.py
@@ -244,7 +244,10 @@ class _AsyncNoveltyLLM:
     def __init__(self, response):
         self._response = response
 
-    async def query(self, msg, system_msg):
+    def get_kwargs(self):
+        return {}
+
+    async def query(self, msg, system_msg, llm_kwargs=None):
         return self._response
 
 


### PR DESCRIPTION
## What changed
- Align async core behavior with sync contracts.
- Preserve kwargs, recovery, summarization, and evaluation semantics.
- Add one-concept parity regressions.

## Review scope
Core async-parity extraction from #153. Based directly on #150.

## Verification
- 13 focused core tests
- Ruff and focused Mypy
- Integrated 876-test gate

Original changes co-authored by Claude Fable 5 <noreply@anthropic.com>.