### PR TITLE
Add hardened Docker evaluation backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,12 @@ For the simplest setup with default settings, you only need to specify the evalu
 ```python
 from shinka.core import ShinkaEvolveRunner, EvolutionConfig
 from shinka.database import DatabaseConfig
-from shinka.launch import LocalJobConfig, SlurmCondaJobConfig, SlurmDockerJobConfig
+from shinka.launch import (
+    LocalJobConfig,
+    SecureDockerJobConfig,
+    SlurmCondaJobConfig,
+    SlurmDockerJobConfig,
+)
 
 # Minimal - only specify what's required
 job_conf = LocalJobConfig(eval_program_path="evaluate.py")
@@ -146,6 +151,14 @@ job_conf = LocalJobConfig(eval_program_path="evaluate.py")
 #     gpus=1,
 #     mem="8G",
 # )
+# Or isolate the existing single-file evaluator and candidate in a hardened,
+# networkless local container. The image must be pre-pulled by digest and
+# include Python, Shinka, evaluator dependencies, and the candidate toolchain.
+# job_conf = SecureDockerJobConfig(
+#     eval_program_path="evaluate.py",
+#     image="registry.example/shinka/evaluator@sha256:<64-hex-digest>",
+# )
+# Use EvolutionConfig(..., job_type="secure_docker") with this backend.
 db_conf = DatabaseConfig()
 evo_conf = EvolutionConfig(init_program_path="initial.py")
 
@@ -213,7 +226,7 @@ Class defaults below come from `shinka/core/config.py` (`EvolutionConfig`). Hydr
 | `num_generations` | `50` | `int` | Number of evolution generations to run |
 | `max_patch_resamples` | `3` | `int` | Max times to resample a patch if it fails |
 | `max_patch_attempts` | `1` | `int` | Max attempts to generate a valid patch |
-| `job_type` | `"local"` | `str` | Job execution type: "local", "slurm_docker", "slurm_conda" |
+| `job_type` | `"local"` | `str` | Job execution type: "local", "secure_docker", "slurm_docker", "slurm_conda" |
 | `language` | `"python"` | `str` | Programming language for evolution |
 | `llm_models` | `["gpt-5-mini", "gemini-3-flash-preview", "gemini-3.1-pro-preview", "gpt-5.4"]` | `List[str]` | List of LLM models for code generation |
 | `llm_dynamic_selection` | `"ucb"` | `Optional[Union[str, BanditBase]]` | Dynamic model selection strategy |
@@ -310,6 +323,11 @@ Class defaults below come from `shinka/database/dbase.py` (`DatabaseConfig`). Hy
 | `time` | `None` | `Optional[str]` | Time limit for job execution |
 | `conda_env` | `None` | `Optional[str]` | Conda environment to run jobs in |
 | `activate_script` | `None` | `Optional[str]` | Sourceable env script path, e.g. `.venv/bin/activate` |
+
+**SecureDockerJobConfig** (hardened local execution): set
+`EvolutionConfig.job_type="secure_docker"`, provide a locally available pinned
+`image`, and see [Hardened Docker Evaluation](docs/secure_docker.md) for the
+full configuration and security boundary.
 
 **SlurmDockerJobConfig** (for SLURM with Docker):
 | Key | Default Value | Type | Explanation |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ Configuration values are resolved in this order (later wins):
 1. Dataclass defaults in code:
    - `shinka/core/config.py` (`EvolutionConfig`)
    - `shinka/database/dbase.py` (`DatabaseConfig`)
-   - `shinka/launch/scheduler.py` (`LocalJobConfig`, `SlurmDockerJobConfig`, `SlurmCondaJobConfig`)
+   - `shinka/launch/scheduler.py` (`LocalJobConfig`, `SecureDockerJobConfig`, `SlurmDockerJobConfig`, `SlurmCondaJobConfig`)
 2. Hydra preset YAMLs in `shinka/configs/`
 3. Task/cluster/variant overrides from Hydra composition
 4. CLI overrides (`shinka_launch ... key=value`, or `shinka_run --set ...`)
@@ -33,7 +33,7 @@ Concurrency is configured on `ShinkaEvolveRunner`, not on `EvolutionConfig`.
 | `num_generations` | `int` | `50` | Target number of generations. |
 | `max_patch_resamples` | `int` | `3` | Max patch resample loops per novelty attempt. |
 | `max_patch_attempts` | `int` | `1` | Max attempts to produce a syntactically valid patch. |
-| `job_type` | `str` | `'local'` | Job backend: `local`, `slurm_docker`, `slurm_conda`. |
+| `job_type` | `str` | `'local'` | Job backend: `local`, `secure_docker`, `slurm_docker`, `slurm_conda`. |
 | `language` | `str` | `'python'` | Language tag for prompts + file handling. |
 | `llm_models` | `List[str]` | `['gpt-5-mini', 'gemini-3-flash-preview', 'gemini-3.1-pro-preview', 'gpt-5.4']` | Mutation model pool. |
 | `llm_dynamic_selection` | `Optional[Union[str, BanditBase]]` | `'ucb'` | Dynamic model selection (`fixed`, `ucb`, `ucb1`, `thompson`, or bandit object). |
@@ -150,6 +150,28 @@ database or WebUI path.
 | `time` | `Optional[str]` | `None` | Optional timeout (`HH:MM:SS`). |
 | `conda_env` | `Optional[str]` | `None` | Optional conda env for local execution. |
 | `activate_script` | `Optional[str]` | `None` | Optional sourceable env script, e.g. `.venv/bin/activate`. |
+
+`SecureDockerJobConfig` adds a hardened local Docker execution mode. It keeps
+the ordinary single-file `evaluate.py --program_path --results_dir` interface;
+see [Hardened Docker Evaluation](secure_docker.md) for the security boundary.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image` | `str` | required | Locally available immutable `@sha256:` image reference. |
+| `evaluator_root` | `Optional[str]` | `None` | Read-only evaluator tree; defaults to `evaluate.py`'s parent. |
+| `container_executable` | `str` | `'docker'` | Docker-compatible CLI executable. |
+| `python_executable` | `str` | `'python'` | Python command inside the evaluator image. |
+| `time` | `str` | `'00:05:00'` | Required wall-time limit (`HH:MM:SS`). |
+| `memory_bytes` | `int` | `2147483648` | Container memory limit. |
+| `cpus` | `float` | `1.0` | Container CPU limit. |
+| `pids_limit` | `int` | `256` | Maximum process count. |
+| `open_files_limit` | `int` | `1024` | Maximum open file descriptors. |
+| `max_output_bytes` | `int` | `8388608` | Combined stdout/stderr cap; overflow terminates the container. |
+| `tmpfs_bytes` | `int` | `536870912` | Writable temporary-filesystem cap. |
+| `result_tmpfs_bytes` | `int` | `67108864` | Isolated evaluator-result tmpfs cap; no host result directory is mounted. |
+| `sandbox_user` | `Optional[str]` | current non-root UID:GID | Container user; must be a non-root numeric UID:GID. |
+| `require_rootless` | `bool` | `True` | Require a rootless Docker engine on Linux. |
+| `allow_rootful_dedicated_vm` | `bool` | `False` | Explicit exception for a dedicated container VM. |
 
 `SlurmDockerJobConfig` adds:
 

--- a/docs/reference/launch_api.md
+++ b/docs/reference/launch_api.md
@@ -38,6 +38,20 @@ SLURM-backed execution where the evaluator runs in a container.
 
 ---
 
+## `SecureDockerJobConfig`
+
+Local hardened Docker execution for the existing single-file
+`evaluate.py --program_path --results_dir` interface. See [Hardened Docker
+Evaluation](../secure_docker.md) for its security model and compatibility
+limits.
+
+::: shinka.launch.scheduler.SecureDockerJobConfig
+    handler: python
+    options:
+      show_source: false
+
+---
+
 ## `JobScheduler`
 
 Lower-level scheduler abstraction for submitting and monitoring evaluation jobs

--- a/docs/secure_docker.md
+++ b/docs/secure_docker.md
@@ -1,0 +1,134 @@
+# Hardened Docker evaluation
+
+`SecureDockerJobConfig` runs Shinka's existing single-file candidate and
+`evaluate.py` interface in one hardened local Docker container. It is opt-in:
+set `EvolutionConfig.job_type="secure_docker"` and supply an immutable image
+digest.
+
+This mode is useful when generated code is untrusted and the main concern is
+protecting the host that runs Shinka. It supports every existing candidate
+language because it does not interpret the candidate itself: the configured
+image supplies the language runtime/compiler, while `evaluate.py` is still
+invoked with its existing arguments. The candidate must remain one regular
+file; it is never treated as a repository or directory tree.
+
+## Use it
+
+Build or obtain an evaluator image that includes:
+
+- Python and `shinka-evolve`, plus the evaluator's Python dependencies;
+- the toolchain required by the candidate task (for example Go, Julia,
+  gfortran, Rust, C/C++, CUDA, Swift, Wolfram, or native Verilog tools); and
+- no Docker `VOLUME` declarations (the launcher rejects them because they can
+  bypass the read-only-root filesystem and consume host-backed storage); and
+- no credentials or private data baked into the image.
+
+Pull the exact image digest before starting a run. The secure launcher never
+pulls an image implicitly.
+
+```python
+from shinka.core import EvolutionConfig, ShinkaEvolveRunner
+from shinka.database import DatabaseConfig
+from shinka.launch import SecureDockerJobConfig
+
+runner = ShinkaEvolveRunner(
+    evo_config=EvolutionConfig(
+        job_type="secure_docker",
+        language="go",
+        init_program_path="examples/go_collatz_steps/initial.go",
+        results_dir="results/go_secure",
+    ),
+    job_config=SecureDockerJobConfig(
+        eval_program_path="examples/go_collatz_steps/evaluate.py",
+        evaluator_root="examples/go_collatz_steps",
+        image="registry.example/shinka/evaluator@sha256:<64-hex-digest>",
+        time="00:05:00",
+    ),
+    db_config=DatabaseConfig(),
+)
+runner.run()
+```
+
+The same mode is available through `shinka_run`:
+
+```bash
+shinka_run \
+  --task-dir examples/go_collatz_steps \
+  --results_dir results/go_secure \
+  --num_generations 20 \
+  --set evo.job_type=secure_docker \
+  --set job.image='registry.example/shinka/evaluator@sha256:<64-hex-digest>'
+```
+
+`evaluator_root` defaults to the parent directory of `evaluate.py`; set it when
+the evaluator imports sibling modules or reads task assets from a broader task
+directory. Keep that tree to ordinary task files: the launcher rejects nested
+mounts, sockets, FIFOs, and device files before mounting it.
+
+## Enforced policy
+
+The launcher uses a shell-free `docker create` / inspect / `docker start`
+sequence and fails before execution if the configured image is not present or
+is not a digest reference. Every evaluation container is:
+
+- networkless and unprivileged;
+- non-root, with all Linux capabilities dropped and
+  `no-new-privileges` enabled, with Docker's default seccomp profile required;
+- read-only except for bounded tmpfs storage;
+- bounded by explicit CPU, memory, PID, open-file, wall-time, and log-output
+  limits (with swap disabled and Docker's persistent log driver disabled); and
+- given only read-only mounts: the evaluator tree, a trusted runtime wrapper,
+  and the one candidate file; it is automatically removed when it exits.
+
+`/workspace/results` is a separate, size-limited container tmpfs
+(`result_tmpfs_bytes`, 64 MiB by default), not a host bind mount. The trusted
+wrapper invokes the evaluator with its ordinary arguments, captures bounded
+stdout/stderr, and exports only regular `metrics.json` and `correct.json` files
+to the host as bounded JSON objects. This prevents a candidate from filling the host disk or using a
+result-path symlink to make the host read or write another file. Other
+evaluator artifacts remain in the container intentionally.
+
+The wrapper enforces the configured `time` limit inside the container as well
+as the scheduler enforcing it on the host, so an evaluator cannot keep running
+indefinitely if the host-side monitor disappears.
+
+On Linux, the Docker engine must be rootless by default. Set
+`allow_rootful_dedicated_vm=True` only when the daemon is inside a dedicated
+container VM. Docker Desktop supplies a VM boundary on macOS and Windows; on
+Windows, configure an explicit non-root numeric `sandbox_user` because a host
+POSIX UID:GID is unavailable.
+
+The `/tmp` tmpfs intentionally remains executable: several supported evaluator
+patterns compile a single-file candidate into a temporary directory before
+running it. The result tmpfs is `noexec`; it is for evaluator result data, not
+compiled programs.
+
+## Important boundary limitation
+
+This mode preserves the old evaluator contract by putting `evaluate.py` and the
+candidate in the **same** container. That is deliberately a host-containment
+boundary, not a confidentiality or score-integrity boundary between the two.
+
+For example, a Python candidate dynamically imported by `evaluate.py` runs in
+the evaluator's interpreter and can access anything that interpreter can read.
+Likewise, a candidate can forge ordinary score data written by a legacy
+evaluator. The wrapper rejects symlink, non-regular, and oversized exports, but
+it cannot make an arbitrary legacy evaluator trust malicious ordinary output.
+
+Do not put secrets or undisclosed private test data in `evaluator_root` when
+using this compatibility mode. Do not use it with evaluators that need a Docker
+socket or unrestricted network access; install their tools directly in the
+pinned image instead. A stronger evaluator/candidate boundary requires a
+separate candidate-runner protocol and therefore a new evaluator API, which is
+intentionally outside this compatibility feature.
+
+For example, a Verilog evaluator can run `iverilog`, `vvp`, Yosys, and OpenSTA
+directly from the pinned image. The current `examples/rtllm/evaluate.py` has a
+fallback that launches nested Docker containers; that fallback is intentionally
+incompatible with this mode because no Docker socket is exposed.
+
+Docker is defense in depth, not a proof of complete safety. A daemon, kernel,
+or runtime escape vulnerability can still break containment; rootless Docker on
+Linux reduces the blast radius but does not remove it. Treat the evaluator image
+and Docker daemon as trusted infrastructure, keep them patched, and use a
+dedicated VM for higher-risk workloads.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - Agentic Usage: agentic_usage.md
       - CLI Usage: cli_usage.md
       - Configuration: configuration.md
+      - Hardened Docker Evaluation: secure_docker.md
       - Local Models: support_local_models.md
   - WebUI: webui.md
   - API Reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,7 @@ markers = [
     "models_dev_live: live models.dev catalog contract coverage",
     "requires_secrets: tests that need CI secrets or private credentials",
 ]
+
+[tool.ruff.lint]
+# Keep CI's established baseline explicit across Ruff releases.
+select = ["E4", "E7", "E9", "F"]

--- a/shinka/cli/run.py
+++ b/shinka/cli/run.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, Union, get_args, get_origin
 
 from shinka.core import ShinkaEvolveRunner, EvolutionConfig
 from shinka.database import DatabaseConfig
-from shinka.launch import LocalJobConfig
+from shinka.launch import JobConfig, LocalJobConfig, SecureDockerJobConfig
 from shinka.cli.run_config import load_optional_yaml_config
 
 SUPPORTED_INITIAL_EXTENSIONS: dict[str, str] = {
@@ -211,10 +211,16 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _field_types() -> Dict[str, Dict[str, Any]]:
+    job_fields: Dict[str, Any] = {}
+    for config_type in (LocalJobConfig, SecureDockerJobConfig):
+        for config_field in fields(config_type):
+            # Preserve the existing local CLI coercion for shared fields such
+            # as Optional[python_executable]; secure-only fields are added.
+            job_fields.setdefault(config_field.name, config_field.type)
     return {
         "evo": {field.name: field.type for field in fields(EvolutionConfig)},
         "db": {field.name: field.type for field in fields(DatabaseConfig)},
-        "job": {field.name: field.type for field in fields(LocalJobConfig)},
+        "job": job_fields,
     }
 
 
@@ -395,6 +401,18 @@ def _build_default_job_values(evaluate_path: Path) -> Dict[str, Any]:
     return asdict(LocalJobConfig(eval_program_path=str(evaluate_path)))
 
 
+def _build_secure_docker_job_values(evaluate_path: Path) -> Dict[str, Any]:
+    # Build dataclass defaults without making the required image optional.
+    values = asdict(
+        SecureDockerJobConfig(
+            eval_program_path=str(evaluate_path),
+            image="bootstrap-only",
+        )
+    )
+    values["image"] = ""
+    return values
+
+
 def _validate_task_dir(task_dir: Path) -> tuple[Path, Path]:
     if not task_dir.exists():
         raise FileNotFoundError(f"Task dir does not exist: {task_dir}")
@@ -412,9 +430,9 @@ def _build_runner(
     args: argparse.Namespace,
     evo_config: EvolutionConfig,
     db_config: DatabaseConfig,
-    job_config: LocalJobConfig,
+    job_config: JobConfig,
     init_program_str: str,
-    evaluate_str: str,
+    evaluate_str: Optional[str],
 ) -> ShinkaEvolveRunner:
     runner_kwargs: Dict[str, Any] = {
         "evo_config": evo_config,
@@ -468,10 +486,6 @@ def main(argv: Optional[list[str]] = None) -> int:
         db_values.update(file_overrides["db"])
         db_values.update(parsed_overrides["db"])
 
-        job_values = _build_default_job_values(evaluate_path)
-        job_values.update(file_overrides["job"])
-        job_values.update(parsed_overrides["job"])
-
         if args.max_evaluation_jobs is None:
             args.max_evaluation_jobs = runner_config.get("max_evaluation_jobs")
         if args.max_proposal_jobs is None:
@@ -485,10 +499,34 @@ def main(argv: Optional[list[str]] = None) -> int:
 
         evo_config = EvolutionConfig(**evo_values)
         db_config = DatabaseConfig(**db_values)
-        job_config = LocalJobConfig(**job_values)
+        job_overrides = {**file_overrides["job"], **parsed_overrides["job"]}
+        if evo_config.job_type == "secure_docker":
+            secure_field_names = {
+                field.name for field in fields(SecureDockerJobConfig)
+            }
+            incompatible = sorted(set(job_overrides) - secure_field_names)
+            if incompatible:
+                raise ValueError(
+                    "These job settings are not supported by secure_docker: "
+                    + ", ".join(incompatible)
+                )
+            job_values = _build_secure_docker_job_values(evaluate_path)
+            job_values.update(job_overrides)
+            job_config = SecureDockerJobConfig(**job_values)
+        else:
+            job_values = _build_default_job_values(evaluate_path)
+            job_values.update(job_overrides)
+            job_config = LocalJobConfig(**job_values)
 
         init_program_str = initial_path.read_text(encoding="utf-8")
-        evaluate_str = evaluate_path.read_text(encoding="utf-8")
+        # Secure Docker mounts the evaluator's real directory read-only. Keeping
+        # the script in place preserves sibling imports and task assets while
+        # retaining the existing evaluate.py CLI contract.
+        evaluate_str = (
+            None
+            if isinstance(job_config, SecureDockerJobConfig)
+            else evaluate_path.read_text(encoding="utf-8")
+        )
 
         runner = _build_runner(
             args=args,

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -37,7 +37,12 @@ from shinka.llm import (
     ThompsonSampler,
 )
 from shinka.embed import AsyncEmbeddingClient
-from shinka.launch import JobScheduler, JobConfig, LocalJobConfig
+from shinka.launch import (
+    JobScheduler,
+    JobConfig,
+    LocalJobConfig,
+    SecureDockerJobConfig,
+)
 from shinka.edit.async_apply import (
     apply_patch_async,
     get_code_embedding_async,
@@ -757,16 +762,21 @@ class ShinkaEvolveRunner:
         return max_evaluation_jobs, max_proposal_jobs, max_db_workers
 
     def _configure_local_job_runtime(self, cpu_count: int) -> None:
-        """Tune local evaluation subprocess runtime defaults for scaling."""
-        if not isinstance(self.job_config, LocalJobConfig):
+        """Tune local-style evaluation runtime defaults for scaling."""
+        if not isinstance(self.job_config, (LocalJobConfig, SecureDockerJobConfig)):
             return
 
         if self.job_config.numeric_threads_per_job is None:
             numeric_threads = max(1, cpu_count // max(1, self.max_evaluation_jobs))
+            if isinstance(self.job_config, SecureDockerJobConfig):
+                numeric_threads = min(
+                    numeric_threads,
+                    max(1, int(self.job_config.cpus)),
+                )
             self.job_config.numeric_threads_per_job = numeric_threads
             if self.verbose:
                 logger.info(
-                    "Configured local numeric thread cap per eval process: %s",
+                    "Configured numeric thread cap per eval process: %s",
                     numeric_threads,
                 )
 

--- a/shinka/launch/__init__.py
+++ b/shinka/launch/__init__.py
@@ -1,6 +1,7 @@
 from .scheduler import JobScheduler, JobConfig
 from .scheduler import (
     LocalJobConfig,
+    SecureDockerJobConfig,
     SlurmDockerJobConfig,
     SlurmCondaJobConfig,
     SlurmEnvJobConfig,
@@ -11,6 +12,7 @@ __all__ = [
     "JobScheduler",
     "JobConfig",
     "LocalJobConfig",
+    "SecureDockerJobConfig",
     "SlurmDockerJobConfig",
     "SlurmCondaJobConfig",
     "SlurmEnvJobConfig",

--- a/shinka/launch/scheduler.py
+++ b/shinka/launch/scheduler.py
@@ -8,6 +8,7 @@ from typing import Optional, Dict, Any, Tuple, Union, List
 from concurrent.futures import ThreadPoolExecutor
 from .local import submit as submit_local, monitor as monitor_local
 from .local import ProcessWithLogging
+from .secure_docker import SecureDockerProcess, submit as submit_secure_docker
 from .slurm import (
     submit_docker as submit_slurm_docker,
     submit_conda as submit_slurm_conda,
@@ -85,6 +86,54 @@ class LocalJobConfig(JobConfig):
 
 
 @dataclass
+class SecureDockerJobConfig(JobConfig):
+    """Run the existing single-file evaluator in a hardened local container.
+
+    ``evaluate.py`` keeps its usual ``--program_path`` and ``--results_dir``
+    arguments. The image must contain Python, the evaluator's dependencies, and
+    any compiler/runtime required by the candidate language.
+    """
+
+    image: str = ""
+    evaluator_root: Optional[str] = None
+    container_executable: str = "docker"
+    python_executable: str = "python"
+    time: str = "00:05:00"
+    memory_bytes: int = 2 * 1024 * 1024 * 1024
+    cpus: float = 1.0
+    pids_limit: int = 256
+    open_files_limit: int = 1024
+    max_output_bytes: int = 8 * 1024 * 1024
+    tmpfs_bytes: int = 512 * 1024 * 1024
+    result_tmpfs_bytes: int = 64 * 1024 * 1024
+    sandbox_user: Optional[str] = None
+    require_rootless: bool = True
+    allow_rootful_dedicated_vm: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.image, str) or not self.image.strip():
+            raise ValueError("SecureDockerJobConfig.image is required")
+        if not isinstance(self.time, str) or not self.time:
+            raise ValueError("SecureDockerJobConfig.time is required")
+        if parse_time_to_seconds(self.time) <= 0:
+            raise ValueError("SecureDockerJobConfig.time must be positive")
+        if self.memory_bytes <= 0:
+            raise ValueError("memory_bytes must be positive")
+        if self.cpus <= 0:
+            raise ValueError("cpus must be positive")
+        if self.pids_limit <= 0:
+            raise ValueError("pids_limit must be positive")
+        if self.open_files_limit <= 0:
+            raise ValueError("open_files_limit must be positive")
+        if self.max_output_bytes <= 0:
+            raise ValueError("max_output_bytes must be positive")
+        if self.tmpfs_bytes <= 0:
+            raise ValueError("tmpfs_bytes must be positive")
+        if self.result_tmpfs_bytes <= 0:
+            raise ValueError("result_tmpfs_bytes must be positive")
+
+
+@dataclass
 class SlurmDockerJobConfig(JobConfig):
     """Configuration for SLURM jobs using Docker"""
 
@@ -126,6 +175,7 @@ class JobScheduler:
         job_type: str,
         config: Union[
             LocalJobConfig,
+            SecureDockerJobConfig,
             SlurmDockerJobConfig,
             SlurmCondaJobConfig,
         ],
@@ -139,14 +189,15 @@ class JobScheduler:
         if self.job_type == "slurm_env":
             self.job_type = "slurm_conda"
 
-        if self.job_type == "local":
+        if self.job_type in ["local", "secure_docker"]:
             self.monitor = monitor_local
         elif self.job_type in ["slurm_docker", "slurm_conda"]:
             self.monitor = monitor_slurm
         else:
             raise ValueError(
                 f"Unknown job type: {job_type}. "
-                f"Must be 'local', 'slurm_docker', 'slurm_conda', or 'slurm_env'"
+                "Must be 'local', 'secure_docker', 'slurm_docker', "
+                "'slurm_conda', or 'slurm_env'"
             )
 
     def _build_command(self, exec_fname_t: str, results_dir_t: str) -> List[str]:
@@ -193,7 +244,9 @@ class JobScheduler:
                     *python_cmd,
                 ]
             if _has_value(self.config.activate_script):
-                activate_script = self.config.activate_script.strip().replace('"', '\\"')
+                activate_script = self.config.activate_script.strip().replace(
+                    '"', '\\"'
+                )
                 return [
                     "bash",
                     "-lc",
@@ -205,9 +258,8 @@ class JobScheduler:
     def _build_eval_env(self) -> Dict[str, str]:
         """Environment for the eval subprocess: verbosity + numeric-thread caps.
 
-        Shared by both the local path (Popen env overrides) and the SLURM path
-        (exported inside the batch script), so behaviour is identical across
-        job types.
+        Shared by the local, secure Docker, and SLURM paths so evaluator
+        verbosity and numeric-thread behavior remain consistent.
         """
         env: Dict[str, str] = {
             "SHINKA_EVAL_VERBOSE": "1" if self.config.eval_verbose else "0",
@@ -221,74 +273,35 @@ class JobScheduler:
             return None
         return self._build_eval_env()
 
-    def run(
+    def _submit_job(
         self, exec_fname_t: str, results_dir_t: str
-    ) -> Tuple[Dict[str, Any], float]:
-        job_id: Union[str, ProcessWithLogging]
-        cmd = self._build_command(exec_fname_t, results_dir_t)
-        start_time = time.time()
-
-        if self.job_type == "local":
-            assert isinstance(self.config, LocalJobConfig)
-            job_id = submit_local(
-                results_dir_t,
-                cmd,
-                verbose=self.verbose,
-                env_overrides=self._build_local_env_overrides(),
+    ) -> Union[str, ProcessWithLogging, SecureDockerProcess]:
+        """Submit one evaluation to the backend selected by ``job_type``."""
+        if self.job_type == "secure_docker":
+            assert isinstance(self.config, SecureDockerJobConfig)
+            return submit_secure_docker(
+                log_dir=results_dir_t,
+                program_path=exec_fname_t,
+                eval_program_path=self.config.eval_program_path or "evaluate.py",
+                evaluator_root=self.config.evaluator_root,
+                image=self.config.image,
+                container_executable=self.config.container_executable,
+                extra_cmd_args=self.config.extra_cmd_args,
+                eval_environment=self._build_eval_env(),
+                sandbox_user=self.config.sandbox_user,
+                memory_bytes=self.config.memory_bytes,
+                cpus=self.config.cpus,
+                pids_limit=self.config.pids_limit,
+                open_files_limit=self.config.open_files_limit,
+                max_output_bytes=self.config.max_output_bytes,
+                timeout_seconds=parse_time_to_seconds(self.config.time),
+                tmpfs_bytes=self.config.tmpfs_bytes,
+                result_tmpfs_bytes=self.config.result_tmpfs_bytes,
+                python_executable=self.config.python_executable,
+                require_rootless=self.config.require_rootless,
+                allow_rootful_dedicated_vm=self.config.allow_rootful_dedicated_vm,
             )
-        elif self.job_type == "slurm_docker":
-            assert isinstance(self.config, SlurmDockerJobConfig)
-            job_id = submit_slurm_docker(
-                results_dir_t,
-                cmd,
-                self.config.time,
-                self.config.partition,
-                self.config.cpus,
-                self.config.gpus,
-                self.config.mem,
-                self.config.docker_flags,
-                self.config.image,
-                image_tar_path=self.config.image_tar_path,
-                verbose=self.verbose,
-                eval_env=self._build_eval_env(),
-            )
-        elif self.job_type == "slurm_conda":
-            assert isinstance(self.config, SlurmCondaJobConfig)
-            job_id = submit_slurm_conda(
-                results_dir_t,
-                cmd,
-                self.config.time,
-                self.config.partition,
-                self.config.cpus,
-                self.config.gpus,
-                self.config.mem,
-                self.config.conda_env,
-                self.config.activate_script,
-                self.config.modules,
-                verbose=self.verbose,
-                eval_env=self._build_eval_env(),
-            )
-        else:
-            raise ValueError(f"Unknown job type: {self.job_type}")
 
-        if isinstance(job_id, str):
-            results = monitor_slurm(job_id, results_dir_t)
-        else:
-            results = monitor_local(job_id, results_dir_t)
-
-        end_time = time.time()
-        rtime = end_time - start_time
-
-        # Ensure results is not None
-        if results is None:
-            results = {"correct": {"correct": False}, "metrics": {}}
-
-        return results, rtime
-
-    def submit_async(
-        self, exec_fname_t: str, results_dir_t: str
-    ) -> Union[str, ProcessWithLogging]:
-        """Submit a job asynchronously and return the job ID or process."""
         cmd = self._build_command(exec_fname_t, results_dir_t)
         if self.job_type == "local":
             assert isinstance(self.config, LocalJobConfig)
@@ -298,7 +311,7 @@ class JobScheduler:
                 verbose=self.verbose,
                 env_overrides=self._build_local_env_overrides(),
             )
-        elif self.job_type == "slurm_docker":
+        if self.job_type == "slurm_docker":
             assert isinstance(self.config, SlurmDockerJobConfig)
             return submit_slurm_docker(
                 results_dir_t,
@@ -314,7 +327,7 @@ class JobScheduler:
                 verbose=self.verbose,
                 eval_env=self._build_eval_env(),
             )
-        elif self.job_type == "slurm_conda":
+        if self.job_type == "slurm_conda":
             assert isinstance(self.config, SlurmCondaJobConfig)
             return submit_slurm_conda(
                 results_dir_t,
@@ -332,6 +345,43 @@ class JobScheduler:
             )
         raise ValueError(f"Unknown job type: {self.job_type}")
 
+    def run(
+        self, exec_fname_t: str, results_dir_t: str
+    ) -> Tuple[Dict[str, Any], float]:
+        job_id: Union[str, ProcessWithLogging, SecureDockerProcess]
+        start_time = time.time()
+        job_id = self._submit_job(exec_fname_t, results_dir_t)
+
+        if isinstance(job_id, str):
+            results = monitor_slurm(job_id, results_dir_t)
+        else:
+            timeout = (
+                self.config.time
+                if isinstance(self.config, SecureDockerJobConfig)
+                else None
+            )
+            results = monitor_local(
+                job_id,
+                results_dir_t,
+                verbose=self.verbose,
+                timeout=timeout,
+            )
+
+        end_time = time.time()
+        rtime = end_time - start_time
+
+        # Ensure results is not None
+        if results is None:
+            results = {"correct": {"correct": False}, "metrics": {}}
+
+        return results, rtime
+
+    def submit_async(
+        self, exec_fname_t: str, results_dir_t: str
+    ) -> Union[str, ProcessWithLogging, SecureDockerProcess]:
+        """Submit a job asynchronously and return the job ID or process."""
+        return self._submit_job(exec_fname_t, results_dir_t)
+
     def check_job_status(self, job) -> bool:
         """Check if job is running. Returns True if running, False if done."""
         if self.job_type in ["slurm_docker", "slurm_conda"]:
@@ -342,10 +392,10 @@ class JobScheduler:
                 return status != ""
             return False  # Should not happen with slurm
         else:
-            if isinstance(job.job_id, ProcessWithLogging):
+            if isinstance(job.job_id, (ProcessWithLogging, SecureDockerProcess)):
                 if (
-                    isinstance(self.config, LocalJobConfig)
-                    and self.config.time
+                    isinstance(self.config, (LocalJobConfig, SecureDockerJobConfig))
+                    and getattr(self.config, "time", None)
                     and job.start_time
                 ):
                     timeout = parse_time_to_seconds(self.config.time)
@@ -388,14 +438,16 @@ class JobScheduler:
             return False
 
     def get_job_results(
-        self, job_id: Union[str, ProcessWithLogging], results_dir: str
+        self,
+        job_id: Union[str, ProcessWithLogging, SecureDockerProcess],
+        results_dir: str,
     ) -> Optional[Dict[str, Any]]:
         """Get results from a completed job."""
         if self.job_type in ["slurm_docker", "slurm_conda"]:
             if isinstance(job_id, str):
                 return monitor_slurm(job_id, results_dir, verbose=self.verbose)
         else:
-            if isinstance(job_id, ProcessWithLogging):
+            if isinstance(job_id, (ProcessWithLogging, SecureDockerProcess)):
                 job_id.wait()
                 return monitor_local(
                     job_id,
@@ -407,7 +459,7 @@ class JobScheduler:
 
     async def submit_async_nonblocking(
         self, exec_fname_t: str, results_dir_t: str
-    ) -> Union[str, ProcessWithLogging]:
+    ) -> Union[str, ProcessWithLogging, SecureDockerProcess]:
         """Submit a job asynchronously without blocking the event loop."""
         loop = asyncio.get_event_loop()
 
@@ -422,7 +474,9 @@ class JobScheduler:
         return await loop.run_in_executor(self.executor, self.check_job_status, job)
 
     async def get_job_results_async(
-        self, job_id: Union[str, ProcessWithLogging], results_dir: str
+        self,
+        job_id: Union[str, ProcessWithLogging, SecureDockerProcess],
+        results_dir: str,
     ) -> Optional[Dict[str, Any]]:
         """Async version of getting job results."""
         loop = asyncio.get_event_loop()
@@ -436,7 +490,9 @@ class JobScheduler:
         tasks = [self.check_job_status_async(job) for job in jobs]
         return await asyncio.gather(*tasks, return_exceptions=True)
 
-    async def cancel_job_async(self, job_id: Union[str, ProcessWithLogging]) -> bool:
+    async def cancel_job_async(
+        self, job_id: Union[str, ProcessWithLogging, SecureDockerProcess]
+    ) -> bool:
         """Cancel a running job asynchronously."""
         loop = asyncio.get_event_loop()
 
@@ -454,7 +510,7 @@ class JobScheduler:
                         return result.returncode == 0
                 else:
                     # For local jobs, kill the process
-                    if isinstance(job_id, ProcessWithLogging):
+                    if isinstance(job_id, (ProcessWithLogging, SecureDockerProcess)):
                         job_id.kill()
                         return True
                 return False

--- a/shinka/launch/secure_docker.py
+++ b/shinka/launch/secure_docker.py
@@ -25,8 +25,9 @@ import tarfile
 import tempfile
 import threading
 import uuid
+from collections.abc import Mapping
 from pathlib import Path, PurePosixPath
-from typing import Any, BinaryIO, Mapping, Optional, TextIO
+from typing import Any, BinaryIO, TextIO
 
 _PINNED_IMAGE_RE = re.compile(r"^\S+@sha256:[0-9a-f]{64}$")
 _SAFE_USER_RE = re.compile(r"^[1-9][0-9]*:[1-9][0-9]*$")
@@ -214,7 +215,7 @@ def _default_sandbox_user() -> str:
     return f"{uid}:{gid}"
 
 
-def _validate_sandbox_user(value: Optional[str]) -> str:
+def _validate_sandbox_user(value: str | None) -> str:
     if value is not None and not isinstance(value, str):
         raise SecureDockerError("sandbox_user must be a non-root numeric UID:GID pair")
     user = _default_sandbox_user() if value is None else value.strip()
@@ -291,13 +292,13 @@ def _preflight(
     if (
         platform.system() == "Linux"
         and require_rootless
+        and not allow_rootful_dedicated_vm
         and not any("rootless" in option for option in normalized_options)
     ):
-        if not allow_rootful_dedicated_vm:
-            raise SecureDockerError(
-                "secure_docker requires a rootless Docker engine on Linux. "
-                "Set allow_rootful_dedicated_vm=true only for a dedicated container VM."
-            )
+        raise SecureDockerError(
+            "secure_docker requires a rootless Docker engine on Linux. "
+            "Set allow_rootful_dedicated_vm=true only for a dedicated container VM."
+        )
 
 
 def _safe_eval_environment(values: Mapping[str, str]) -> list[str]:
@@ -578,8 +579,12 @@ class SecureDockerProcess:
         self._transport_limited = threading.Event()
         self._removed = False
         self._cleaned = False
-        self._response_file = tempfile.TemporaryFile(mode="w+b")
-        self._docker_stderr_file = tempfile.TemporaryFile(mode="w+b")
+        # These handles span the attached process lifetime and are closed in
+        # ``cleanup_logging`` rather than a lexical context-manager scope.
+        self._response_file = tempfile.TemporaryFile(mode="w+b")  # noqa: SIM115
+        self._docker_stderr_file = tempfile.TemporaryFile(  # noqa: SIM115
+            mode="w+b"
+        )
         self._threads = (
             threading.Thread(
                 target=self._capture_transport,
@@ -603,16 +608,14 @@ class SecureDockerProcess:
         return self.process.pid
 
     @property
-    def returncode(self) -> Optional[int]:
+    def returncode(self) -> int | None:
         return self.process.returncode
 
     @property
     def output_limited(self) -> bool:
         return self._transport_limited.is_set()
 
-    def _capture_transport(
-        self, pipe: Optional[BinaryIO], file_handle: BinaryIO
-    ) -> None:
+    def _capture_transport(self, pipe: BinaryIO | None, file_handle: BinaryIO) -> None:
         if pipe is None:
             return
         try:
@@ -642,10 +645,10 @@ class SecureDockerProcess:
             self._removed = True
         _remove_container(self.executable, self.container_id)
 
-    def poll(self) -> Optional[int]:
+    def poll(self) -> int | None:
         return self.process.poll()
 
-    def wait(self, timeout: Optional[float] = None) -> int:
+    def wait(self, timeout: float | None = None) -> int:
         return self.process.wait(timeout=timeout)
 
     def kill(self) -> None:
@@ -731,7 +734,7 @@ class SecureDockerProcess:
         self._response_file.seek(0)
         seen: set[str] = set()
         log_bytes = 0
-        metadata: Optional[Mapping[str, Any]] = None
+        metadata: Mapping[str, Any] | None = None
         try:
             with tarfile.open(fileobj=self._response_file, mode="r:") as archive:
                 for member in archive:
@@ -836,12 +839,12 @@ def submit(
     log_dir: str,
     program_path: str,
     eval_program_path: str,
-    evaluator_root: Optional[str],
+    evaluator_root: str | None,
     image: str,
     container_executable: str,
     extra_cmd_args: Mapping[str, Any],
     eval_environment: Mapping[str, str],
-    sandbox_user: Optional[str],
+    sandbox_user: str | None,
     memory_bytes: int,
     cpus: float,
     pids_limit: int,
@@ -927,8 +930,8 @@ def submit(
     if not container_id:
         raise SecureDockerError("Docker did not return a container ID")
 
-    stdout_file: Optional[TextIO] = None
-    stderr_file: Optional[TextIO] = None
+    stdout_file: TextIO | None = None
+    stderr_file: TextIO | None = None
     try:
         _verify_container(
             executable=executable,

--- a/shinka/launch/secure_docker.py
+++ b/shinka/launch/secure_docker.py
@@ -1,0 +1,972 @@
+"""Hardened Docker execution for Shinka's existing single-file evaluators.
+
+This module deliberately preserves the ``evaluate.py --program_path --results_dir``
+contract. It confines that evaluator *and* its one candidate file to one
+networkless container. The host result directory is never mounted into that
+container: a trusted in-container wrapper exports bounded result data over the
+Docker attach stream instead.
+
+This is host containment, not a confidentiality or score-integrity boundary
+between an in-process candidate and its evaluator. A stronger boundary would
+require a different evaluator API.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import threading
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Any, BinaryIO, Mapping, Optional, TextIO
+
+_PINNED_IMAGE_RE = re.compile(r"^\S+@sha256:[0-9a-f]{64}$")
+_SAFE_USER_RE = re.compile(r"^[1-9][0-9]*:[1-9][0-9]*$")
+_SAFE_ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_MAX_RESULT_FILE_BYTES = 8 * 1024 * 1024
+_MAX_META_BYTES = 64 * 1024
+_TRANSPORT_OVERHEAD_BYTES = 1024 * 1024
+_RESULT_FILES = ("metrics.json", "correct.json")
+_LOG_FILES = ("job_log.out", "job_log.err")
+_ARCHIVE_FILES = ("meta.json", "stdout.log", "stderr.log", *_RESULT_FILES)
+
+
+class SecureDockerError(RuntimeError):
+    """Raised when secure Docker preflight or containment fails."""
+
+
+def validate_pinned_image(image: str) -> str:
+    """Require an immutable image digest; tags are never a secure reference."""
+    if not isinstance(image, str):
+        raise SecureDockerError("secure_docker.image must be a string")
+    normalized = image.strip()
+    if not _PINNED_IMAGE_RE.fullmatch(normalized):
+        raise SecureDockerError(
+            "secure_docker.image must be an immutable image digest "
+            "(for example, registry.example/evaluator@sha256:<64-hex-digest>)"
+        )
+    return normalized
+
+
+def _validate_positive_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise SecureDockerError(f"{name} must be a positive integer")
+    return value
+
+
+def _validate_positive_float(name: str, value: float) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise SecureDockerError(f"{name} must be a positive number")
+    return float(value)
+
+
+def _safe_existing_file(value: str | Path, *, label: str) -> Path:
+    source = Path(value).expanduser()
+    if source.is_symlink():
+        raise SecureDockerError(f"{label} cannot be a symlink")
+    try:
+        resolved = source.resolve(strict=True)
+    except OSError as exc:
+        raise SecureDockerError(f"{label} does not exist: {source}") from exc
+    if not resolved.is_file():
+        raise SecureDockerError(f"{label} must be a regular file: {resolved}")
+    return resolved
+
+
+def _safe_existing_directory(value: str | Path, *, label: str) -> Path:
+    source = Path(value).expanduser()
+    if source.is_symlink():
+        raise SecureDockerError(f"{label} cannot be a symlink")
+    try:
+        resolved = source.resolve(strict=True)
+    except OSError as exc:
+        raise SecureDockerError(f"{label} does not exist: {source}") from exc
+    if not resolved.is_dir():
+        raise SecureDockerError(f"{label} must be a directory: {resolved}")
+    return resolved
+
+
+def _validate_read_only_tree(root: Path, *, label: str) -> None:
+    """Reject special files and nested mounts that could escape a read-only bind."""
+    try:
+        for directory, directory_names, file_names in os.walk(root, followlinks=False):
+            directory_path = Path(directory)
+            if directory_path != root and directory_path.is_mount():
+                raise SecureDockerError(
+                    f"{label} cannot contain nested mount points: {directory_path}"
+                )
+            for name in (*directory_names, *file_names):
+                path = directory_path / name
+                if path.is_mount():
+                    raise SecureDockerError(
+                        f"{label} cannot contain nested mount points: {path}"
+                    )
+                mode = path.lstat().st_mode
+                if stat.S_ISFIFO(mode) or stat.S_ISSOCK(mode):
+                    raise SecureDockerError(
+                        f"{label} cannot contain FIFO or socket files: {path}"
+                    )
+                if stat.S_ISBLK(mode) or stat.S_ISCHR(mode):
+                    raise SecureDockerError(
+                        f"{label} cannot contain device files: {path}"
+                    )
+    except OSError as exc:
+        raise SecureDockerError(f"could not inspect {label}") from exc
+
+
+def _safe_results_directory(value: str | Path) -> Path:
+    requested = Path(value).expanduser()
+    requested.mkdir(parents=True, exist_ok=True)
+    if requested.is_symlink():
+        raise SecureDockerError("results directory cannot be a symlink")
+    resolved = requested.resolve(strict=True)
+    if not resolved.is_dir():
+        raise SecureDockerError("results directory must be a directory")
+    if resolved == Path(resolved.anchor):
+        raise SecureDockerError("results directory cannot be the filesystem root")
+    for name in (*_LOG_FILES, *_RESULT_FILES):
+        try:
+            (resolved / name).lstat()
+        except FileNotFoundError:
+            continue
+        raise SecureDockerError(
+            f"results directory already contains {name}; secure_docker requires "
+            "a fresh per-evaluation directory"
+        )
+    return resolved
+
+
+def _open_private_text_output(results_dir: Path, name: str) -> TextIO:
+    """Create a host output file before the container is allowed to start."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(results_dir / name, flags, 0o600)
+    except OSError as exc:
+        raise SecureDockerError(f"could not safely create {name}") from exc
+    return os.fdopen(descriptor, "w", encoding="utf-8", buffering=1)
+
+
+def _open_private_binary_output(results_dir: Path, name: str) -> BinaryIO:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(results_dir / name, flags, 0o600)
+    except OSError as exc:
+        raise SecureDockerError(f"could not safely create {name}") from exc
+    return os.fdopen(descriptor, "wb")
+
+
+def _remove_private_output(results_dir: Path, name: str) -> None:
+    path = results_dir / name
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISREG(metadata.st_mode):
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
+
+def _mount(source: Path, target: str, *, read_only: bool) -> list[str]:
+    source_text = str(source)
+    if "," in source_text or "\x00" in source_text:
+        raise SecureDockerError("container mount source contains an unsafe character")
+    destination = PurePosixPath(target)
+    if not destination.is_absolute() or ".." in destination.parts:
+        raise SecureDockerError(
+            "container mount target must be absolute and normalized"
+        )
+    if "," in str(destination):
+        raise SecureDockerError("container mount target contains an unsafe character")
+    specification = f"type=bind,src={source},dst={destination}"
+    if read_only:
+        specification += ",readonly"
+    return ["--mount", specification]
+
+
+def _default_sandbox_user() -> str:
+    if not hasattr(os, "getuid") or not hasattr(os, "getgid"):
+        raise SecureDockerError(
+            "secure_docker requires sandbox_user on platforms without POSIX user IDs"
+        )
+    uid = os.getuid()
+    gid = os.getgid()
+    if uid == 0 or gid == 0:
+        raise SecureDockerError(
+            "secure_docker refuses to run as root; configure a non-root sandbox_user"
+        )
+    return f"{uid}:{gid}"
+
+
+def _validate_sandbox_user(value: Optional[str]) -> str:
+    if value is not None and not isinstance(value, str):
+        raise SecureDockerError("sandbox_user must be a non-root numeric UID:GID pair")
+    user = _default_sandbox_user() if value is None else value.strip()
+    if not _SAFE_USER_RE.fullmatch(user):
+        raise SecureDockerError(
+            "sandbox_user must be a non-root numeric UID:GID pair, "
+            "for example 1000:1000"
+        )
+    return user
+
+
+def _docker_command(executable: str) -> str:
+    command = executable.strip()
+    if not command:
+        raise SecureDockerError("container_executable cannot be empty")
+    if shutil.which(command) is None:
+        raise SecureDockerError(
+            f"secure_docker requires a Docker-compatible executable: {command}"
+        )
+    return command
+
+
+def _run_checked(
+    argv: list[str],
+    *,
+    timeout: float = 60.0,
+) -> subprocess.CompletedProcess[bytes]:
+    try:
+        completed = subprocess.run(
+            argv,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SecureDockerError("secure Docker preflight could not run") from exc
+    if completed.returncode != 0:
+        diagnostic = completed.stderr.decode("utf-8", errors="replace").strip()
+        detail = f": {diagnostic[-500:]}" if diagnostic else ""
+        raise SecureDockerError(f"secure Docker command was rejected{detail}")
+    return completed
+
+
+def _preflight(
+    *,
+    executable: str,
+    image: str,
+    require_rootless: bool,
+    allow_rootful_dedicated_vm: bool,
+) -> None:
+    inspected_image = _run_checked([executable, "image", "inspect", image])
+    try:
+        image_data = json.loads(inspected_image.stdout)
+        image_config = image_data[0].get("Config") or {}
+    except (IndexError, TypeError, json.JSONDecodeError) as exc:
+        raise SecureDockerError("Docker returned an invalid image inspection") from exc
+    if image_config.get("Volumes"):
+        raise SecureDockerError(
+            "secure_docker images cannot declare Docker volumes; use bounded tmpfs "
+            "storage instead"
+        )
+    info = _run_checked([executable, "info", "--format", "{{json .SecurityOptions}}"])
+    try:
+        options = json.loads(info.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SecureDockerError("Docker returned invalid security options") from exc
+    if not isinstance(options, list):
+        raise SecureDockerError("Docker returned invalid security options")
+    normalized_options = [str(option).lower() for option in options]
+    if not any("seccomp" in option for option in normalized_options):
+        raise SecureDockerError(
+            "secure_docker requires Docker's default seccomp profile"
+        )
+    if (
+        platform.system() == "Linux"
+        and require_rootless
+        and not any("rootless" in option for option in normalized_options)
+    ):
+        if not allow_rootful_dedicated_vm:
+            raise SecureDockerError(
+                "secure_docker requires a rootless Docker engine on Linux. "
+                "Set allow_rootful_dedicated_vm=true only for a dedicated container VM."
+            )
+
+
+def _safe_eval_environment(values: Mapping[str, str]) -> list[str]:
+    result: list[str] = []
+    for name, value in sorted(values.items()):
+        if (
+            not isinstance(name, str)
+            or not isinstance(value, str)
+            or not _SAFE_ENV_NAME_RE.fullmatch(name)
+            or "\x00" in value
+        ):
+            raise SecureDockerError("invalid evaluation environment entry")
+        result.extend(["--env", f"{name}={value}"])
+    return result
+
+
+def build_create_argv(
+    *,
+    executable: str,
+    container_name: str,
+    image: str,
+    evaluator_root: Path,
+    runtime_root: Path,
+    eval_relative_path: PurePosixPath,
+    candidate_path: Path,
+    extra_cmd_args: Mapping[str, Any],
+    eval_environment: Mapping[str, str],
+    sandbox_user: str,
+    memory_bytes: int,
+    cpus: float,
+    pids_limit: int,
+    open_files_limit: int,
+    max_output_bytes: int,
+    timeout_seconds: int,
+    tmpfs_bytes: int,
+    result_tmpfs_bytes: int,
+    python_executable: str,
+) -> list[str]:
+    """Build a shell-free, policy-fixed Docker ``create`` command."""
+    if not container_name.startswith("shinka-secure-eval-"):
+        raise SecureDockerError("secure Docker container name has an invalid prefix")
+    if not python_executable or "/" in python_executable:
+        raise SecureDockerError("python_executable must be a simple executable name")
+
+    candidate_name = candidate_path.name
+    if (
+        not candidate_name
+        or candidate_name != Path(candidate_name).name
+        or "," in candidate_name
+        or "\x00" in candidate_name
+    ):
+        raise SecureDockerError("candidate filename is unsafe")
+
+    evaluator_path = PurePosixPath("/workspace/evaluator") / eval_relative_path
+    candidate_target = PurePosixPath("/workspace/candidate") / candidate_name
+    result_target = PurePosixPath("/workspace/results")
+
+    argv = [
+        executable,
+        "create",
+        "--pull",
+        "never",
+        "--rm",
+        "--name",
+        container_name,
+        "--init",
+        "--network",
+        "none",
+        "--no-healthcheck",
+        "--read-only",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges:true",
+        "--pids-limit",
+        str(pids_limit),
+        "--memory",
+        str(memory_bytes),
+        "--memory-swap",
+        str(memory_bytes),
+        "--cpus",
+        str(cpus),
+        "--ulimit",
+        f"nofile={open_files_limit}:{open_files_limit}",
+        "--user",
+        sandbox_user,
+        "--workdir",
+        "/workspace/evaluator",
+        "--entrypoint",
+        python_executable,
+        "--log-driver",
+        "none",
+        "--label",
+        "io.shinka.managed=true",
+        "--label",
+        "io.shinka.role=single-file-evaluation",
+        "--tmpfs",
+        f"/tmp:rw,nosuid,nodev,size={tmpfs_bytes},mode=1777",
+        "--tmpfs",
+        "/run:rw,nosuid,nodev,noexec,size=16m,mode=755",
+        "--tmpfs",
+        f"/workspace/results:rw,nosuid,nodev,noexec,size={result_tmpfs_bytes},mode=1777",
+        "--env",
+        "HOME=/tmp/home",
+        "--env",
+        "TMPDIR=/tmp",
+        "--env",
+        "XDG_CACHE_HOME=/tmp/cache",
+        "--env",
+        "PYTHONDONTWRITEBYTECODE=1",
+    ]
+    argv.extend(_safe_eval_environment(eval_environment))
+    argv.extend(_mount(evaluator_root, "/workspace/evaluator", read_only=True))
+    argv.extend(_mount(runtime_root, "/workspace/runtime", read_only=True))
+    argv.extend(_mount(candidate_path, str(candidate_target), read_only=True))
+    argv.extend(
+        [
+            image,
+            "/workspace/runtime/secure_runner.py",
+            "--evaluator",
+            str(evaluator_path),
+            "--program-path",
+            str(candidate_target),
+            "--results-dir",
+            str(result_target),
+            "--max-output-bytes",
+            str(max_output_bytes),
+            "--timeout-seconds",
+            str(timeout_seconds),
+            "--max-result-file-bytes",
+            str(_MAX_RESULT_FILE_BYTES),
+            "--",
+        ]
+    )
+    for key, value in extra_cmd_args.items():
+        if not isinstance(key, str) or not key or key.startswith("-"):
+            raise SecureDockerError(
+                "extra_cmd_args keys must be non-empty argument names"
+            )
+        argv.extend([f"--{key}", str(value)])
+    return argv
+
+
+def _inspect_container(executable: str, container_id: str) -> Mapping[str, Any]:
+    raw = _run_checked([executable, "inspect", container_id]).stdout
+    try:
+        parsed = json.loads(raw)
+        return parsed[0]
+    except (IndexError, TypeError, json.JSONDecodeError) as exc:
+        raise SecureDockerError(
+            "Docker returned an invalid container inspection"
+        ) from exc
+
+
+def _verify_container(
+    *,
+    executable: str,
+    container_id: str,
+    image: str,
+    sandbox_user: str,
+    memory_bytes: int,
+    cpus: float,
+    pids_limit: int,
+    open_files_limit: int,
+) -> None:
+    data = _inspect_container(executable, container_id)
+    config = data.get("Config") or {}
+    host = data.get("HostConfig") or {}
+    labels = config.get("Labels") or {}
+    if labels.get("io.shinka.managed") != "true":
+        raise SecureDockerError("secure container is missing its ownership label")
+    if str(config.get("Image", "")) != image:
+        raise SecureDockerError("secure container image differs from the pinned image")
+    if str(config.get("User", "")) != sandbox_user:
+        raise SecureDockerError("secure container user differs from the launch policy")
+    if not host.get("AutoRemove"):
+        raise SecureDockerError(
+            "secure container must be removed automatically after evaluation"
+        )
+    if (host.get("RestartPolicy") or {}).get("Name") not in ("", "no"):
+        raise SecureDockerError("secure container unexpectedly has a restart policy")
+    if host.get("Privileged") or host.get("NetworkMode") != "none":
+        raise SecureDockerError(
+            "secure container has an unsafe privilege or network mode"
+        )
+    if host.get("PidMode") == "host" or host.get("IpcMode") == "host":
+        raise SecureDockerError("secure container shares a host namespace")
+    if host.get("UsernsMode") == "host" or host.get("CgroupnsMode") == "host":
+        raise SecureDockerError("secure container shares an unsafe host namespace")
+    if host.get("Devices") or host.get("DeviceRequests"):
+        raise SecureDockerError("secure container unexpectedly has device access")
+    mounts = data.get("Mounts") or []
+    if not isinstance(mounts, list) or any(
+        isinstance(mount, dict) and mount.get("Type") == "volume" for mount in mounts
+    ):
+        raise SecureDockerError("secure container unexpectedly has a Docker volume")
+    if host.get("Binds"):
+        raise SecureDockerError("secure container unexpectedly has legacy bind mounts")
+    if set(host.get("CapAdd") or []):
+        raise SecureDockerError("secure container unexpectedly adds capabilities")
+    if "ALL" not in set(host.get("CapDrop") or []):
+        raise SecureDockerError("secure container does not drop all capabilities")
+    options = {str(value) for value in host.get("SecurityOpt") or []}
+    if not any(value.startswith("no-new-privileges") for value in options):
+        raise SecureDockerError("secure container lacks no-new-privileges")
+    if not bool(host.get("ReadonlyRootfs")):
+        raise SecureDockerError("secure container root filesystem is writable")
+    if int(host.get("PidsLimit") or 0) != pids_limit:
+        raise SecureDockerError(
+            "secure container PID limit differs from the launch policy"
+        )
+    if int(host.get("Memory") or 0) != memory_bytes:
+        raise SecureDockerError(
+            "secure container memory limit differs from the launch policy"
+        )
+    if int(host.get("MemorySwap") or 0) != memory_bytes:
+        raise SecureDockerError(
+            "secure container swap limit differs from the launch policy"
+        )
+    if int(host.get("NanoCpus") or 0) != int(cpus * 1_000_000_000):
+        raise SecureDockerError(
+            "secure container CPU limit differs from the launch policy"
+        )
+    expected_limit = {("nofile", open_files_limit, open_files_limit)}
+    actual_limit = {
+        (str(item.get("Name")), int(item.get("Soft", 0)), int(item.get("Hard", 0)))
+        for item in host.get("Ulimits") or []
+    }
+    if actual_limit != expected_limit:
+        raise SecureDockerError(
+            "secure container file limit differs from the launch policy"
+        )
+    if (host.get("LogConfig") or {}).get("Type") != "none":
+        raise SecureDockerError("secure container unexpectedly persists Docker logs")
+
+
+def _remove_container(executable: str, container_id: str) -> None:
+    try:
+        subprocess.run(
+            [executable, "rm", "--force", container_id],
+            capture_output=True,
+            timeout=30.0,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        # Do not mask the original evaluator result with best-effort cleanup.
+        pass
+
+
+class SecureDockerProcess:
+    """A Docker-attached process compatible with the local scheduler monitor."""
+
+    def __init__(
+        self,
+        *,
+        process: subprocess.Popen[bytes],
+        executable: str,
+        container_id: str,
+        stdout_file: TextIO,
+        stderr_file: TextIO,
+        max_output_bytes: int,
+        results_dir: Path,
+    ) -> None:
+        self.process = process
+        self.executable = executable
+        self.container_id = container_id
+        self.stdout_file = stdout_file
+        self.stderr_file = stderr_file
+        self.max_output_bytes = max_output_bytes
+        self.results_dir = results_dir
+        self._max_transport_bytes = (
+            max_output_bytes + 2 * _MAX_RESULT_FILE_BYTES + _TRANSPORT_OVERHEAD_BYTES
+        )
+        self._transport_bytes = 0
+        self._transport_lock = threading.Lock()
+        self._remove_lock = threading.Lock()
+        self._cleanup_lock = threading.Lock()
+        self._transport_limited = threading.Event()
+        self._removed = False
+        self._cleaned = False
+        self._response_file = tempfile.TemporaryFile(mode="w+b")
+        self._docker_stderr_file = tempfile.TemporaryFile(mode="w+b")
+        self._threads = (
+            threading.Thread(
+                target=self._capture_transport,
+                args=(process.stdout, self._response_file),
+                daemon=True,
+            ),
+            threading.Thread(
+                target=self._capture_transport,
+                args=(process.stderr, self._docker_stderr_file),
+                daemon=True,
+            ),
+        )
+        for thread in self._threads:
+            thread.start()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.process, name)
+
+    @property
+    def pid(self) -> int:
+        return self.process.pid
+
+    @property
+    def returncode(self) -> Optional[int]:
+        return self.process.returncode
+
+    @property
+    def output_limited(self) -> bool:
+        return self._transport_limited.is_set()
+
+    def _capture_transport(
+        self, pipe: Optional[BinaryIO], file_handle: BinaryIO
+    ) -> None:
+        if pipe is None:
+            return
+        try:
+            while True:
+                chunk = pipe.read(64 * 1024)
+                if not chunk:
+                    return
+                with self._transport_lock:
+                    remaining = self._max_transport_bytes - self._transport_bytes
+                    accepted = chunk[: max(0, remaining)]
+                    self._transport_bytes += len(accepted)
+                    exceeded = len(chunk) > len(accepted)
+                if accepted:
+                    file_handle.write(accepted)
+                    file_handle.flush()
+                if exceeded:
+                    self._transport_limited.set()
+                    self.kill()
+                    return
+        finally:
+            pipe.close()
+
+    def _remove_once(self) -> None:
+        with self._remove_lock:
+            if self._removed:
+                return
+            self._removed = True
+        _remove_container(self.executable, self.container_id)
+
+    def poll(self) -> Optional[int]:
+        return self.process.poll()
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        return self.process.wait(timeout=timeout)
+
+    def kill(self) -> None:
+        self._remove_once()
+        if self.process.poll() is None:
+            try:
+                self.process.kill()
+            except OSError:
+                pass
+
+    def _write_stderr(self, message: str) -> None:
+        self.stderr_file.write(message.rstrip() + "\n")
+        self.stderr_file.flush()
+
+    def _copy_archive_log(
+        self, archive: tarfile.TarFile, member: tarfile.TarInfo
+    ) -> None:
+        source = archive.extractfile(member)
+        if source is None:
+            raise SecureDockerError(f"secure runtime archive lacks {member.name}")
+        destination = (
+            self.stdout_file if member.name == "stdout.log" else self.stderr_file
+        )
+        remaining = member.size
+        while remaining:
+            chunk = source.read(min(64 * 1024, remaining))
+            if not chunk:
+                raise SecureDockerError(
+                    f"secure runtime archive truncates {member.name}"
+                )
+            destination.write(chunk.decode("utf-8", errors="replace"))
+            remaining -= len(chunk)
+        destination.flush()
+
+    def _copy_archive_result(
+        self, archive: tarfile.TarFile, member: tarfile.TarInfo
+    ) -> None:
+        source = archive.extractfile(member)
+        if source is None:
+            raise SecureDockerError(f"secure runtime archive lacks {member.name}")
+        payload = source.read(member.size + 1)
+        if len(payload) != member.size:
+            raise SecureDockerError(f"secure runtime archive truncates {member.name}")
+        try:
+            parsed = json.loads(payload.decode("utf-8"))
+        except (RecursionError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise SecureDockerError(
+                f"secure runtime result {member.name} is not valid JSON"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise SecureDockerError(
+                f"secure runtime result {member.name} must be a JSON object"
+            )
+        destination = _open_private_binary_output(self.results_dir, member.name)
+        try:
+            destination.write(payload)
+        except Exception:
+            destination.close()
+            _remove_private_output(self.results_dir, member.name)
+            raise
+        else:
+            destination.close()
+
+    def _read_archive_meta(
+        self, archive: tarfile.TarFile, member: tarfile.TarInfo
+    ) -> Mapping[str, Any]:
+        source = archive.extractfile(member)
+        if source is None:
+            raise SecureDockerError("secure runtime archive lacks meta.json")
+        payload = source.read(_MAX_META_BYTES + 1)
+        if len(payload) > _MAX_META_BYTES:
+            raise SecureDockerError("secure runtime metadata exceeds its limit")
+        try:
+            parsed = json.loads(payload.decode("utf-8"))
+        except (RecursionError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise SecureDockerError("secure runtime metadata is invalid") from exc
+        if not isinstance(parsed, dict):
+            raise SecureDockerError("secure runtime metadata must be an object")
+        return parsed
+
+    def _decode_response(self) -> None:
+        self._response_file.flush()
+        self._response_file.seek(0)
+        seen: set[str] = set()
+        log_bytes = 0
+        metadata: Optional[Mapping[str, Any]] = None
+        try:
+            with tarfile.open(fileobj=self._response_file, mode="r:") as archive:
+                for member in archive:
+                    if member.name not in _ARCHIVE_FILES or member.name in seen:
+                        raise SecureDockerError(
+                            "secure runtime archive has an invalid entry"
+                        )
+                    if not member.isfile():
+                        raise SecureDockerError(
+                            "secure runtime archive entry is not a file"
+                        )
+                    seen.add(member.name)
+                    if member.name == "meta.json":
+                        metadata = self._read_archive_meta(archive, member)
+                    elif member.name in ("stdout.log", "stderr.log"):
+                        if (
+                            member.size > self.max_output_bytes
+                            or log_bytes + member.size > self.max_output_bytes
+                        ):
+                            raise SecureDockerError(
+                                "secure runtime log output exceeds its limit"
+                            )
+                        self._copy_archive_log(archive, member)
+                        log_bytes += member.size
+                    else:
+                        if member.size > _MAX_RESULT_FILE_BYTES:
+                            raise SecureDockerError(
+                                f"secure runtime result {member.name} exceeds its limit"
+                            )
+                        self._copy_archive_result(archive, member)
+            if metadata is None:
+                raise SecureDockerError("secure runtime did not emit metadata")
+        except (OSError, RecursionError, SecureDockerError, tarfile.TarError) as exc:
+            for name in _RESULT_FILES:
+                _remove_private_output(self.results_dir, name)
+            self._write_stderr(f"secure_docker: rejected runtime response: {exc}")
+            return
+
+        if metadata.get("output_limited"):
+            self._write_stderr(
+                "secure_docker: evaluation output exceeded its configured limit."
+            )
+        if metadata.get("timed_out"):
+            self._write_stderr(
+                "secure_docker: evaluation exceeded its configured wall-time limit."
+            )
+        return_code = metadata.get("returncode")
+        if isinstance(return_code, int) and return_code != 0:
+            self._write_stderr(
+                f"secure_docker: evaluator exited with return code {return_code}."
+            )
+        wrapper_error = metadata.get("error")
+        if isinstance(wrapper_error, str) and wrapper_error:
+            self._write_stderr(f"secure_docker: runtime error: {wrapper_error}")
+
+    def _append_docker_stderr(self) -> None:
+        self._docker_stderr_file.flush()
+        self._docker_stderr_file.seek(0)
+        data = self._docker_stderr_file.read()
+        if data:
+            self._write_stderr(
+                "secure_docker transport stderr:\n"
+                + data.decode("utf-8", errors="replace")
+            )
+
+    def cleanup_logging(self) -> None:
+        with self._cleanup_lock:
+            if self._cleaned:
+                return
+            self._cleaned = True
+
+        for thread in self._threads:
+            thread.join(timeout=2.0)
+        # ``docker start --attach`` should return only after the container exits,
+        # but remove it before parsing output so a malformed attach never leaves
+        # candidate code running while host files are being promoted.
+        self._remove_once()
+        try:
+            if self.output_limited:
+                self._write_stderr(
+                    "secure_docker: runtime transport exceeded its configured limit; "
+                    "container was terminated."
+                )
+            else:
+                self._decode_response()
+            self._append_docker_stderr()
+        finally:
+            for file_handle in (self._response_file, self._docker_stderr_file):
+                try:
+                    file_handle.close()
+                except OSError:
+                    pass
+            for file_handle in (self.stdout_file, self.stderr_file):
+                try:
+                    file_handle.close()
+                except OSError:
+                    pass
+
+
+def submit(
+    *,
+    log_dir: str,
+    program_path: str,
+    eval_program_path: str,
+    evaluator_root: Optional[str],
+    image: str,
+    container_executable: str,
+    extra_cmd_args: Mapping[str, Any],
+    eval_environment: Mapping[str, str],
+    sandbox_user: Optional[str],
+    memory_bytes: int,
+    cpus: float,
+    pids_limit: int,
+    open_files_limit: int,
+    max_output_bytes: int,
+    timeout_seconds: int,
+    tmpfs_bytes: int,
+    result_tmpfs_bytes: int,
+    python_executable: str,
+    require_rootless: bool,
+    allow_rootful_dedicated_vm: bool,
+) -> SecureDockerProcess:
+    """Launch one hardened evaluation container without invoking a shell."""
+    executable = _docker_command(container_executable)
+    immutable_image = validate_pinned_image(image)
+    candidate = _safe_existing_file(program_path, label="candidate program")
+    if candidate.is_mount():
+        raise SecureDockerError("candidate program cannot be a mount point")
+    evaluator = _safe_existing_file(eval_program_path, label="evaluation script")
+    root = _safe_existing_directory(
+        evaluator_root or str(evaluator.parent), label="evaluator_root"
+    )
+    if root == Path(root.anchor):
+        raise SecureDockerError("evaluator_root cannot be the filesystem root")
+    runtime_root = _safe_existing_directory(
+        Path(__file__).parent, label="secure runtime"
+    )
+    _validate_read_only_tree(root, label="evaluator_root")
+    _validate_read_only_tree(runtime_root, label="secure runtime")
+    try:
+        relative_evaluator = PurePosixPath(evaluator.relative_to(root).as_posix())
+    except ValueError as exc:
+        raise SecureDockerError(
+            "evaluation script must be contained by evaluator_root"
+        ) from exc
+    results = _safe_results_directory(log_dir)
+    user = _validate_sandbox_user(sandbox_user)
+    memory = _validate_positive_int("memory_bytes", memory_bytes)
+    cpu_limit = _validate_positive_float("cpus", cpus)
+    pids = _validate_positive_int("pids_limit", pids_limit)
+    open_files = _validate_positive_int("open_files_limit", open_files_limit)
+    output_limit = _validate_positive_int("max_output_bytes", max_output_bytes)
+    runtime_timeout = _validate_positive_int("timeout_seconds", timeout_seconds)
+    tmpfs_limit = _validate_positive_int("tmpfs_bytes", tmpfs_bytes)
+    result_tmpfs_limit = _validate_positive_int(
+        "result_tmpfs_bytes", result_tmpfs_bytes
+    )
+    if result_tmpfs_limit < _MAX_RESULT_FILE_BYTES:
+        raise SecureDockerError(
+            "result_tmpfs_bytes must accommodate at least one bounded result file"
+        )
+
+    _preflight(
+        executable=executable,
+        image=immutable_image,
+        require_rootless=require_rootless,
+        allow_rootful_dedicated_vm=allow_rootful_dedicated_vm,
+    )
+    name = f"shinka-secure-eval-{uuid.uuid4().hex[:20]}"
+    create_argv = build_create_argv(
+        executable=executable,
+        container_name=name,
+        image=immutable_image,
+        evaluator_root=root,
+        runtime_root=runtime_root,
+        eval_relative_path=relative_evaluator,
+        candidate_path=candidate,
+        extra_cmd_args=extra_cmd_args,
+        eval_environment=eval_environment,
+        sandbox_user=user,
+        memory_bytes=memory,
+        cpus=cpu_limit,
+        pids_limit=pids,
+        open_files_limit=open_files,
+        max_output_bytes=output_limit,
+        timeout_seconds=runtime_timeout,
+        tmpfs_bytes=tmpfs_limit,
+        result_tmpfs_bytes=result_tmpfs_limit,
+        python_executable=python_executable,
+    )
+    created = _run_checked(create_argv, timeout=120.0)
+    container_id = created.stdout.decode("utf-8", errors="replace").strip()
+    if not container_id:
+        raise SecureDockerError("Docker did not return a container ID")
+
+    stdout_file: Optional[TextIO] = None
+    stderr_file: Optional[TextIO] = None
+    try:
+        _verify_container(
+            executable=executable,
+            container_id=container_id,
+            image=immutable_image,
+            sandbox_user=user,
+            memory_bytes=memory,
+            cpus=cpu_limit,
+            pids_limit=pids,
+            open_files_limit=open_files,
+        )
+        # The container never receives this host directory. Opening these files
+        # before ``docker start`` also avoids symlink races on error paths.
+        stdout_file = _open_private_text_output(results, "job_log.out")
+        stderr_file = _open_private_text_output(results, "job_log.err")
+        process = subprocess.Popen(
+            [executable, "start", "--attach", container_id],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        return SecureDockerProcess(
+            process=process,
+            executable=executable,
+            container_id=container_id,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file,
+            max_output_bytes=output_limit,
+            results_dir=results,
+        )
+    except Exception:
+        for file_handle in (stdout_file, stderr_file):
+            if file_handle is not None:
+                try:
+                    file_handle.close()
+                except OSError:
+                    pass
+        for output_name in _LOG_FILES:
+            _remove_private_output(results, output_name)
+        _remove_container(executable, container_id)
+        raise

--- a/shinka/launch/secure_runner.py
+++ b/shinka/launch/secure_runner.py
@@ -20,7 +20,7 @@ import tarfile
 import tempfile
 import threading
 from pathlib import Path
-from typing import BinaryIO, Optional
+from typing import BinaryIO
 
 _CHUNK_SIZE = 64 * 1024
 _RESULT_FILES = ("metrics.json", "correct.json")
@@ -58,7 +58,7 @@ def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
 
 
 def _capture_stream(
-    pipe: Optional[BinaryIO],
+    pipe: BinaryIO | None,
     destination: BinaryIO,
     budget: _OutputBudget,
     process: subprocess.Popen[bytes],
@@ -105,7 +105,7 @@ def _add_open_file(
     archive.addfile(info, file_handle)
 
 
-def _read_regular_result(path: Path, max_bytes: int) -> Optional[bytes]:
+def _read_regular_result(path: Path, max_bytes: int) -> bytes | None:
     try:
         initial = path.lstat()
     except FileNotFoundError:
@@ -164,7 +164,7 @@ def main() -> int:
         tempfile.TemporaryFile(mode="w+b") as stdout_capture,
         tempfile.TemporaryFile(mode="w+b") as stderr_capture,
     ):
-        process: Optional[subprocess.Popen[bytes]] = None
+        process: subprocess.Popen[bytes] | None = None
         try:
             process = subprocess.Popen(
                 [

--- a/shinka/launch/secure_runner.py
+++ b/shinka/launch/secure_runner.py
@@ -1,0 +1,262 @@
+"""Trusted in-container wrapper for secure single-file evaluation.
+
+It preserves the evaluator's public CLI, captures its output with a fixed
+budget, and emits a bounded tar response for the host launcher. This file uses
+only the Python standard library because it is mounted into the evaluator image
+at runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import signal
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+from pathlib import Path
+from typing import BinaryIO, Optional
+
+_CHUNK_SIZE = 64 * 1024
+_RESULT_FILES = ("metrics.json", "correct.json")
+
+
+class _OutputBudget:
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self.used = 0
+        self.limited = False
+        self.lock = threading.Lock()
+
+    def take(self, data: bytes) -> tuple[bytes, bool]:
+        with self.lock:
+            remaining = self.limit - self.used
+            accepted = data[: max(0, remaining)]
+            self.used += len(accepted)
+            exceeded = len(data) > len(accepted)
+            if exceeded:
+                self.limited = True
+            return accepted, exceeded
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    if hasattr(os, "killpg"):
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+            return
+        except (PermissionError, ProcessLookupError):
+            pass
+    try:
+        process.kill()
+    except OSError:
+        pass
+
+
+def _capture_stream(
+    pipe: Optional[BinaryIO],
+    destination: BinaryIO,
+    budget: _OutputBudget,
+    process: subprocess.Popen[bytes],
+) -> None:
+    if pipe is None:
+        return
+    try:
+        while True:
+            data = pipe.read(_CHUNK_SIZE)
+            if not data:
+                return
+            accepted, exceeded = budget.take(data)
+            if accepted:
+                destination.write(accepted)
+            if exceeded:
+                _terminate_process_group(process)
+                return
+    except (OSError, ValueError):
+        return
+    finally:
+        try:
+            pipe.close()
+        except (OSError, ValueError):
+            pass
+
+
+def _add_bytes(archive: tarfile.TarFile, name: str, value: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(value)
+    info.mode = 0o600
+    archive.addfile(info, io.BytesIO(value))
+
+
+def _add_open_file(
+    archive: tarfile.TarFile,
+    name: str,
+    file_handle: BinaryIO,
+    size: int,
+) -> None:
+    file_handle.seek(0)
+    info = tarfile.TarInfo(name)
+    info.size = size
+    info.mode = 0o600
+    archive.addfile(info, file_handle)
+
+
+def _read_regular_result(path: Path, max_bytes: int) -> Optional[bytes]:
+    try:
+        initial = path.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(initial.st_mode) or initial.st_size > max_bytes:
+        return None
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return None
+    with os.fdopen(descriptor, "rb") as result_file:
+        current = os.fstat(result_file.fileno())
+        if (
+            not stat.S_ISREG(current.st_mode)
+            or current.st_dev != initial.st_dev
+            or current.st_ino != initial.st_ino
+            or current.st_size > max_bytes
+        ):
+            return None
+        value = result_file.read(max_bytes + 1)
+        return value if len(value) <= max_bytes else None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evaluator", required=True)
+    parser.add_argument("--program-path", required=True)
+    parser.add_argument("--results-dir", required=True)
+    parser.add_argument("--max-output-bytes", required=True, type=int)
+    parser.add_argument("--timeout-seconds", required=True, type=int)
+    parser.add_argument("--max-result-file-bytes", required=True, type=int)
+    parser.add_argument("extra_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if (
+        args.max_output_bytes <= 0
+        or args.timeout_seconds <= 0
+        or args.max_result_file_bytes <= 0
+    ):
+        parser.error("output limits must be positive")
+    if args.extra_args[:1] == ["--"]:
+        args.extra_args = args.extra_args[1:]
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+    metadata: dict[str, object] = {
+        "returncode": 127,
+        "output_limited": False,
+        "timed_out": False,
+    }
+    Path(args.results_dir).mkdir(parents=True, exist_ok=True)
+    with (
+        tempfile.TemporaryFile(mode="w+b") as stdout_capture,
+        tempfile.TemporaryFile(mode="w+b") as stderr_capture,
+    ):
+        process: Optional[subprocess.Popen[bytes]] = None
+        try:
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    args.evaluator,
+                    "--program_path",
+                    args.program_path,
+                    "--results_dir",
+                    args.results_dir,
+                    *args.extra_args,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+            budget = _OutputBudget(args.max_output_bytes)
+            threads = (
+                threading.Thread(
+                    target=_capture_stream,
+                    args=(process.stdout, stdout_capture, budget, process),
+                    daemon=True,
+                ),
+                threading.Thread(
+                    target=_capture_stream,
+                    args=(process.stderr, stderr_capture, budget, process),
+                    daemon=True,
+                ),
+            )
+            for thread in threads:
+                thread.start()
+            try:
+                return_code = process.wait(timeout=args.timeout_seconds)
+            except subprocess.TimeoutExpired:
+                _terminate_process_group(process)
+                return_code = process.wait()
+                metadata["timed_out"] = True
+            # A legacy evaluator can leave descendants behind. They must not
+            # keep the capture pipes open or race result export after their
+            # immediate parent has exited.
+            _terminate_process_group(process)
+            for thread in threads:
+                thread.join(timeout=1.0)
+            if any(thread.is_alive() for thread in threads):
+                # An adversarial child can leave a pipe open after escaping the
+                # evaluator process group. Do not let that block the wrapper
+                # indefinitely; Docker tears down the remaining container
+                # processes when this wrapper exits.
+                for pipe in (process.stdout, process.stderr):
+                    if pipe is not None:
+                        try:
+                            pipe.close()
+                        except (OSError, ValueError):
+                            pass
+                metadata["error"] = "evaluator left an output pipe open"
+                metadata["output_limited"] = True
+            metadata["returncode"] = return_code
+            metadata["output_limited"] = (
+                bool(metadata["output_limited"]) or budget.limited
+            )
+        except OSError as exc:
+            metadata["error"] = str(exc)
+        finally:
+            if process is not None:
+                _terminate_process_group(process)
+
+        with tarfile.open(fileobj=sys.stdout.buffer, mode="w|") as archive:
+            _add_bytes(
+                archive,
+                "meta.json",
+                json.dumps(metadata, sort_keys=True).encode("utf-8"),
+            )
+            _add_open_file(
+                archive,
+                "stdout.log",
+                stdout_capture,
+                stdout_capture.tell(),
+            )
+            _add_open_file(
+                archive,
+                "stderr.log",
+                stderr_capture,
+                stderr_capture.tell(),
+            )
+            results_dir = Path(args.results_dir)
+            for name in _RESULT_FILES:
+                value = _read_regular_result(
+                    results_dir / name, args.max_result_file_bytes
+                )
+                if value is not None:
+                    _add_bytes(archive, name, value)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_secure_docker.py
+++ b/tests/test_secure_docker.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from shinka.launch import JobScheduler, SecureDockerJobConfig
+from shinka.launch.secure_docker import (
+    SecureDockerError,
+    SecureDockerProcess,
+    _validate_read_only_tree,
+    build_create_argv,
+    submit,
+    validate_pinned_image,
+)
+
+IMAGE = "registry.example/shinka/evaluator@sha256:" + "a" * 64
+
+
+def _value_after(argv: list[str], flag: str) -> str:
+    return argv[argv.index(flag) + 1]
+
+
+def _tar_response(entries: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for name, value in entries.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(value)
+            archive.addfile(info, io.BytesIO(value))
+    return buffer.getvalue()
+
+
+def test_pinned_image_rejects_mutable_references() -> None:
+    assert validate_pinned_image(IMAGE) == IMAGE
+    with pytest.raises(SecureDockerError, match="immutable image digest"):
+        validate_pinned_image("python:3.12")
+
+
+def test_preflight_rejects_images_with_writable_docker_volumes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run_checked(
+        argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert argv[:3] == ["docker", "image", "inspect"]
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=b'[{"Config": {"Volumes": {"/data": {}}}}]',
+        )
+
+    monkeypatch.setattr("shinka.launch.secure_docker._run_checked", fake_run_checked)
+    with pytest.raises(SecureDockerError, match="cannot declare Docker volumes"):
+        from shinka.launch.secure_docker import _preflight
+
+        _preflight(
+            executable="docker",
+            image=IMAGE,
+            require_rootless=False,
+            allow_rootful_dedicated_vm=False,
+        )
+
+
+def test_preflight_requires_seccomp_support(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run_checked(
+        argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        if argv[:3] == ["docker", "image", "inspect"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                stdout=b'[{"Config": {}}]',
+            )
+        assert argv[:2] == ["docker", "info"]
+        return subprocess.CompletedProcess(argv, 0, stdout=b'["rootless"]')
+
+    monkeypatch.setattr("shinka.launch.secure_docker._run_checked", fake_run_checked)
+    with pytest.raises(SecureDockerError, match="default seccomp"):
+        from shinka.launch.secure_docker import _preflight
+
+        _preflight(
+            executable="docker",
+            image=IMAGE,
+            require_rootless=False,
+            allow_rootful_dedicated_vm=False,
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
+def test_evaluator_tree_rejects_special_files(tmp_path: Path) -> None:
+    os.mkfifo(tmp_path / "service.pipe")
+    with pytest.raises(SecureDockerError, match="FIFO or socket"):
+        _validate_read_only_tree(tmp_path, label="evaluator_root")
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        ".py",
+        ".go",
+        ".jl",
+        ".f90",
+        ".sv",
+        ".rs",
+        ".swift",
+        ".cpp",
+        ".cc",
+        ".cxx",
+        ".cu",
+        ".json",
+        ".wl",
+        ".f95",
+        ".f03",
+        ".f08",
+    ],
+)
+def test_create_command_preserves_single_file_candidate_contract(
+    tmp_path: Path, suffix: str
+) -> None:
+    evaluator_root = tmp_path / "task"
+    evaluator_root.mkdir()
+    evaluator = evaluator_root / "evaluate.py"
+    evaluator.write_text("# trusted evaluator\n", encoding="utf-8")
+    candidate = tmp_path / f"main{suffix}"
+    candidate.write_text("candidate\n", encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+
+    argv = build_create_argv(
+        executable="docker",
+        container_name="shinka-secure-eval-0123456789abcdef",
+        image=IMAGE,
+        evaluator_root=evaluator_root,
+        runtime_root=runtime_root,
+        eval_relative_path=Path("evaluate.py"),
+        candidate_path=candidate,
+        extra_cmd_args={"case_count": 10},
+        eval_environment={"SHINKA_EVAL_VERBOSE": "0"},
+        sandbox_user="1000:1000",
+        memory_bytes=512 * 1024 * 1024,
+        cpus=1.5,
+        pids_limit=64,
+        open_files_limit=128,
+        max_output_bytes=1024,
+        timeout_seconds=300,
+        tmpfs_bytes=64 * 1024 * 1024,
+        result_tmpfs_bytes=16 * 1024 * 1024,
+        python_executable="python",
+    )
+
+    assert ["--network", "none"] == [
+        "--network",
+        _value_after(argv, "--network"),
+    ]
+    assert "--no-healthcheck" in argv
+    assert _value_after(argv, "--pull") == "never"
+    assert "--rm" in argv
+    assert "--read-only" in argv
+    assert ["--cap-drop", "ALL"] == ["--cap-drop", _value_after(argv, "--cap-drop")]
+    assert ["--security-opt", "no-new-privileges:true"] == [
+        "--security-opt",
+        _value_after(argv, "--security-opt"),
+    ]
+    assert _value_after(argv, "--user") == "1000:1000"
+    assert _value_after(argv, "--memory") == str(512 * 1024 * 1024)
+    assert _value_after(argv, "--memory-swap") == str(512 * 1024 * 1024)
+    assert _value_after(argv, "--cpus") == "1.5"
+    assert _value_after(argv, "--pids-limit") == "64"
+    assert _value_after(argv, "--log-driver") == "none"
+    mounts = [argv[index + 1] for index, value in enumerate(argv) if value == "--mount"]
+    assert f"src={evaluator_root},dst=/workspace/evaluator,readonly" in mounts[0]
+    assert f"src={runtime_root},dst=/workspace/runtime,readonly" in mounts[1]
+    assert (
+        f"src={candidate},dst=/workspace/candidate/main{suffix},readonly" in mounts[2]
+    )
+    assert all("/workspace/results" not in mount for mount in mounts)
+    assert any(
+        value.startswith("/workspace/results:rw,nosuid,nodev,noexec,size=")
+        for value in argv
+    )
+    assert argv[argv.index(IMAGE) :] == [
+        IMAGE,
+        "/workspace/runtime/secure_runner.py",
+        "--evaluator",
+        "/workspace/evaluator/evaluate.py",
+        "--program-path",
+        f"/workspace/candidate/main{suffix}",
+        "--results-dir",
+        "/workspace/results",
+        "--max-output-bytes",
+        "1024",
+        "--timeout-seconds",
+        "300",
+        "--max-result-file-bytes",
+        str(8 * 1024 * 1024),
+        "--",
+        "--case_count",
+        "10",
+    ]
+
+
+def test_secure_config_requires_an_image() -> None:
+    with pytest.raises(ValueError, match="image is required"):
+        SecureDockerJobConfig()
+    with pytest.raises(ValueError, match="time must be positive"):
+        SecureDockerJobConfig(image=IMAGE, time="00:00:00")
+
+
+def test_submit_uses_create_inspect_start_without_a_shell(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    evaluator = tmp_path / "evaluate.py"
+    candidate = tmp_path / "main.go"
+    results = tmp_path / "results"
+    evaluator.write_text("# evaluator\n", encoding="utf-8")
+    candidate.write_text("package main\n", encoding="utf-8")
+    created_commands: list[list[str]] = []
+    start_commands: list[list[str]] = []
+    removed: list[str] = []
+
+    class FakePopen:
+        pid = 123
+        returncode = 0
+
+        def __init__(self, argv: list[str], **kwargs: object) -> None:
+            start_commands.append(argv)
+            self.stdout = io.BytesIO(
+                _tar_response(
+                    {
+                        "meta.json": json.dumps(
+                            {
+                                "returncode": 0,
+                                "output_limited": False,
+                                "timed_out": False,
+                            }
+                        ).encode(),
+                        "stdout.log": b"evaluator output\n",
+                        "stderr.log": b"",
+                        "metrics.json": b'{"score": 1}',
+                        "correct.json": b'{"correct": true}',
+                    }
+                )
+            )
+            self.stderr = io.BytesIO()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    def fake_run_checked(
+        argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        created_commands.append(argv)
+        assert argv[1] == "create"
+        return subprocess.CompletedProcess(argv, 0, stdout=b"container-id\n")
+
+    monkeypatch.setattr(
+        "shinka.launch.secure_docker._docker_command", lambda _: "docker"
+    )
+    monkeypatch.setattr("shinka.launch.secure_docker._preflight", lambda **_: None)
+    monkeypatch.setattr("shinka.launch.secure_docker._run_checked", fake_run_checked)
+    monkeypatch.setattr(
+        "shinka.launch.secure_docker._verify_container", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "shinka.launch.secure_docker._remove_container",
+        lambda _, cid: removed.append(cid),
+    )
+    monkeypatch.setattr("shinka.launch.secure_docker.subprocess.Popen", FakePopen)
+
+    process = submit(
+        log_dir=str(results),
+        program_path=str(candidate),
+        eval_program_path=str(evaluator),
+        evaluator_root=None,
+        image=IMAGE,
+        container_executable="docker",
+        extra_cmd_args={},
+        eval_environment={"SHINKA_EVAL_VERBOSE": "1"},
+        sandbox_user="1000:1000",
+        memory_bytes=512 * 1024 * 1024,
+        cpus=1.0,
+        pids_limit=64,
+        open_files_limit=128,
+        max_output_bytes=1024,
+        timeout_seconds=300,
+        tmpfs_bytes=64 * 1024 * 1024,
+        result_tmpfs_bytes=16 * 1024 * 1024,
+        python_executable="python",
+        require_rootless=True,
+        allow_rootful_dedicated_vm=False,
+    )
+
+    process.cleanup_logging()
+
+    assert created_commands and created_commands[0][:2] == ["docker", "create"]
+    assert start_commands == [["docker", "start", "--attach", "container-id"]]
+    assert removed == ["container-id"]
+    assert (results / "job_log.out").read_text(encoding="utf-8") == "evaluator output\n"
+    assert json.loads((results / "metrics.json").read_text(encoding="utf-8")) == {
+        "score": 1
+    }
+
+
+def test_secure_runner_preserves_evaluator_cli_contract(tmp_path: Path) -> None:
+    evaluator = tmp_path / "evaluate.py"
+    candidate = tmp_path / "main.f90"
+    results = tmp_path / "results"
+    evaluator.write_text(
+        """
+import argparse
+import json
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--program_path', required=True)
+parser.add_argument('--results_dir', required=True)
+parser.add_argument('--marker', required=True)
+args = parser.parse_args()
+assert Path(args.program_path).name == 'main.f90'
+assert args.marker == 'kept'
+Path(args.results_dir).mkdir(parents=True, exist_ok=True)
+Path(args.results_dir, 'metrics.json').write_text(json.dumps({'score': 3}))
+Path(args.results_dir, 'correct.json').write_text(json.dumps({'correct': True}))
+print('evaluator stdout')
+""",
+        encoding="utf-8",
+    )
+    candidate.write_text("program main\nend program main\n", encoding="utf-8")
+    secure_runner = Path(__file__).parents[1] / "shinka/launch/secure_runner.py"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(secure_runner),
+            "--evaluator",
+            str(evaluator),
+            "--program-path",
+            str(candidate),
+            "--results-dir",
+            str(results),
+            "--max-output-bytes",
+            "1024",
+            "--timeout-seconds",
+            "30",
+            "--max-result-file-bytes",
+            "1024",
+            "--",
+            "--marker",
+            "kept",
+        ],
+        capture_output=True,
+        check=True,
+    )
+    with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
+        entries = {
+            member.name: archive.extractfile(member).read()
+            for member in archive
+            if member.isfile()
+        }
+
+    assert json.loads(entries["meta.json"]) == {
+        "output_limited": False,
+        "returncode": 0,
+        "timed_out": False,
+    }
+    assert entries["stdout.log"] == b"evaluator stdout\n"
+    assert json.loads(entries["metrics.json"]) == {"score": 3}
+    assert json.loads(entries["correct.json"]) == {"correct": True}
+
+
+def test_secure_runner_enforces_its_own_wall_time(tmp_path: Path) -> None:
+    evaluator = tmp_path / "evaluate.py"
+    candidate = tmp_path / "main.py"
+    results = tmp_path / "results"
+    evaluator.write_text(
+        "import time\ntime.sleep(5)\n",
+        encoding="utf-8",
+    )
+    candidate.write_text("print('candidate')\n", encoding="utf-8")
+    secure_runner = Path(__file__).parents[1] / "shinka/launch/secure_runner.py"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(secure_runner),
+            "--evaluator",
+            str(evaluator),
+            "--program-path",
+            str(candidate),
+            "--results-dir",
+            str(results),
+            "--max-output-bytes",
+            "1024",
+            "--timeout-seconds",
+            "1",
+            "--max-result-file-bytes",
+            "1024",
+        ],
+        capture_output=True,
+        check=True,
+        timeout=10,
+    )
+    with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
+        metadata = json.loads(archive.extractfile("meta.json").read())
+
+    assert metadata["timed_out"] is True
+    assert metadata["returncode"] != 0
+
+
+def test_host_rejects_nonregular_runtime_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    archive_buffer = io.BytesIO()
+    with tarfile.open(fileobj=archive_buffer, mode="w") as archive:
+        for name, value in {
+            "meta.json": b'{"returncode": 0, "output_limited": false}',
+            "stdout.log": b"",
+            "stderr.log": b"",
+        }.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(value)
+            archive.addfile(info, io.BytesIO(value))
+        link = tarfile.TarInfo("metrics.json")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        archive.addfile(link)
+
+    class FinishedProcess:
+        pid = 321
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.stdout = io.BytesIO(archive_buffer.getvalue())
+            self.stderr = io.BytesIO()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    results = tmp_path / "results"
+    results.mkdir()
+    monkeypatch.setattr(
+        "shinka.launch.secure_docker._remove_container", lambda *_: None
+    )
+    process = SecureDockerProcess(
+        process=FinishedProcess(),  # type: ignore[arg-type]
+        executable="docker",
+        container_id="container-id",
+        stdout_file=(results / "job_log.out").open("w", encoding="utf-8"),
+        stderr_file=(results / "job_log.err").open("w", encoding="utf-8"),
+        max_output_bytes=1024,
+        results_dir=results,
+    )
+
+    process.cleanup_logging()
+
+    assert not (results / "metrics.json").exists()
+    assert "rejected runtime response" in (results / "job_log.err").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_host_validates_result_json_before_promoting_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FinishedProcess:
+        pid = 321
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.stdout = io.BytesIO(
+                _tar_response(
+                    {
+                        "meta.json": b'{"returncode": 0}',
+                        "stdout.log": b"",
+                        "stderr.log": b"",
+                        "metrics.json": b"[]",
+                    }
+                )
+            )
+            self.stderr = io.BytesIO()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    results = tmp_path / "results"
+    results.mkdir()
+    monkeypatch.setattr(
+        "shinka.launch.secure_docker._remove_container", lambda *_: None
+    )
+    process = SecureDockerProcess(
+        process=FinishedProcess(),  # type: ignore[arg-type]
+        executable="docker",
+        container_id="container-id",
+        stdout_file=(results / "job_log.out").open("w", encoding="utf-8"),
+        stderr_file=(results / "job_log.err").open("w", encoding="utf-8"),
+        max_output_bytes=1024,
+        results_dir=results,
+    )
+
+    process.cleanup_logging()
+
+    assert not (results / "metrics.json").exists()
+    assert "rejected runtime response" in (results / "job_log.err").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_scheduler_submits_secure_container_with_legacy_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    process = object()
+
+    def fake_submit(**kwargs):  # type: ignore[no-untyped-def]
+        captured.update(kwargs)
+        return process
+
+    monkeypatch.setattr("shinka.launch.scheduler.submit_secure_docker", fake_submit)
+    scheduler = JobScheduler(
+        job_type="secure_docker",
+        config=SecureDockerJobConfig(
+            image=IMAGE,
+            evaluator_root="/trusted/task",
+            extra_cmd_args={"seed": 42},
+            numeric_threads_per_job=2,
+        ),
+    )
+
+    submitted = scheduler.submit_async("/candidate/main.go", "/results/gen_1")
+
+    assert submitted is process
+    assert captured["program_path"] == "/candidate/main.go"
+    assert captured["eval_program_path"] == "evaluate.py"
+    assert captured["evaluator_root"] == "/trusted/task"
+    assert captured["extra_cmd_args"] == {"seed": 42}
+    assert captured["result_tmpfs_bytes"] == 64 * 1024 * 1024
+    assert captured["timeout_seconds"] == 300
+    assert captured["eval_environment"] == {
+        "SHINKA_EVAL_VERBOSE": "1",
+        "OMP_NUM_THREADS": "2",
+        "OMP_THREAD_LIMIT": "2",
+        "OMP_DYNAMIC": "FALSE",
+        "OMP_WAIT_POLICY": "PASSIVE",
+        "OPENBLAS_NUM_THREADS": "2",
+        "MKL_NUM_THREADS": "2",
+        "MKL_DYNAMIC": "FALSE",
+        "NUMEXPR_NUM_THREADS": "2",
+        "NUMEXPR_MAX_THREADS": "2",
+        "VECLIB_MAXIMUM_THREADS": "2",
+        "BLIS_NUM_THREADS": "2",
+        "GOTO_NUM_THREADS": "2",
+    }

--- a/tests/test_secure_docker.py
+++ b/tests/test_secure_docker.py
@@ -365,11 +365,12 @@ print('evaluator stdout')
         check=True,
     )
     with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
-        entries = {
-            member.name: archive.extractfile(member).read()
-            for member in archive
-            if member.isfile()
-        }
+        entries: dict[str, bytes] = {}
+        for member in archive:
+            if member.isfile():
+                source = archive.extractfile(member)
+                assert source is not None
+                entries[member.name] = source.read()
 
     assert json.loads(entries["meta.json"]) == {
         "output_limited": False,
@@ -414,7 +415,9 @@ def test_secure_runner_enforces_its_own_wall_time(tmp_path: Path) -> None:
         timeout=10,
     )
     with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
-        metadata = json.loads(archive.extractfile("meta.json").read())
+        metadata_file = archive.extractfile("meta.json")
+        assert metadata_file is not None
+        metadata = json.loads(metadata_file.read())
 
     assert metadata["timed_out"] is True
     assert metadata["returncode"] != 0

--- a/tests/test_shinka_run_cli.py
+++ b/tests/test_shinka_run_cli.py
@@ -272,6 +272,41 @@ def test_shinka_run_parses_json_overrides(tmp_path, monkeypatch):
     assert job_config.extra_cmd_args == {"seed": 42}
 
 
+def test_shinka_run_selects_secure_docker_and_keeps_evaluator_tree(
+    tmp_path, monkeypatch
+):
+    _reset_dummy_runner()
+    task_dir = _make_task_dir(tmp_path)
+    (task_dir / "helper.py").write_text("VALUE = 1\n", encoding="utf-8")
+    results_dir = tmp_path / "results_secure"
+    monkeypatch.setattr(cli_run, "ShinkaEvolveRunner", _DummyRunner)
+    image = "registry.example/shinka/evaluator@sha256:" + "a" * 64
+
+    cli_run.main(
+        [
+            "--task-dir",
+            str(task_dir),
+            "--results_dir",
+            str(results_dir),
+            "--num_generations",
+            "3",
+            "--set",
+            "evo.job_type=secure_docker",
+            "--set",
+            f"job.image={image}",
+            "--set",
+            "job.require_rootless=false",
+        ]
+    )
+
+    assert _DummyRunner.last_kwargs is not None
+    job_config = _DummyRunner.last_kwargs["job_config"]
+    assert isinstance(job_config, cli_run.SecureDockerJobConfig)
+    assert job_config.eval_program_path == str(task_dir / "evaluate.py")
+    assert job_config.require_rootless is False
+    assert _DummyRunner.last_kwargs["evaluate_str"] is None
+
+
 def test_shinka_run_parses_activate_script_override(tmp_path, monkeypatch):
     _reset_dummy_runner()
     task_dir = _make_task_dir(tmp_path)


### PR DESCRIPTION
## Summary

- Add the opt-in `secure_docker` execution backend for single-file candidates.
- Run the unchanged `evaluate.py --program_path --results_dir` interface in a hardened, networkless Docker container.
- Keep host result directories outside the container; a trusted wrapper promotes only bounded JSON results and logs.
- Make CI's established Ruff rule baseline explicit, avoiding unrelated failures after Ruff 0.16 changed its defaults.

## Why

Generated candidate code is untrusted. The existing local backend runs it with the host user's privileges. This backend reduces host exposure while preserving the evaluator interface used by existing tasks.

## Testing

- `uv run ruff check tests --exclude tests/file.py`
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
- `uv run --with pytest-cov pytest -q -m "not requires_secrets and not models_dev_live" --cov=shinka --cov-report=term-missing --cov-report=xml:coverage.xml`
- `python3 -m pytest tests/test_secure_docker.py tests/test_scheduler_env_activation.py tests/test_shinka_run_cli.py -q`
- `uv run --group docs mkdocs build --strict`

All checks pass. The coverage run reports 751 passed and 2 deselected; focused backend tests report 59 passed.

## Risks and compatibility

- Requires a locally available, digest-pinned evaluator image and Docker's default seccomp profile; Linux requires rootless Docker unless explicitly configured for a dedicated VM.
- Docker is host containment, not a complete security boundary: the daemon, image, kernel, and runtime remain trusted.
- Candidate and evaluator intentionally share one container for compatibility. This does not prevent evaluator inspection, reward hacking, or score forgery by an adversarial candidate.
- Only `metrics.json`, `correct.json`, and bounded logs return to the host. Other evaluator artifacts remain in the container.
- No default local or SLURM backend behavior changes.

## Evaluation evidence

- An end-to-end `secure_docker.submit(...)` smoke test used `python@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de`.
- The test evaluator invoked a one-file Python candidate through the ordinary `--program_path` and `--results_dir` arguments. The candidate printed `42`; the evaluator emitted `{"score": 1.0}` and `{"correct": true}`.
- The container exited with status 0, the host received only the expected JSON result files, and the managed container was automatically removed.
- This validates the secure dispatch path and evaluator contract. The automated suite covers command construction, runtime-response validation, and policy rejection cases.

## Docs and UI

- Added hardened-Docker usage, configuration/API reference entries, and README guidance.
- No UI changes.
