### PR TITLE
perf(database): parse each program's AST once in analyze_code_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Changed
 
+- Reduced Python complexity-analysis overhead by parsing each candidate AST once
+  while preserving the existing metrics contract. Thanks @dexhunter.
 - Relaxed the exact HTTPX dependency pin to a `>=0.27` compatibility lower
   bound in issue #180. Thanks @htmai-880.
 - Removed the automatic Claude Code Review pull-request workflow.

--- a/shinka/database/complexity.py
+++ b/shinka/database/complexity.py
@@ -1,43 +1,43 @@
 import ast
-from radon.complexity import cc_visit
-from radon.metrics import h_visit
-from radon.raw import analyze
 import math
 import re
+
+from radon.complexity import cc_visit_ast
+from radon.metrics import h_visit_ast
+from radon.raw import analyze
+
+
+class _NestingVisitor(ast.NodeVisitor):
+    """Track the deepest chain of nested control structures."""
+
+    def __init__(self):
+        self.current_depth = 0
+        self.max_depth = 0
+
+    def _visit_nested(self, node):
+        self.current_depth += 1
+        self.max_depth = max(self.max_depth, self.current_depth)
+        self.generic_visit(node)
+        self.current_depth -= 1
+
+    visit_If = _visit_nested
+    visit_For = _visit_nested
+    visit_While = _visit_nested
+    visit_With = _visit_nested
+    visit_Try = _visit_nested
+    visit_FunctionDef = _visit_nested
+    visit_AsyncFunctionDef = _visit_nested
+
+
+def _max_nesting_depth(tree):
+    visitor = _NestingVisitor()
+    visitor.visit(tree)
+    return visitor.max_depth
 
 
 def max_nesting_depth(code_string):
     """Calculate maximum nesting depth for Python code using AST."""
-
-    class NestingVisitor(ast.NodeVisitor):
-        def __init__(self):
-            self.current_depth = 0
-            self.max_depth = 0
-
-        def generic_visit(self, node):
-            if isinstance(
-                node,
-                (
-                    ast.If,
-                    ast.For,
-                    ast.While,
-                    ast.With,
-                    ast.Try,
-                    ast.FunctionDef,
-                    ast.AsyncFunctionDef,
-                ),
-            ):
-                self.current_depth += 1
-                self.max_depth = max(self.max_depth, self.current_depth)
-                super().generic_visit(node)
-                self.current_depth -= 1
-            else:
-                super().generic_visit(node)
-
-    tree = ast.parse(code_string)
-    visitor = NestingVisitor()
-    visitor.visit(tree)
-    return visitor.max_depth
+    return _max_nesting_depth(ast.parse(code_string))
 
 
 def analyze_python_complexity(code_string):
@@ -54,11 +54,13 @@ def analyze_python_complexity(code_string):
     Raises:
         SyntaxError: If the code cannot be parsed as valid Python
     """
-    cc_results = cc_visit(code_string)
+    tree = ast.parse(code_string)
+
+    cc_results = cc_visit_ast(tree)
     total_cc = sum(block.complexity for block in cc_results)
     avg_cc = total_cc / len(cc_results) if cc_results else 0
 
-    h_metrics = h_visit(code_string)
+    h_metrics = h_visit_ast(tree)
     halstead_total = h_metrics.total if h_metrics.total else None
     halstead_volume = halstead_total.volume if halstead_total else 1
     halstead_difficulty = halstead_total.difficulty if halstead_total else 0
@@ -76,7 +78,7 @@ def analyze_python_complexity(code_string):
         - 16.2 * (math.log2(loc) if loc > 0 else 0)
     )
 
-    nesting_depth = max_nesting_depth(code_string)
+    nesting_depth = _max_nesting_depth(tree)
 
     # Normalized scores for aggregation
     norm_cc = total_cc / 10  # Assuming 10 is high complexity

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,9 +1,19 @@
+import ast
+from unittest.mock import patch
+
 from shinka.database.complexity import analyze_code_metrics
 
 
-def test_go_uses_regex_complexity_analysis():
-    metrics = analyze_code_metrics(
-        """
+PYTHON_PROGRAM = """\
+def classify(values):
+    total = 0
+    for value in values:
+        if value > 0:
+            total += value
+    return total
+"""
+
+GO_PROGRAM = """\
 package main
 
 func score(xs []int) int {
@@ -15,8 +25,59 @@ func score(xs []int) int {
     }
     return total
 }
-""",
-        language="go",
-    )
+"""
 
-    assert metrics["cyclomatic_complexity"] > 1
+
+def test_python_complexity_metrics_contract():
+    assert analyze_code_metrics(PYTHON_PROGRAM) == {
+        "cyclomatic_complexity": 3,
+        "average_cyclomatic_complexity": 3.0,
+        "halstead_volume": 13.931568569324174,
+        "halstead_difficulty": 1.3333333333333333,
+        "halstead_effort": 18.575424759098897,
+        "lines_of_code": 6,
+        "logical_lines_of_code": 6,
+        "comments": 0,
+        "maintainability_index": 108.67212134673596,
+        "max_nesting_depth": 3,
+        "complexity_score": 0.364,
+    }
+
+
+def test_invalid_python_preserves_cpp_fallback_metrics():
+    assert analyze_code_metrics("def broken(:\n    pass\n") == {
+        "cyclomatic_complexity": 1,
+        "average_cyclomatic_complexity": 1,
+        "halstead_volume": 1,
+        "halstead_difficulty": 1.0,
+        "halstead_effort": 1,
+        "lines_of_code": 3,
+        "logical_lines_of_code": 2,
+        "comments": 0,
+        "maintainability_index": 145.09360748831728,
+        "max_nesting_depth": 0,
+        "complexity_score": 0.1,
+    }
+
+
+def test_python_complexity_parses_ast_once():
+    with patch("shinka.database.complexity.ast.parse", wraps=ast.parse) as parse:
+        analyze_code_metrics(PYTHON_PROGRAM)
+
+    assert parse.call_count == 1
+
+
+def test_go_uses_regex_complexity_analysis():
+    assert analyze_code_metrics(GO_PROGRAM, language="go") == {
+        "cyclomatic_complexity": 3,
+        "average_cyclomatic_complexity": 3,
+        "halstead_volume": 15.84962500721156,
+        "halstead_difficulty": 1.0,
+        "halstead_effort": 15.84962500721156,
+        "lines_of_code": 12,
+        "logical_lines_of_code": 10,
+        "comments": 0,
+        "maintainability_index": 91.50444811614277,
+        "max_nesting_depth": 3,
+        "complexity_score": 0.38,
+    }


### PR DESCRIPTION
## Summary

- Parse valid Python source once during complexity analysis and reuse the AST for Radon cyclomatic, Halstead, and nesting metrics.
- Preserve `max_nesting_depth(code_string)` and every returned metric key/value.
- Add exact-contract regressions for Python, invalid-Python fallback, Go, and single-parse behavior.
- Credit @dexhunter in the changelog.

## Verification

- `uv run pytest -q tests/test_complexity.py` — 4 passed.
- Database-adjacent tests — 16 passed.
- Ruff and Mypy focused checks — clean.
- Full CI-equivalent gate — 731 passed, 7 skipped, 2 deselected.
- `shinka/database/complexity.py` coverage — 93%.
- Fresh GitHub CI — green on `be04d05`.

## Compatibility and rollback

Public call signatures and Python/non-Python metric contracts are unchanged. Revert `be04d05` to restore the prior three-parse implementation.

## Weco dashboard

[View the optimization run](https://dashboard.weco.ai/share/XpTb21O9z1DcWjRs9EFjbggGSWVr6QFl)