### PR TITLE
feat(headless): preserve durable Docker sessions in Shinka

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,33 @@ python examples/sine_approx_headless/run_evo.py
 ```
 
 
+#### Running Headless agents in Docker
+
+Point `SHINKA_HEADLESS_COMMAND` at the `shinka_headless_docker` wrapper to run every mutation inside a container:
+
+```bash
+SHINKA_HEADLESS_COMMAND=shinka_headless_docker \
+SHINKA_HEADLESS_DOCKER_IMAGE=ghcr.io/roberttlange/headless:latest \
+shinka_run --task-dir examples/sine_approx_headless ...
+```
+
+The image must contain the native CLI for each provider you use. The public
+Headless image supports the standard Codex and Cursor paths, but does not ship
+Antigravity's proprietary `agy` executable; use a provider image that includes
+it when running Antigravity models.
+
+Headless seeds an agent's credentials by mounting its auth seed paths read-only under `/tmp/headless-host-home` and copying that tree into the container's tmpfs `$HOME`. Some agents keep credentials next to bulk state — `~/.gemini/antigravity-cli` also holds conversation and brain logs and routinely exceeds 500 MB — so seeding straight from your real home copies that entire tree into container RAM on every proposal. The wrapper stages a throwaway home containing only the credential files and sanitizes the Codex config so host-only desktop, marketplace, and MCP entries stay behind. It drops `--session` by default because that staged home is temporary; set `SHINKA_HEADLESS_DOCKER_SESSION_ROOT` to an absolute private directory outside proposal worktrees to enable durable Headless sessions across disposable containers.
+
+| Variable | Purpose |
+| --- | --- |
+| `SHINKA_HEADLESS_DOCKER_IMAGE` | Image to run. Defaults to the Headless CLI's own default. |
+| `SHINKA_HEADLESS_DOCKER_PLATFORM` | Forwarded as `docker run --platform`. |
+| `SHINKA_HEADLESS_DOCKER_ARGS` | Extra `docker run` arguments, parsed as a shell word list. |
+| `SHINKA_HEADLESS_DOCKER_SEED_EXTRA` | Additional home-relative paths to stage, separated by `os.pathsep`. |
+| `SHINKA_HEADLESS_DOCKER_CODEX_SERVICE_TIER` | Codex service tier: `fast` (default) or `flex`. |
+| `SHINKA_HEADLESS_DOCKER_SESSION_ROOT` | Optional absolute root for durable Headless Docker sessions; must be private and outside proposal worktrees. |
+| `SHINKA_HEADLESS_DOCKER_BASE_COMMAND` | Headless CLI command. Defaults to `npx -y @roberttlange/headless`. |
+
 ## Interactive WebUI 🎨
 
 Monitor your evolution experiments in real-time with Shinka's interactive web interface! The WebUI provides live visualization of the evolutionary process, genealogy trees, and performance metrics.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,54 @@ results directory is resumed, its `.wandb_run_id` is reused with
 without uploading. W&B failures are non-fatal and do not alter the existing
 database or WebUI path.
 
+### Headless Agent Models in Docker
+
+`headless/<agent>` model strings shell out to the Headless CLI, which Shinka
+invokes as `npx -y @roberttlange/headless` unless `SHINKA_HEADLESS_COMMAND`
+says otherwise. Setting that variable to `shinka_headless_docker` runs every
+mutation inside a container:
+
+```bash
+export SHINKA_HEADLESS_COMMAND=shinka_headless_docker
+export SHINKA_HEADLESS_DOCKER_IMAGE=ghcr.io/roberttlange/headless:latest
+```
+
+The selected image must contain the native CLI for every provider in use. The
+public Headless image supports the standard Codex and Cursor paths, but does
+not ship Antigravity's proprietary `agy` executable; use a provider image that
+includes it when running Antigravity models.
+
+Headless seeds agent credentials by mounting the agent's auth seed paths
+read-only under `/tmp/headless-host-home` and copying that tree into the
+container's tmpfs `$HOME`. Several agents keep credentials next to bulk state:
+`~/.gemini/antigravity-cli` holds the OAuth token alongside conversation and
+brain logs and routinely exceeds 500 MB, and `~/.codex/config.toml` records
+desktop themes, plugin marketplaces, and MCP server commands that only resolve
+on the host. Seeding straight from a real home therefore copies that state into
+container RAM on every proposal.
+
+`shinka_headless_docker` stages a throwaway home holding only the credential
+files, capped at 4 MiB per file and 16 MiB in total, and prints a warning for
+anything it skips. Directory seed paths are never copied wholesale. It also
+rewrites the Codex config down to its model keys, keeps npm pointed at the host
+cache so the staged home does not trigger a package re-download per proposal.
+By default it drops `--session` because the staged home is temporary. To keep
+Headless's native conversation state across disposable Docker containers, set
+`SHINKA_HEADLESS_DOCKER_SESSION_ROOT` to an absolute, private directory outside
+the proposal worktree. The wrapper then forwards `--session` and maps that
+directory to Headless's `HEADLESS_DOCKER_SESSION_ROOT`; Headless validates its
+ownership, permissions, and worktree separation.
+
+| Variable | Description |
+|----------|-------------|
+| `SHINKA_HEADLESS_DOCKER_IMAGE` | Image to run. Defaults to the Headless CLI's own default. |
+| `SHINKA_HEADLESS_DOCKER_PLATFORM` | Forwarded as `docker run --platform`. |
+| `SHINKA_HEADLESS_DOCKER_ARGS` | Extra `docker run` arguments, parsed as a shell word list. |
+| `SHINKA_HEADLESS_DOCKER_SEED_EXTRA` | Additional home-relative paths to stage, separated by `os.pathsep`. |
+| `SHINKA_HEADLESS_DOCKER_CODEX_SERVICE_TIER` | Codex service tier: `fast` (default) or `flex`. |
+| `SHINKA_HEADLESS_DOCKER_SESSION_ROOT` | Optional absolute root for durable Headless Docker sessions; must be private and outside proposal worktrees. |
+| `SHINKA_HEADLESS_DOCKER_BASE_COMMAND` | Headless CLI command. Defaults to `npx -y @roberttlange/headless`. |
+
 ### DatabaseConfig (`shinka.database.DatabaseConfig`)
 
 | Parameter | Type | Default | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
 wandb = ["wandb"]
 
 [project.scripts]
+shinka_headless_docker = "shinka.llm.providers.headless_docker:main"
 shinka_launch = "shinka.cli.launch:main"
 shinka_models = "shinka.cli.models:main"
 shinka_run = "shinka.cli.run:main"
@@ -86,7 +87,7 @@ shinka = [
 dev = [
     "pytest>=6.0",
     "pytest-cov",
-    "ruff",
+    "ruff>=0.15.21,<0.16",
     "mypy",
     "black",
     "isort",

--- a/shinka/llm/providers/headless_docker.py
+++ b/shinka/llm/providers/headless_docker.py
@@ -1,0 +1,328 @@
+"""Launch the Headless CLI in Docker with a minimal provider auth seed.
+
+Headless mounts each agent's auth seed paths read-only under
+``/tmp/headless-host-home`` and its container bootstrap then runs
+``cp -R /tmp/headless-host-home/. "$HOME"/`` into a tmpfs home. When a seed
+path is a directory the whole tree is mounted and copied, so agents that keep
+conversation logs next to their credentials (antigravity keeps hundreds of
+megabytes under ``~/.gemini/antigravity-cli``) push that entire tree into
+container RAM on every proposal.
+
+This module stages a throwaway ``HOME`` holding only the credential files the
+agent needs, then points Headless at it, so the container copy stays in the
+kilobyte range.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_BASE_COMMAND = "npx -y @roberttlange/headless"
+BASE_COMMAND_ENV = "SHINKA_HEADLESS_DOCKER_BASE_COMMAND"
+IMAGE_ENV = "SHINKA_HEADLESS_DOCKER_IMAGE"
+PLATFORM_ENV = "SHINKA_HEADLESS_DOCKER_PLATFORM"
+EXTRA_ARGS_ENV = "SHINKA_HEADLESS_DOCKER_ARGS"
+EXTRA_SEED_ENV = "SHINKA_HEADLESS_DOCKER_SEED_EXTRA"
+CODEX_SERVICE_TIER_ENV = "SHINKA_HEADLESS_DOCKER_CODEX_SERVICE_TIER"
+SESSION_ROOT_ENV = "SHINKA_HEADLESS_DOCKER_SESSION_ROOT"
+HEADLESS_SESSION_ROOT_ENV = "HEADLESS_DOCKER_SESSION_ROOT"
+
+# Mirrors the ``seedPaths`` table of @roberttlange/headless. Kept local so the
+# wrapper does not pay an extra CLI round trip per proposal;
+# ``tests/test_headless_docker.py`` checks it against ``--show-config``.
+AGENT_SEED_PATHS: dict[str, tuple[str, ...]] = {
+    "acp": (".config/acp",),
+    "antigravity": (".gemini/antigravity-cli", ".gemini/config"),
+    "claude": (
+        ".claude.json",
+        ".claude/settings.json",
+        ".claude/.credentials.json",
+        ".claude/auth.json",
+    ),
+    "codex": (".codex/auth.json", ".codex/config.toml"),
+    "cursor": (".cursor/cli-config.json",),
+    "gemini": (
+        ".gemini/google_accounts.json",
+        ".gemini/settings.json",
+        ".gemini/state.json",
+        ".gemini/trustedFolders.json",
+        ".gemini/installation_id",
+    ),
+    "opencode": (".config/opencode",),
+    "pi": (".pi/agent/auth.json", ".pi/agent/settings.json"),
+}
+
+# Directory seed paths are never copied wholesale. Where the credential files
+# are known, only those are staged; otherwise the generic rule in
+# ``_stage_directory_seed`` keeps top-level regular files and drops subtrees.
+SEED_DIRECTORY_ALLOWLIST: dict[str, tuple[str, ...]] = {
+    ".gemini/antigravity-cli": (
+        "antigravity-oauth-token",
+        "settings.json",
+        "installation_id",
+        "jetski_state.pbtxt",
+    ),
+}
+
+# Codex writes desktop themes, plugin marketplaces and MCP server commands into
+# the same config as its model preferences. Those entries point at host-only
+# paths, so only the keys that still mean something inside a container are
+# carried over.
+CODEX_CONFIG_KEYS = (
+    "model",
+    "model_reasoning_effort",
+    "model_reasoning_summary",
+    "model_verbosity",
+    "preferred_auth_method",
+    "service_tier",
+)
+CODEX_SERVICE_TIERS = frozenset({"fast", "flex"})
+
+MAX_SEED_FILE_BYTES = 4 * 1024 * 1024
+MAX_SEED_TOTAL_BYTES = 16 * 1024 * 1024
+
+# Subcommands and flags that never reach an agent container, so they run
+# against the real home instead of a staged one.
+PASSTHROUGH_FLAGS = frozenset(
+    {"--check", "--help", "-h", "--list", "--show-config", "--version", "-v"}
+)
+PASSTHROUGH_SUBCOMMANDS = frozenset(
+    {"attach", "cron", "docker", "rename", "run", "send"}
+)
+
+DOCKER_DESKTOP_BIN = "/Applications/Docker.app/Contents/Resources/bin"
+
+
+def base_command() -> list[str]:
+    raw_command = os.getenv(BASE_COMMAND_ENV, DEFAULT_BASE_COMMAND).strip()
+    if not raw_command:
+        raise ValueError(f"{BASE_COMMAND_ENV} cannot be empty.")
+    return shlex.split(raw_command)
+
+
+def seed_paths(agent: str) -> tuple[str, ...]:
+    paths = AGENT_SEED_PATHS.get(agent, ())
+    extra = os.getenv(EXTRA_SEED_ENV, "")
+    additional = tuple(part for part in extra.split(os.pathsep) if part.strip())
+    return paths + additional
+
+
+class SeedBudget:
+    def __init__(self, *, total_bytes: int = MAX_SEED_TOTAL_BYTES) -> None:
+        self.remaining = total_bytes
+        self.skipped: list[str] = []
+
+    def copy(self, source: Path, destination: Path, label: str) -> None:
+        size = source.stat().st_size
+        if size > MAX_SEED_FILE_BYTES:
+            self.skipped.append(f"{label} ({size} bytes exceeds per-file limit)")
+            return
+        if size > self.remaining:
+            self.skipped.append(f"{label} ({size} bytes exceeds remaining budget)")
+            return
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+        destination.chmod(0o600)
+        self.remaining -= size
+
+
+def _stage_directory_seed(
+    *,
+    source: Path,
+    destination: Path,
+    relative: str,
+    budget: SeedBudget,
+) -> None:
+    allowlist = SEED_DIRECTORY_ALLOWLIST.get(relative)
+    if allowlist is not None:
+        candidates = [source / name for name in allowlist]
+    else:
+        candidates = sorted(source.iterdir())
+    for candidate in candidates:
+        if candidate.is_symlink() or not candidate.is_file():
+            continue
+        budget.copy(
+            candidate,
+            destination / candidate.name,
+            f"{relative}/{candidate.name}",
+        )
+
+
+def _codex_service_tier() -> str:
+    service_tier = os.getenv(CODEX_SERVICE_TIER_ENV, "fast").strip()
+    if service_tier not in CODEX_SERVICE_TIERS:
+        raise ValueError(
+            f"{CODEX_SERVICE_TIER_ENV} must be one of "
+            f"{sorted(CODEX_SERVICE_TIERS)}."
+        )
+    return service_tier
+
+
+def _minimal_codex_config(source: Path, *, service_tier: str = "fast") -> str:
+    lines: list[str] = []
+    seen: set[str] = set()
+    if source.is_file():
+        for raw_line in source.read_text(errors="replace").splitlines():
+            line = raw_line.strip()
+            if line.startswith("["):
+                break
+            key, separator, value = line.partition("=")
+            key = key.strip()
+            if not separator or key not in CODEX_CONFIG_KEYS or key in seen:
+                continue
+            value = value.strip()
+            if not value or value.startswith(("[", "{")):
+                continue
+            if key == "service_tier":
+                normalized_value = value.strip('"\'')
+                if normalized_value not in CODEX_SERVICE_TIERS:
+                    continue
+            seen.add(key)
+            lines.append(f"{key} = {value}")
+    defaults = (f'service_tier = "{service_tier}"',)
+    for default in defaults:
+        key = default.split("=", 1)[0].strip()
+        if key not in seen:
+            lines.append(default)
+    return "\n".join(lines) + "\n"
+
+
+def stage_auth_home(*, agent: str, host_home: Path, stage_home: Path) -> SeedBudget:
+    budget = SeedBudget()
+    for relative in seed_paths(agent):
+        source = host_home / relative
+        if source.is_symlink() or not source.exists():
+            continue
+        destination = stage_home / relative
+        if source.is_dir():
+            _stage_directory_seed(
+                source=source,
+                destination=destination,
+                relative=relative,
+                budget=budget,
+            )
+        else:
+            budget.copy(source, destination, relative)
+
+    if agent == "codex":
+        config = stage_home / ".codex" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            _minimal_codex_config(
+                host_home / ".codex" / "config.toml",
+                service_tier=_codex_service_tier(),
+            )
+        )
+        config.chmod(0o600)
+    return budget
+
+
+def _durable_sessions_enabled() -> bool:
+    """Return whether the child has a session root that outlives staged HOME."""
+    return bool(
+        os.getenv(SESSION_ROOT_ENV, "").strip()
+        or os.getenv(HEADLESS_SESSION_ROOT_ENV, "").strip()
+    )
+
+
+def strip_session_args(args: list[str], *, preserve: bool | None = None) -> list[str]:
+    """Drop session flags unless a durable Docker session root is configured."""
+    if preserve is None:
+        preserve = _durable_sessions_enabled()
+    if preserve:
+        return list(args)
+
+    stripped: list[str] = []
+    index = 0
+    while index < len(args):
+        argument = args[index]
+        if argument == "--session":
+            index += 2
+            continue
+        if argument.startswith("--session="):
+            index += 1
+            continue
+        stripped.append(argument)
+        index += 1
+    return stripped
+
+
+def docker_flags() -> list[str]:
+    flags: list[str] = ["--docker"]
+    image = os.getenv(IMAGE_ENV, "").strip()
+    if image:
+        flags.extend(["--docker-image", image])
+    platform = os.getenv(PLATFORM_ENV, "").strip()
+    if platform:
+        flags.extend(["--docker-arg", f"--platform={platform}"])
+    for extra in shlex.split(os.getenv(EXTRA_ARGS_ENV, "")):
+        flags.extend(["--docker-arg", extra])
+    return flags
+
+
+def build_command(*, agent: str, args: list[str]) -> list[str]:
+    return [*base_command(), agent, *docker_flags(), *strip_session_args(args)]
+
+
+def child_env(*, host_home: Path, stage_home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(stage_home)
+    configured_session_root = os.getenv(SESSION_ROOT_ENV, "").strip()
+    if configured_session_root:
+        env[HEADLESS_SESSION_ROOT_ENV] = configured_session_root
+    # Keep npm/npx pointed at the real cache. Otherwise every proposal
+    # re-downloads the Headless package (~50 MB) into the staged home.
+    env.setdefault("npm_config_cache", str(host_home / ".npm"))
+    if shutil.which("docker") is None and Path(DOCKER_DESKTOP_BIN).is_dir():
+        env["PATH"] = os.pathsep.join([DOCKER_DESKTOP_BIN, env.get("PATH", "")])
+    return env
+
+
+def _is_passthrough(args: list[str]) -> bool:
+    if not args:
+        return True
+    if args[0] in PASSTHROUGH_SUBCOMMANDS:
+        return True
+    return any(argument in PASSTHROUGH_FLAGS for argument in args)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if _is_passthrough(args):
+        return subprocess.call([*base_command(), *args])
+
+    agent = args[0]
+    if agent not in AGENT_SEED_PATHS:
+        # Still containerize. Falling back to a plain invocation would silently
+        # run the agent on the host, which is the opposite of what the caller
+        # asked for; an unauthenticated container fails loudly instead.
+        print(
+            f"headless-docker: no auth seed paths known for agent {agent!r}; "
+            f"set {EXTRA_SEED_ENV} if it needs credentials",
+            file=sys.stderr,
+        )
+
+    host_home = Path(os.path.expanduser("~"))
+    stage_home = Path(tempfile.mkdtemp(prefix="shinka-headless-home."))
+    try:
+        budget = stage_auth_home(
+            agent=agent, host_home=host_home, stage_home=stage_home
+        )
+        for entry in budget.skipped:
+            print(f"headless-docker: skipped auth seed {entry}", file=sys.stderr)
+        return subprocess.call(
+            build_command(agent=agent, args=args[1:]),
+            env=child_env(host_home=host_home, stage_home=stage_home),
+        )
+    finally:
+        shutil.rmtree(stage_home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_headless_docker.py
+++ b/tests/test_headless_docker.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from shinka.llm.providers import headless_docker as hd
+
+
+def _staged_files(stage_home: Path) -> dict[str, int]:
+    return {
+        str(path.relative_to(stage_home)): path.stat().st_size
+        for path in sorted(stage_home.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _make_antigravity_home(root: Path, *, bulk_files: int = 400) -> Path:
+    home = root / "home"
+    cli_dir = home / ".gemini" / "antigravity-cli"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "antigravity-oauth-token").write_text("token")
+    (cli_dir / "settings.json").write_text('{"useG1Credits": true}')
+    (cli_dir / "installation_id").write_text("abc123")
+    (cli_dir / "jetski_state.pbtxt").write_text("post_onboarding: true")
+    (cli_dir / "conversation_summaries.db").write_bytes(b"\0" * 400_000)
+    for name in ("conversations", "brain", "log"):
+        bulk = cli_dir / name
+        bulk.mkdir()
+        for index in range(bulk_files):
+            (bulk / f"{index}.bin").write_bytes(b"\0" * 4096)
+    return home
+
+
+def test_directory_seed_never_copies_the_whole_tree(tmp_path):
+    host_home = _make_antigravity_home(tmp_path)
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    hd.stage_auth_home(agent="antigravity", host_home=host_home, stage_home=stage_home)
+
+    staged = _staged_files(stage_home)
+    assert set(staged) == {
+        ".gemini/antigravity-cli/antigravity-oauth-token",
+        ".gemini/antigravity-cli/settings.json",
+        ".gemini/antigravity-cli/installation_id",
+        ".gemini/antigravity-cli/jetski_state.pbtxt",
+    }
+    assert sum(staged.values()) < 64 * 1024
+
+
+def test_directory_seed_without_allowlist_keeps_only_top_level_files(tmp_path):
+    host_home = tmp_path / "home"
+    config_dir = host_home / ".config" / "opencode"
+    (config_dir / "cache").mkdir(parents=True)
+    (config_dir / "auth.json").write_text("{}")
+    (config_dir / "cache" / "blob.bin").write_bytes(b"\0" * 200_000)
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    hd.stage_auth_home(agent="opencode", host_home=host_home, stage_home=stage_home)
+
+    assert set(_staged_files(stage_home)) == {".config/opencode/auth.json"}
+
+
+def test_symlinked_seed_paths_are_skipped(tmp_path):
+    host_home = tmp_path / "home"
+    (host_home / ".cursor").mkdir(parents=True)
+    outside = tmp_path / "outside.json"
+    outside.write_text("secret")
+    (host_home / ".cursor" / "cli-config.json").symlink_to(outside)
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    hd.stage_auth_home(agent="cursor", host_home=host_home, stage_home=stage_home)
+
+    assert _staged_files(stage_home) == {}
+
+
+def test_oversized_seed_files_are_skipped_and_reported(tmp_path):
+    host_home = tmp_path / "home"
+    (host_home / ".claude").mkdir(parents=True)
+    (host_home / ".claude.json").write_bytes(b"\0" * (hd.MAX_SEED_FILE_BYTES + 1))
+    (host_home / ".claude" / "auth.json").write_text("{}")
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    budget = hd.stage_auth_home(
+        agent="claude", host_home=host_home, stage_home=stage_home
+    )
+
+    assert set(_staged_files(stage_home)) == {".claude/auth.json"}
+    assert any("per-file limit" in entry for entry in budget.skipped)
+    assert any(entry.startswith(".claude.json") for entry in budget.skipped)
+
+
+def test_total_seed_budget_is_enforced(tmp_path):
+    host_home = tmp_path / "home"
+    gemini_dir = host_home / ".gemini"
+    gemini_dir.mkdir(parents=True)
+    for name in hd.AGENT_SEED_PATHS["gemini"]:
+        (host_home / name).write_bytes(b"\0" * (hd.MAX_SEED_FILE_BYTES - 1))
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    budget = hd.stage_auth_home(
+        agent="gemini", host_home=host_home, stage_home=stage_home
+    )
+
+    assert sum(_staged_files(stage_home).values()) <= hd.MAX_SEED_TOTAL_BYTES
+    assert any("remaining budget" in entry for entry in budget.skipped)
+
+
+def test_codex_config_keeps_model_keys_and_drops_host_sections(tmp_path):
+    host_home = tmp_path / "home"
+    (host_home / ".codex").mkdir(parents=True)
+    (host_home / ".codex" / "auth.json").write_text("{}")
+    (host_home / ".codex" / "config.toml").write_text(
+        "\n".join(
+            [
+                'model = "gpt-5.6-luna"',
+                'model_reasoning_effort = "xhigh"',
+                'service_tier = "default"',
+                "notify = [",
+                '  "/Users/someone/notify.sh",',
+                "]",
+                "[desktop]",
+                'theme = "dark"',
+                "[mcp_servers.node_repl]",
+                'command = "/Applications/ChatGPT.app/node_repl"',
+            ]
+        )
+    )
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    hd.stage_auth_home(agent="codex", host_home=host_home, stage_home=stage_home)
+
+    config = (stage_home / ".codex" / "config.toml").read_text()
+    assert 'model = "gpt-5.6-luna"' in config
+    assert 'model_reasoning_effort = "xhigh"' in config
+    assert 'service_tier = "fast"' in config
+    assert "mcp_servers" not in config
+    assert "desktop" not in config
+    assert "notify" not in config
+    assert "/Users/someone" not in config
+
+
+def test_codex_config_falls_back_to_defaults_without_host_config(tmp_path):
+    host_home = tmp_path / "home"
+    (host_home / ".codex").mkdir(parents=True)
+    (host_home / ".codex" / "auth.json").write_text("{}")
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+
+    hd.stage_auth_home(agent="codex", host_home=host_home, stage_home=stage_home)
+
+    assert (stage_home / ".codex" / "config.toml").read_text() == (
+        'service_tier = "fast"\n'
+    )
+
+
+def test_codex_service_tier_can_use_flex(tmp_path, monkeypatch):
+    host_home = tmp_path / "home"
+    (host_home / ".codex").mkdir(parents=True)
+    (host_home / ".codex" / "auth.json").write_text("{}")
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+    monkeypatch.setenv(hd.CODEX_SERVICE_TIER_ENV, "flex")
+
+    hd.stage_auth_home(agent="codex", host_home=host_home, stage_home=stage_home)
+
+    assert (stage_home / ".codex" / "config.toml").read_text() == (
+        'service_tier = "flex"\n'
+    )
+
+
+def test_extra_seed_paths_can_be_added(tmp_path, monkeypatch):
+    host_home = tmp_path / "home"
+    (host_home / ".gemini").mkdir(parents=True)
+    (host_home / ".gemini" / "config.json").write_text("{}")
+    stage_home = tmp_path / "stage"
+    stage_home.mkdir()
+    monkeypatch.setenv(hd.EXTRA_SEED_ENV, ".gemini/config.json")
+
+    hd.stage_auth_home(agent="cursor", host_home=host_home, stage_home=stage_home)
+
+    assert set(_staged_files(stage_home)) == {".gemini/config.json"}
+
+
+def test_session_args_are_stripped():
+    assert hd.strip_session_args(
+        ["--session", "gen1", "--model", "composer-2.5", "--session=gen2", "--json"]
+    ) == ["--model", "composer-2.5", "--json"]
+
+
+def test_session_args_are_preserved_for_a_durable_root(tmp_path, monkeypatch):
+    monkeypatch.setenv(hd.SESSION_ROOT_ENV, str(tmp_path / "sessions"))
+
+    command = hd.build_command(
+        agent="codex",
+        args=["--session", "gen1", "--model", "gpt-5.5", "--json"],
+    )
+
+    assert command[-5:] == ["--session", "gen1", "--model", "gpt-5.5", "--json"]
+
+
+def test_build_command_requests_docker_and_honours_env(monkeypatch):
+    monkeypatch.setenv(hd.IMAGE_ENV, "example/image:tag")
+    monkeypatch.setenv(hd.PLATFORM_ENV, "linux/arm64")
+    monkeypatch.setenv(hd.EXTRA_ARGS_ENV, "--memory=4g --cpus=2")
+
+    command = hd.build_command(agent="codex", args=["--json"])
+
+    assert command == [
+        "npx",
+        "-y",
+        "@roberttlange/headless",
+        "codex",
+        "--docker",
+        "--docker-image",
+        "example/image:tag",
+        "--docker-arg",
+        "--platform=linux/arm64",
+        "--docker-arg",
+        "--memory=4g",
+        "--docker-arg",
+        "--cpus=2",
+        "--json",
+    ]
+
+
+def test_child_env_stages_home_but_keeps_the_host_npm_cache(tmp_path, monkeypatch):
+    monkeypatch.delenv("npm_config_cache", raising=False)
+    host_home = tmp_path / "home"
+    stage_home = tmp_path / "stage"
+
+    env = hd.child_env(host_home=host_home, stage_home=stage_home)
+
+    assert env["HOME"] == str(stage_home)
+    assert env["npm_config_cache"] == str(host_home / ".npm")
+
+
+def test_child_env_maps_shinka_session_root_to_headless(tmp_path, monkeypatch):
+    session_root = tmp_path / "sessions"
+    monkeypatch.setenv(hd.SESSION_ROOT_ENV, str(session_root))
+
+    env = hd.child_env(host_home=tmp_path / "home", stage_home=tmp_path / "stage")
+
+    assert env[hd.HEADLESS_SESSION_ROOT_ENV] == str(session_root)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [[], ["--check"], ["codex", "--check"], ["docker", "doctor"], ["run", "list"]],
+)
+def test_informational_invocations_bypass_staging(args, monkeypatch):
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(
+        hd.subprocess, "call", lambda cmd, **kwargs: recorded.append(cmd) or 0
+    )
+
+    assert hd.main(args) == 0
+    assert recorded == [[*hd.base_command(), *args]]
+    assert all("--docker" not in cmd for cmd in recorded)
+
+
+def test_unknown_agents_still_run_in_docker(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    recorded: list[list[str]] = []
+    monkeypatch.setattr(
+        hd.subprocess, "call", lambda cmd, **kwargs: recorded.append(cmd) or 0
+    )
+
+    assert hd.main(["brand-new-agent", "--json"]) == 0
+
+    assert "--docker" in recorded[0]
+    assert "no auth seed paths known" in capsys.readouterr().err
+
+
+def test_main_stages_a_minimal_home_and_cleans_it_up(tmp_path, monkeypatch):
+    host_home = _make_antigravity_home(tmp_path, bulk_files=50)
+    monkeypatch.setenv("HOME", str(host_home))
+    observed: dict[str, object] = {}
+
+    def fake_call(cmd, **kwargs):
+        stage_home = Path(kwargs["env"]["HOME"])
+        observed["command"] = cmd
+        observed["stage_home"] = stage_home
+        observed["staged"] = _staged_files(stage_home)
+        return 0
+
+    monkeypatch.setattr(hd.subprocess, "call", fake_call)
+
+    assert hd.main(["antigravity", "--json"]) == 0
+
+    assert "--docker" in observed["command"]
+    assert sum(observed["staged"].values()) < 64 * 1024
+    assert not Path(observed["stage_home"]).exists()
+
+
+@pytest.mark.integration
+def test_seed_paths_match_the_installed_headless_cli():
+    if shutil.which("npx") is None:
+        pytest.skip("npx is unavailable")
+    for agent, expected in hd.AGENT_SEED_PATHS.items():
+        completed = subprocess.run(
+            ["npx", "-y", "@roberttlange/headless", agent, "--show-config"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            env={**os.environ, "HOME": os.path.expanduser("~")},
+        )
+        if completed.returncode != 0:
+            pytest.skip(f"headless --show-config unavailable: {completed.stderr}")
+        reported = tuple(
+            line.split("|")[2].strip()
+            for line in completed.stdout.splitlines()
+            if "| Seed path" in line
+        )
+        assert reported == expected, agent

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -52,6 +52,7 @@ def test_project_metadata_targets_pypi_release():
     assert project["readme"] == "README.md"
     assert project["license"] == "Apache-2.0"
     assert project["scripts"] == {
+        "shinka_headless_docker": "shinka.llm.providers.headless_docker:main",
         "shinka_launch": "shinka.cli.launch:main",
         "shinka_models": "shinka.cli.models:main",
         "shinka_run": "shinka.cli.run:main",


### PR DESCRIPTION
## Summary

- Add a `shinka_headless_docker` wrapper so Headless mutations can run in Docker via `SHINKA_HEADLESS_COMMAND`.
- Preserve `--session` when an explicit durable Docker session root is configured.
- Map `SHINKA_HEADLESS_DOCKER_SESSION_ROOT` to Headless CLI's `HEADLESS_DOCKER_SESSION_ROOT`.
- Keep the existing temporary-home behavior as the default.
- Document the security and worktree-separation requirements.

## Why

Headless CLI PR [#21](https://github.com/RobertTLange/headless-cli/pull/21) added durable Docker sessions, but Shinka's credential-staging wrapper still removed `--session`. This companion makes the feature usable across disposable containers without persisting the staged auth home.

## Scope

Headless Docker wrapper + durable session wiring only. Repo-mode / agent-based repo evolution stays on the fork and is **not** included.

## Validation

- `uv run ruff check shinka/llm/providers/headless_docker.py tests/test_headless_docker.py tests/test_packaging_release.py`
- `uv run pytest -q tests/test_headless_docker.py tests/test_packaging_release.py` — 32 passed
- `git diff --check`