### PR TITLE
feat(llm): support Gemini 3.6 Flash on the Google provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Added
 
+- Added native Google Gemini 3.6 Flash support with current pricing and
+  level-based thinking controls. Thanks @anantgar.
 - Added optional Weights & Biases logging with resumable run IDs, per-individual
   scores, timing and cost metrics, and final run summaries in PR #149. Thanks
   @anantgar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "adjustText",
     "markdown",
     "aiofiles",
-    "google-genai",
+    "google-genai>=2.13,<3",
     "psutil",
     "httpx>=0.27"
 ]

--- a/shinka/llm/constants.py
+++ b/shinka/llm/constants.py
@@ -25,3 +25,16 @@ BACKOFF_MAX_TIME = _env_int(
     "SHINKA_LLM_BACKOFF_MAX_TIME",
     TIMEOUT * BACKOFF_MAX_TIME_MULTIPLIER,
 )
+
+GEMINI_THINKING_LEVEL_MODELS = frozenset(
+    {
+        "gemini-3.6-flash",
+    }
+)
+GEMINI_THINKING_LEVEL_BY_EFFORT = {
+    "min": "LOW",
+    "low": "LOW",
+    "medium": "MEDIUM",
+    "high": "HIGH",
+    "max": "HIGH",
+}

--- a/shinka/llm/kwargs.py
+++ b/shinka/llm/kwargs.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional
+from typing import Any, List, Union, Optional
 import random
 from .providers.pricing import (
     is_reasoning_model,
@@ -6,6 +6,10 @@ from .providers.pricing import (
     requires_reasoning,
 )
 from .providers.model_resolver import resolve_model_backend
+from .constants import (
+    GEMINI_THINKING_LEVEL_BY_EFFORT,
+    GEMINI_THINKING_LEVEL_MODELS,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -22,6 +26,7 @@ NO_TEMPERATURE_MODELS = {
     "claude-opus-4-8",
     "deepseek-v4-flash",
     "deepseek-v4-pro",
+    *GEMINI_THINKING_LEVEL_MODELS,
     "us.anthropic.claude-opus-4-8",
 }
 
@@ -36,7 +41,7 @@ def sample_batch_kwargs(
     unique_filter: bool = False,
 ):
     """Sample a dictionary of kwargs for a given model."""
-    all_kwargs = []
+    all_kwargs: list[dict[str, Any]] = []
     attempts = 0
     max_attempts = num_samples * 10  # Prevent infinite loops
 
@@ -85,7 +90,7 @@ def sample_model_kwargs(
     if isinstance(reasoning_efforts, str):
         reasoning_efforts = [reasoning_efforts]
 
-    kwargs_dict = {}
+    kwargs_dict: dict[str, Any] = {}
 
     # 1. SAMPLE: model name
     if model_sample_probs is not None:
@@ -156,8 +161,12 @@ def sample_model_kwargs(
     # 4.b) SET: max_tokens for Google reasoning effort
     elif provider == "google" and is_reasoning_model(model_name):
         kwargs_dict["max_tokens"] = random.choice(max_tokens)
-        think_bool = r_effort != "disabled"
-        if think_bool:
+        if api_model_name in GEMINI_THINKING_LEVEL_MODELS:
+            if r_effort != "disabled":
+                kwargs_dict["thinking_level"] = GEMINI_THINKING_LEVEL_BY_EFFORT[
+                    r_effort
+                ]
+        elif r_effort != "disabled":
             t = THINKING_TOKENS[r_effort]
             thinking_tokens = t if t < kwargs_dict["max_tokens"] else 1024
             kwargs_dict["thinking_budget"] = thinking_tokens

--- a/shinka/llm/providers/gemini.py
+++ b/shinka/llm/providers/gemini.py
@@ -2,7 +2,12 @@ import backoff
 import logging
 from typing import Any, cast
 from google.genai import types
-from shinka.llm.constants import BACKOFF_MAX_TIME, BACKOFF_MAX_TRIES, BACKOFF_MAX_VALUE
+from shinka.llm.constants import (
+    BACKOFF_MAX_TIME,
+    BACKOFF_MAX_TRIES,
+    BACKOFF_MAX_VALUE,
+    GEMINI_THINKING_LEVEL_MODELS,
+)
 from .pricing import calculate_cost
 from .result import QueryResult
 
@@ -32,6 +37,24 @@ def build_gemini_thinking_config(thinking_budget: int):
     return thinking_config_cls(**config_kwargs)
 
 
+def build_gemini_thinking_level_config(thinking_level: str | None):
+    """Build level-based thinking config for current Gemini Flash models."""
+    config_kwargs: dict[str, object] = {"include_thoughts": True}
+    if thinking_level is not None:
+        valid_levels = {
+            "LOW": types.ThinkingLevel.LOW,
+            "MEDIUM": types.ThinkingLevel.MEDIUM,
+            "HIGH": types.ThinkingLevel.HIGH,
+        }
+        try:
+            config_kwargs["thinking_level"] = valid_levels[thinking_level.upper()]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported Gemini thinking level: {thinking_level}") from exc
+
+    thinking_config_cls = cast(Any, types.ThinkingConfig)
+    return thinking_config_cls(**config_kwargs)
+
+
 def build_gemini_afc_config():
     """Build Gemini automatic function-calling config without SDK warnings."""
     model_fields = getattr(types.AutomaticFunctionCallingConfig, "model_fields", {})
@@ -45,6 +68,37 @@ def build_gemini_afc_config():
 
     afc_config_cls = cast(Any, types.AutomaticFunctionCallingConfig)
     return afc_config_cls(**config_kwargs)
+
+
+def build_gemini_generation_config(
+    *,
+    model: str,
+    temperature: float,
+    top_p: float,
+    max_tokens: int,
+    system_instruction: str | None,
+    thinking_budget: int,
+    thinking_level: str | None,
+):
+    """Build a model-compatible config for sync and async requests."""
+    config_kwargs: dict[str, object] = {
+        "max_output_tokens": int(max_tokens),
+        "system_instruction": system_instruction,
+        "automatic_function_calling": build_gemini_afc_config(),
+    }
+    if model in GEMINI_THINKING_LEVEL_MODELS:
+        config_kwargs["thinking_config"] = build_gemini_thinking_level_config(
+            thinking_level
+        )
+    else:
+        config_kwargs.update(
+            temperature=float(temperature),
+            top_p=float(top_p),
+            thinking_config=build_gemini_thinking_config(thinking_budget),
+        )
+
+    generation_config_cls = cast(Any, types.GenerateContentConfig)
+    return generation_config_cls(**config_kwargs)
 
 
 def get_gemini_costs(response, model):
@@ -175,13 +229,14 @@ def query_gemini(
     max_tokens = kwargs.get("max_tokens", 2048)
     thinking_budget = kwargs.get("thinking_budget", 1024)
 
-    generation_config = types.GenerateContentConfig(
-        temperature=float(temperature),
-        top_p=float(top_p),
-        max_output_tokens=int(max_tokens),
+    generation_config = build_gemini_generation_config(
+        model=model,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
         system_instruction=system_msg if system_msg else None,
-        automatic_function_calling=build_gemini_afc_config(),
-        thinking_config=build_gemini_thinking_config(thinking_budget),
+        thinking_budget=thinking_budget,
+        thinking_level=kwargs.get("thinking_level"),
     )
 
     response = client.models.generate_content(
@@ -251,13 +306,14 @@ async def query_gemini_async(
     max_tokens = kwargs.get("max_tokens", 2048)
     thinking_budget = kwargs.get("thinking_budget", 0)
 
-    generation_config = types.GenerateContentConfig(
-        temperature=float(temperature),
-        top_p=float(top_p),
-        max_output_tokens=int(max_tokens),
+    generation_config = build_gemini_generation_config(
+        model=model,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
         system_instruction=system_msg if system_msg else None,
-        automatic_function_calling=build_gemini_afc_config(),
-        thinking_config=build_gemini_thinking_config(thinking_budget),
+        thinking_budget=thinking_budget,
+        thinking_level=kwargs.get("thinking_level"),
     )
 
     response = await client.aio.models.generate_content(

--- a/shinka/llm/providers/pricing.csv
+++ b/shinka/llm/providers/pricing.csv
@@ -54,6 +54,7 @@ deepseek-chat,deepseek,0.14,0.28,,,,False,0,0
 deepseek-reasoner,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-flash,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-pro,deepseek,0.435,0.87,,,,True,0,0
+gemini-3.6-flash,google,0.75,3.75,,,,True,0,0
 gemini-3.5-flash,google,1.5,9.0,,,,True,0,0
 gemini-3-flash-preview,google,0.5,3.0,,,,True,0,0
 gemini-3-pro-preview,google,2.0,12.0,4.0,18.0,200000,True,0,0

--- a/shinka/tools/pricing/models_dev_overlay.json
+++ b/shinka/tools/pricing/models_dev_overlay.json
@@ -83,6 +83,14 @@
   ],
   "llm_overrides": [
     {
+      "provider": "google",
+      "model_name": "gemini-3.6-flash",
+      "input_price": 0.75,
+      "output_price": 3.75,
+      "is_reasoning": true,
+      "think_temp_fixed": false
+    },
+    {
       "provider": "anthropic",
       "model_name": "claude-3-5-haiku-20241022",
       "input_price": 0.8,

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,3 +1,10 @@
+import asyncio
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+from google.genai import types
+
 from shinka.llm.providers import gemini
 
 
@@ -57,3 +64,220 @@ def test_build_gemini_afc_config_sets_max_remote_calls_none(monkeypatch):
     gemini.build_gemini_afc_config()
 
     assert captured == {"disable": True, "maximum_remote_calls": None}
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [
+        ("LOW", types.ThinkingLevel.LOW),
+        ("low", types.ThinkingLevel.LOW),
+        ("MEDIUM", types.ThinkingLevel.MEDIUM),
+        ("medium", types.ThinkingLevel.MEDIUM),
+        ("HIGH", types.ThinkingLevel.HIGH),
+        ("high", types.ThinkingLevel.HIGH),
+        (None, None),
+    ],
+)
+def test_build_gemini_thinking_level_config_uses_sdk_enum(
+    monkeypatch,
+    level: str | None,
+    expected: types.ThinkingLevel | None,
+):
+    captured = {}
+
+    class ThinkingConfig:
+        model_fields: ClassVar[dict[str, object]] = {
+            "include_thoughts": object(),
+            "thinking_level": object(),
+        }
+
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(gemini.types, "ThinkingConfig", ThinkingConfig)
+
+    gemini.build_gemini_thinking_level_config(level)
+
+    assert captured["include_thoughts"] is True
+    if expected is None:
+        assert "thinking_level" not in captured
+    else:
+        assert captured["thinking_level"] == expected
+
+
+def test_build_gemini_thinking_level_config_rejects_unknown_level():
+    with pytest.raises(ValueError, match="NOT_A_LEVEL"):
+        gemini.build_gemini_thinking_level_config("NOT_A_LEVEL")
+
+
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+def test_latest_gemini_generation_config_omits_unsupported_fields(
+    monkeypatch,
+    model_name: str,
+):
+    captured = {}
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        gemini.types,
+        "GenerateContentConfig",
+        GenerateContentConfig,
+    )
+    monkeypatch.setattr(gemini, "build_gemini_afc_config", lambda: "afc")
+    monkeypatch.setattr(
+        gemini,
+        "build_gemini_thinking_level_config",
+        lambda level: {"thinking_level": level},
+    )
+
+    gemini.build_gemini_generation_config(
+        model=model_name,
+        temperature=0.25,
+        top_p=0.9,
+        max_tokens=4096,
+        system_instruction="system",
+        thinking_budget=1024,
+        thinking_level="MEDIUM",
+    )
+
+    assert captured == {
+        "max_output_tokens": 4096,
+        "system_instruction": "system",
+        "automatic_function_calling": "afc",
+        "thinking_config": {"thinking_level": "MEDIUM"},
+    }
+    for unsupported_field in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "candidate_count",
+        "thinking_budget",
+    ):
+        assert unsupported_field not in captured
+
+
+def test_legacy_gemini_generation_config_keeps_sampling_and_budget(monkeypatch):
+    captured = {}
+
+    class GenerateContentConfig:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        gemini.types,
+        "GenerateContentConfig",
+        GenerateContentConfig,
+    )
+    monkeypatch.setattr(gemini, "build_gemini_afc_config", lambda: "afc")
+    monkeypatch.setattr(
+        gemini,
+        "build_gemini_thinking_config",
+        lambda budget: {"thinking_budget": budget},
+    )
+
+    gemini.build_gemini_generation_config(
+        model="gemini-2.5-flash",
+        temperature=0.25,
+        top_p=0.9,
+        max_tokens=4096,
+        system_instruction="system",
+        thinking_budget=1024,
+        thinking_level=None,
+    )
+
+    assert captured == {
+        "temperature": 0.25,
+        "top_p": 0.9,
+        "max_output_tokens": 4096,
+        "system_instruction": "system",
+        "automatic_function_calling": "afc",
+        "thinking_config": {"thinking_budget": 1024},
+    }
+
+
+def test_sync_query_uses_shared_generation_config_builder(monkeypatch):
+    captured = {}
+    response = SimpleNamespace(candidates=[], text="answer", usage_metadata=None)
+
+    class Models:
+        def generate_content(self, **kwargs):
+            captured["request"] = kwargs
+            return response
+
+    def build_config(**kwargs):
+        captured["config_kwargs"] = kwargs
+        return "config"
+
+    monkeypatch.setattr(gemini, "build_gemini_generation_config", build_config)
+
+    result = gemini.query_gemini(
+        SimpleNamespace(models=Models()),
+        "gemini-3.6-flash",
+        "prompt",
+        "system",
+        [],
+        None,
+        temperature=0.25,
+        top_p=0.9,
+        top_k=40,
+        candidate_count=2,
+        max_tokens=4096,
+        thinking_budget=2048,
+        thinking_level="HIGH",
+    )
+
+    assert result.content == "answer"
+    assert captured["config_kwargs"] == {
+        "model": "gemini-3.6-flash",
+        "temperature": 0.25,
+        "top_p": 0.9,
+        "max_tokens": 4096,
+        "system_instruction": "system",
+        "thinking_budget": 2048,
+        "thinking_level": "HIGH",
+    }
+    assert captured["request"]["config"] == "config"
+
+
+def test_async_query_uses_shared_generation_config_builder(monkeypatch):
+    captured = {}
+    response = SimpleNamespace(candidates=[], text="answer", usage_metadata=None)
+
+    class Models:
+        async def generate_content(self, **kwargs):
+            captured["request"] = kwargs
+            return response
+
+    def build_config(**kwargs):
+        captured["config_kwargs"] = kwargs
+        return "config"
+
+    monkeypatch.setattr(gemini, "build_gemini_generation_config", build_config)
+
+    result = asyncio.run(
+        gemini.query_gemini_async(
+            SimpleNamespace(aio=SimpleNamespace(models=Models())),
+            "gemini-3.6-flash",
+            "prompt",
+            "system",
+            [],
+            None,
+            max_tokens=4096,
+            thinking_level="LOW",
+        )
+    )
+
+    assert result.content == "answer"
+    assert captured["config_kwargs"] == {
+        "model": "gemini-3.6-flash",
+        "temperature": 0.8,
+        "top_p": 1.0,
+        "max_tokens": 4096,
+        "system_instruction": "system",
+        "thinking_budget": 0,
+        "thinking_level": "LOW",
+    }
+    assert captured["request"]["config"] == "config"

--- a/tests/test_llm_kwargs.py
+++ b/tests/test_llm_kwargs.py
@@ -1,3 +1,5 @@
+import pytest
+
 from shinka.llm.kwargs import sample_model_kwargs
 from shinka.llm.providers.pricing import is_reasoning_model, requires_reasoning
 
@@ -44,6 +46,74 @@ def test_gpt5_mini_pricing_metadata_enables_reasoning_kwargs_without_temperature
     assert "temperature" not in kwargs
     assert kwargs["max_output_tokens"] == 8192
     assert kwargs["reasoning"] == {"effort": "minimal", "summary": "auto"}
+
+
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_level"),
+    [
+        ("min", "LOW"),
+        ("low", "LOW"),
+        ("medium", "MEDIUM"),
+        ("high", "HIGH"),
+        ("max", "HIGH"),
+    ],
+)
+def test_latest_gemini_flash_maps_reasoning_effort_to_thinking_level(
+    model_name: str,
+    reasoning_effort: str,
+    expected_level: str,
+):
+    kwargs = sample_model_kwargs(
+        model_names=[model_name],
+        temperatures=[0.25],
+        max_tokens=[4096],
+        reasoning_efforts=[reasoning_effort],
+    )
+
+    assert kwargs == {
+        "model_name": model_name,
+        "max_tokens": 4096,
+        "thinking_level": expected_level,
+    }
+
+
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+def test_latest_gemini_flash_disabled_reasoning_omits_thinking_controls(
+    model_name: str,
+):
+    kwargs = sample_model_kwargs(
+        model_names=[model_name],
+        temperatures=[0.25],
+        max_tokens=[4096],
+        reasoning_efforts=["disabled"],
+    )
+
+    assert kwargs == {"model_name": model_name, "max_tokens": 4096}
+    for unsupported_kwarg in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "candidate_count",
+        "thinking_budget",
+    ):
+        assert unsupported_kwarg not in kwargs
+
+
+def test_legacy_gemini_keeps_token_budget_reasoning():
+    kwargs = sample_model_kwargs(
+        model_names=["gemini-2.5-flash"],
+        temperatures=[0.25],
+        max_tokens=[4096],
+        reasoning_efforts=["medium"],
+    )
+
+    assert kwargs == {
+        "model_name": "gemini-2.5-flash",
+        "temperature": 0.25,
+        "max_tokens": 4096,
+        "thinking_budget": 1024,
+    }
 
 
 def test_deepseek_v4_reasoning_kwargs_enable_thinking_mode():

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -57,12 +57,25 @@ def test_claude_opus_keeps_standard_pricing_across_context_window(
     }
 
 
-def test_gemini_3_5_flash_pricing_is_registered():
-    resolved = resolve_model_backend("gemini-3.5-flash")
+@pytest.mark.parametrize(
+    "model_name",
+    ["gemini-3.6-flash"],
+)
+def test_latest_gemini_flash_pricing_is_registered(model_name: str):
+    resolved = resolve_model_backend(model_name)
     assert resolved.provider == "google"
-    assert resolved.api_model_name == "gemini-3.5-flash"
+    assert resolved.api_model_name == model_name
 
+    prices = get_model_prices(model_name)
+    assert prices == {
+        "input_price": 0.75 / 1_000_000,
+        "output_price": 3.75 / 1_000_000,
+    }
+
+
+def test_gemini_3_5_flash_pricing_is_registered():
     prices = get_model_prices("gemini-3.5-flash")
+
     assert prices == {
         "input_price": 1.5 / 1_000_000,
         "output_price": 9.0 / 1_000_000,

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -82,6 +82,12 @@ def test_httpx_dependency_allows_compatible_updates() -> None:
     assert "httpx>=0.27" in dependencies
 
 
+def test_google_genai_dependency_supports_thinking_levels() -> None:
+    dependencies = _read_pyproject()["project"]["dependencies"]
+
+    assert "google-genai>=2.13,<3" in dependencies
+
+
 def test_readme_documents_package_install():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 

--- a/tests/test_pricing_csv_generation.py
+++ b/tests/test_pricing_csv_generation.py
@@ -164,6 +164,29 @@ def test_generate_embedding_rows_maps_azure_alias_and_manual_google_entry():
     ]
 
 
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+def test_generate_latest_gemini_flash_from_manual_overlay(model_name: str):
+    rows = generate_llm_rows(
+        _payload(),
+        [TargetModel("llm", model_name, "google")],
+    )
+
+    assert rows == [
+        {
+            "model_name": model_name,
+            "provider": "google",
+            "input_price": "0.75",
+            "output_price": "3.75",
+            "input_price_tier2": "",
+            "output_price_tier2": "",
+            "tier_threshold": "",
+            "is_reasoning": "True",
+            "think_temp_fixed": "0",
+            "requires_reasoning": "0",
+        }
+    ]
+
+
 def test_load_models_dev_payload_uses_browser_safe_user_agent(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

- Register native Google gemini-3.6-flash with the current introductory price of $0.75 input and $3.75 output per million tokens.
- Upgrade to google-genai>=2.13,<3 for supported thinking-level configuration.
- Map Shinka reasoning effort to LOW/MEDIUM/HIGH, accept documented lowercase values, and omit unsupported sampling/budget parameters.
- Preserve legacy Gemini token-budget behavior and sync/async parity.
- Add catalog generation, resolver, pricing, packaging, kwargs, and provider regressions.
- Credit @anantgar in the changelog.

## Verification

Commit: d46aee2

- Focused model/catalog suite: 68 passed for the 3.6 commit.
- Stacked 3.6/3.7 branch full CI-equivalent gate: 762 passed, 7 skipped, 2 deselected.
- Ruff and Mypy: clean.
- Provider coverage: 79%; diff coverage: 96%.
- Fresh GitHub CI: passed.
- Native credential-backed gemini-3.6-flash request: exact OK response; 4 input, 1 output, 57 thinking tokens; $0.0002205 calculated cost; 2.844s.
- Post-live focused provider/resolver/pricing suite: 62 passed.
- No credential value was logged or persisted.

## Compatibility and rollback

Only Gemini 3.6 uses level-based thinking and parameter omission; older Gemini models retain token-budget behavior. Revert the feature commit to remove 3.6 support and restore the prior SDK constraint.