### PR TITLE
fix(database): cluster program embeddings in the PCA space the plots use

### DIFF
--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -2778,7 +2778,7 @@ class ProgramDatabase:
                 embeddings, method="pca", dims=3
             )
             cluster_ids = embedding_client.get_embedding_clusters(
-                embeddings, num_clusters=num_clusters
+                reduced_3d, num_clusters=num_clusters
             )
         except Exception as e:
             logger.error(f"Failed to recompute embedding features: {e}")
@@ -2874,7 +2874,7 @@ class ProgramDatabase:
 
                 logger.info(f"Computing GMM clustering with {num_clusters} clusters...")
                 cluster_ids = embedding_client.get_embedding_clusters(
-                    embeddings, num_clusters=num_clusters
+                    reduced_3d, num_clusters=num_clusters
                 )
                 logger.info("GMM clustering completed")
             except Exception as e:

--- a/tests/test_embedding_cluster_space.py
+++ b/tests/test_embedding_cluster_space.py
@@ -1,0 +1,125 @@
+"""The embedding cluster fit must run in the PCA-reduced space.
+
+`get_embedding_clusters` documents itself as clustering "the PCA-reduced
+embeddings", and the cluster ids it produces are only ever consumed as the
+marker colour of the web UI's PCA scatter plots. Fitting the mixture on the raw
+1536-d embedding array instead colours those plots from a different space, and
+the full-covariance fit is degenerate at that dimensionality. These tests pin
+the input that reaches the mixture.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def _program(program_id: str, embedding, island_idx: int = 0) -> Program:
+    return Program(
+        id=program_id,
+        code=f"def f():\n    return {program_id!r}\n",
+        correct=True,
+        combined_score=1.0,
+        generation=0,
+        island_idx=island_idx,
+        embedding=embedding,
+    )
+
+
+class _RecordingEmbeddingClient:
+    """Stands in for EmbeddingClient, recording what each stage is handed."""
+
+    def __init__(self):
+        self.cluster_inputs = []
+        self.reduction_dims = []
+
+    def get_dim_reduction(self, embeddings, method="pca", dims=2):
+        self.reduction_dims.append(dims)
+        X = np.asarray(embeddings, dtype=float)
+        # A deterministic stand-in for PCA: keep the leading `dims` columns.
+        return X[:, :dims]
+
+    def get_embedding_clusters(self, embeddings, num_clusters=4, verbose=False):
+        arr = np.asarray(embeddings, dtype=float)
+        self.cluster_inputs.append(arr)
+        return np.arange(len(arr)) % num_clusters
+
+
+def _seeded_db(tmpdir, n_programs=8, dim=32):
+    rng = np.random.default_rng(0)
+    db = ProgramDatabase(
+        config=DatabaseConfig(db_path=str(Path(tmpdir) / "test.db"), num_islands=1),
+        embedding_model="",
+    )
+    for i in range(n_programs):
+        vec = rng.normal(size=dim).tolist()
+        db.add(_program(f"p{i}", vec), defer_maintenance=True)
+    return db
+
+
+def _assert_clustered_in_reduced_space(client, dim):
+    assert client.cluster_inputs, "the mixture was never fitted"
+    fitted = client.cluster_inputs[-1]
+    assert fitted.ndim == 2
+    assert fitted.shape[1] == 3, (
+        "the cluster fit must receive the 3-D PCA projection, not the raw "
+        f"{fitted.shape[1]}-d embedding array"
+    )
+    assert fitted.shape[1] != dim
+
+
+def test_sync_recompute_clusters_in_pca_space():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dim = 32
+        db = _seeded_db(tmpdir, dim=dim)
+        client = _RecordingEmbeddingClient()
+        db.embedding_client = client
+        db._ensure_embedding_client = lambda: client
+        try:
+            db._recompute_embeddings_and_clusters(num_clusters=4)
+        finally:
+            db.close()
+        assert client.reduction_dims == [2, 3]
+        _assert_clustered_in_reduced_space(client, dim)
+
+
+def test_thread_safe_recompute_clusters_in_pca_space():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dim = 32
+        db = _seeded_db(tmpdir, dim=dim)
+        client = _RecordingEmbeddingClient()
+        db.embedding_client = client
+        db._ensure_embedding_client = lambda: client
+        try:
+            db._recompute_embeddings_and_clusters_thread_safe(num_clusters=4)
+        finally:
+            db.close()
+        assert client.reduction_dims == [2, 3]
+        _assert_clustered_in_reduced_space(client, dim)
+
+
+def test_persisted_cluster_ids_and_pca_columns_stay_consistent():
+    """Every program keeps a 2-D column, a 3-D column and a cluster id."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = _seeded_db(tmpdir, n_programs=8, dim=32)
+        client = _RecordingEmbeddingClient()
+        db.embedding_client = client
+        db._ensure_embedding_client = lambda: client
+        try:
+            db._recompute_embeddings_and_clusters(num_clusters=4)
+            db.cursor.execute(
+                "SELECT embedding_pca_2d, embedding_pca_3d, embedding_cluster_id "
+                "FROM programs"
+            )
+            rows = db.cursor.fetchall()
+        finally:
+            db.close()
+
+        assert rows
+        for row in rows:
+            assert len(json.loads(row["embedding_pca_2d"])) == 2
+            assert len(json.loads(row["embedding_pca_3d"])) == 3
+            assert row["embedding_cluster_id"] is not None


### PR DESCRIPTION
## Summary

`_recompute_embeddings_and_clusters` computes a 2-D and a 3-D PCA projection of the program embeddings and then fits the Gaussian mixture on the **raw** embedding array, two statements later:

```python
reduced_2d = embedding_client.get_dim_reduction(embeddings, method="pca", dims=2)
reduced_3d = embedding_client.get_dim_reduction(embeddings, method="pca", dims=3)
cluster_ids = embedding_client.get_embedding_clusters(embeddings, num_clusters=num_clusters)
```

`get_embedding_clusters` already describes its input as the reduced one:

```python
# Perform GMM clustering on the PCA-reduced embeddings
gmm = GaussianMixture(n_components=num_clusters, random_state=42)
```

This passes `reduced_3d` instead. Two call sites (`_recompute_embeddings_and_clusters` and its `_thread_safe` twin), one argument each.

**I am not certain this is a bug rather than a deliberate choice, and I would rather ask than assume** — see "Is this intended?" at the bottom. If clustering in the raw embedding space was intentional, the useful part of this report is the conditioning evidence below, and I am happy to close this and send a comment-only note instead.

## Why: the mixture is degenerate at embedding dimensionality

With the default `text-embedding-3-small` the array is 1536-d, while an archive holds tens to a few hundred programs. A 4-component **full**-covariance mixture at that shape asks for ~4.7M covariance parameters from ≤320 points. What comes back is not a Gaussian mixture in any useful sense — measured on the real `get_embedding_clusters` path, over archives of 40–320 programs:

| Probe at 1536-d | Result |
|---|---|
| Fitted covariance eigenvalues sitting exactly at the `reg_covar` floor (1e-6) | **95–100%** of all 1536, per component |
| Capping EM at `max_iter=1` | **identical** assignments, 60/60 configurations |
| Tightening `tol` from 1e-3 to 1e-9 | **identical** assignments, 60/60 configurations |
| Replacing the full covariance with a **diagonal** one | **identical** assignments (ARI 1.00) |
| Mean per-sample log-likelihood | **+8817 … +9177** |

Read together: the off-diagonal covariance structure provably does not affect the output, and neither does any EM iteration after initialisation. The result is decided entirely by the k-means initialisation, and the log-density of +9000/sample is the signature of components collapsed onto a near-zero-volume subspace. The 3-D fit behaves like an actual mixture — it runs 4–16 EM iterations and carries soft responsibilities (mean max responsibility 0.78–0.99) in the regimes where the 1536-d fit is already saturated at exactly 1.0.

The cost follows from the same cause rather than being the point: the 1536×1536 triangular solves that build the precision Cholesky dominate the call, so the fit costs **~1.2 s at 20 programs and ~1.6 s at 640** (8 threads; ~2.6–4.4 s single-threaded) and barely varies with archive size, against **2.6–4.4 ms** on the 3-D projection. Because `reduced_3d` is already computed unconditionally two statements earlier, the fix adds no new work. This is background work on the async path (`embedding_recompute_interval`, default 10 additions), so it is a modest saving per run — I mention it for completeness, not as the argument.

## This changes clustering output

It has to — it is a different fit. Characterising it honestly, as the fraction of programs whose cluster membership moves under optimal label matching:

| Archive cohesion (mean pairwise cosine) | Programs reassigned |
|---|---|
| 0.90 | 0.0% |
| 0.75 | 4.8% (0–34%) |
| 0.50 | 10.3% (0–33%) |
| 0.15 | 44.8% (34–58%) |

Cluster recovery against known latent lineages is comparable, slightly favouring the 3-D fit (mean ARI 0.727 vs 0.712), but I would not claim that as a decisive quality win — the two are close, and on some archives the raw fit matches it. The stronger claim is the conditioning one above.

I could not use real embeddings here (no API access in the environment), so these numbers come from synthetic archives with a low-rank lineage structure, swept across mean pairwise cosine 0.15–0.90 so the conclusion does not rest on one guess about how similar real archives are. The conditioning results are regime-independent; the reassignment figures are not, hence the sweep.

**Blast radius:** `embedding_cluster_id` is written by these two methods, carried through `islands.py` migration/archive copies, and consumed only by the web UI cluster view — as the marker colour of the `embedding_pca_2d` / `embedding_pca_3d` scatter plots and the cluster-transition indicator. No selection, novelty, parent-sampling, inspiration, archive or island-migration path reads it. So this does not alter evolution behaviour, and the visible effect is the colouring of plots whose axes are already the PCA projection.

## Tests

Adds `tests/test_embedding_cluster_space.py`: three tests pinning that both recompute paths hand the mixture the 3-D projection, and that the persisted 2-D/3-D columns and cluster ids stay consistent. The two space-pinning tests fail on current `main` (`assert 32 == 3`) and pass with this change. No existing test asserted anything about the clustering input, so nothing was relaxed.

- `uv run ruff check tests --exclude tests/file.py` — unchanged error count vs `main` (the new file is clean)
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py` — clean
- `uv run pytest -q -m "not requires_secrets"` — 727 passed, 1 deselected

Base: `b67a07328ab7e21e999d9e20a44f4f0054a4b83c`.

## Is this intended?

Arguments that it is a bug: the function's own comment says PCA-reduced; the only consumer plots these ids on the PCA axes; and at 1536-d the code cannot obtain the model it names.

Arguments that it may be deliberate: the PCA outputs are *not* dead — both are persisted and plotted — so nothing is being thrown away, and this has been the behaviour since the initial commit rather than being recent drift. Density in the original embedding space is a defensible thing to want.

If you did want the raw-space fit, the conditioning numbers still suggest `covariance_type="diag"` there, since it provably returns the same assignments for ~100× less work. Happy to take it in whichever direction you prefer.

Supplementary autoresearch — 16 measured variants of this fit (projection dimensionality, covariance type, EM budget, k-means, Bayesian mixture, randomized SVD, subsampling, float32, warm start), including the ones that were neutral or worse: https://dashboard.weco.ai/share/Q3EWW_Am1Yn_doXoL4TfYRy8vfJAa395
