### PR TITLE
fix: log W&B population progress on a monotonic axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 - Added native Google Gemini 3.6 Flash support with current pricing and
   level-based thinking controls. Thanks @anantgar.
 - Added optional Weights & Biases logging with resumable run IDs, per-individual
-  scores, timing and cost metrics, and final run summaries in PR #149. Thanks
-  @anantgar.
+  scores, timing and cost metrics, and final run summaries in PR #149. PR #177
+  adds monotonic population/island snapshots and a secured metadata boundary.
+  Thanks @anantgar.
 - Added Verilog/SystemVerilog as a first-class evolution target in PR #137,
   including `.sv` task detection, syntax validation, EVOLVE-BLOCK marker support,
   failure-artifact rendering, and a self-contained RTLLM example. Thanks @Tyronita.

--- a/README.md
+++ b/README.md
@@ -192,13 +192,31 @@ shinka_run --task-dir examples/circle_packing \
 ```
 
 W&B logging is additive: the existing SQLite database and WebUI logging remain
-enabled. Each evaluated individual logs `score/individual` against `generation`,
-along with compact evaluation, cost, and timing metrics. Resuming the same
-results directory reuses its persisted W&B run ID by default. Online mode uses
-the credentials from `wandb login` or `WANDB_API_KEY`; use `wandb_mode=offline`
-to record locally without uploading. See
+enabled. Population and island snapshots use the monotonic
+`population/evaluated_count` axis for counts, correctness, scores, cumulative
+`cost/*`, and cumulative `timing/*_total`. Raw evaluated candidates use
+`score/individual` and `individual/*` fields without binding those events to a
+generation step. Administrative island copies remain in population/table counts
+but are excluded from evaluated count, candidate history, and costs. The final
+population is available as `population/final_table`, without program code or
+embeddings. Resuming the same results directory reuses its persisted W&B run ID
+by default. Online mode uses credentials from `wandb login` or `WANDB_API_KEY`;
+use `wandb_mode=offline` to record locally without uploading. See
 [Configuration](docs/configuration.md#evolutionconfig-shinkacoreconfigevolutionconfig)
 for all W&B options.
+
+Shinka disables W&B console, Git, code, requirements, machine, and system-stat
+capture. Run configuration contains an explicit allowlist of scalar experiment
+settings plus the recursively redacted `wandb_config` extension. Arbitrary
+`wandb_config` values cross the upload boundary when their keys are not
+recognized as sensitive, so do not put secrets or private data there. Candidate
+telemetry excludes private metrics and logs at most 64 public numeric metrics
+with keys no longer than 128 characters; secret-like metric names are dropped.
+Population snapshots use a dedicated serialized telemetry worker and a compact
+database aggregate, throttled to at most once every five seconds. Overlapping
+requests are coalesced so telemetry cannot stall active job processing. The
+bounded candidate queue drops the newest raw event with a rate-limited warning
+if saturated; population and final snapshots remain authoritative.
 
 <details>
 <summary><strong>EvolutionConfig Parameters</strong> (click to expand)</summary>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,18 +94,37 @@ pip install 'shinka-evolve[wandb]'
 # Authenticate online runs. In CI, provide this through a secret manager.
 export WANDB_API_KEY=<your-api-key>
 
-# Add W&B metrics and a compact individuals table alongside the WebUI database.
+# Add W&B metrics and a compact final table alongside the WebUI database.
 shinka_run --task-dir examples/circle_packing --results_dir results/circle_wandb --num_generations 20 \
   --set evo.enable_wandb_logging=true \
   --set evo.wandb_project=shinka-evolve
 ```
 
-Each evaluated individual logs `score/individual` against `generation`. When a
-results directory is resumed, its `.wandb_run_id` is reused with
-`wandb_resume='allow'` by default. Online mode uses the credentials from
+Population and island snapshots use the monotonic
+`population/evaluated_count` axis. They include counts, correctness, scores,
+cumulative `cost/*`, and cumulative `timing/*_total`. Raw evaluated candidates
+use `score/individual` and `individual/*` fields without binding those events to
+generation. Administrative island copies remain in population/table counts but
+are excluded from evaluated count, candidate history, and costs. The compact
+`population/final_table` omits program code, embeddings, and unrestricted
+metadata. When a results directory is resumed, its `.wandb_run_id` is reused
+with `wandb_resume='allow'` by default. Online mode uses credentials from
 `wandb login` or `WANDB_API_KEY`; set `wandb_mode=offline` to record locally
 without uploading. W&B failures are non-fatal and do not alter the existing
 database or WebUI path.
+
+The integration disables W&B console, Git, code, requirements, machine, and
+system-stat capture. Its run config contains only an explicit allowlist of safe
+scalar experiment settings; `wandb_config` remains an explicit extension and is
+recursively redacted for secret-like keys. Arbitrary `wandb_config` values cross
+the upload boundary when their keys are not recognized as sensitive, so do not
+put secrets or private data there. Candidate events omit private metrics and
+include at most 64 public numeric metrics whose full keys are at most 128
+characters; secret-like keys are discarded. Population snapshots use a compact
+database aggregate on a dedicated serialized telemetry worker, run at most once
+every five seconds, and overlapping refresh requests are coalesced. If the
+bounded raw-candidate queue saturates, the newest candidate event is dropped
+with a rate-limited warning; population and final snapshots remain authoritative.
 
 ### DatabaseConfig (`shinka.database.DatabaseConfig`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-wandb = ["wandb"]
+wandb = ["wandb>=0.19"]
 
 [project.scripts]
 shinka_launch = "shinka.cli.launch:main"

--- a/shinka/core/async_runner.py
+++ b/shinka/core/async_runner.py
@@ -13,7 +13,9 @@ import os
 import math
 import psutil
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import List, Optional, Dict, Any, Set, Tuple, Union, Iterable
 from dataclasses import dataclass, field
@@ -69,6 +71,7 @@ from shinka.pricing.catalog import (
     write_run_pricing_snapshot,
 )
 from shinka.wandb_logging import ShinkaWandbLogger
+from shinka.wandb_metrics import build_program_log_payload, is_island_copy
 from shinka.utils import (
     get_language_extension,
     parse_time_to_seconds,
@@ -77,6 +80,11 @@ from shinka.utils import (
 from shinka.utils.languages import get_evolve_comment_prefix
 
 logger = logging.getLogger(__name__)
+
+_WANDB_CANDIDATE_QUEUE_SIZE = 256
+_WANDB_DROP_WARNING_INTERVAL_SECONDS = 30.0
+_WANDB_POPULATION_INTERVAL_SECONDS = 5.0
+_WANDB_CANDIDATE_STOP = object()
 
 
 def _print_gradient_logo_and_mirror(
@@ -568,6 +576,17 @@ class ShinkaEvolveRunner:
         self._background_side_effects_busy_count = 0
         self._completed_job_batch_tasks: Set[asyncio.Task] = set()
         self._completed_jobs_pending = 0
+        self._wandb_population_task: Optional[asyncio.Task] = None
+        self._wandb_population_delay_task: Optional[asyncio.Task] = None
+        self._wandb_population_pending = False
+        self._wandb_last_population_snapshot_at: Optional[float] = None
+        self._wandb_population_interval_seconds = _WANDB_POPULATION_INTERVAL_SECONDS
+        self._wandb_executor: Optional[ThreadPoolExecutor] = None
+        self._wandb_candidate_queue: Optional[asyncio.Queue] = None
+        self._wandb_candidate_worker_task: Optional[asyncio.Task] = None
+        self._wandb_candidate_queue_size = _WANDB_CANDIDATE_QUEUE_SIZE
+        self._wandb_dropped_candidate_events = 0
+        self._wandb_last_drop_warning_at: Optional[float] = None
         self._meta_side_effect_lock = asyncio.Lock()
         self._prompt_side_effect_lock = asyncio.Lock()
         self._best_solution_lock = asyncio.Lock()
@@ -1183,12 +1202,14 @@ class ShinkaEvolveRunner:
         if self.evo_config.evolve_prompts:
             await self._setup_prompt_evolution()
 
-        self.wandb_logger.start(
-            evo_config=self.evo_config,
-            db_config=self.db_config,
-            job_config=self.job_config,
-            results_dir=Path(self.results_dir),
-        )
+        if self.wandb_logger.enabled:
+            await self._run_wandb_operation(
+                self.wandb_logger.start,
+                evo_config=self.evo_config,
+                db_config=self.db_config,
+                job_config=self.job_config,
+                results_dir=Path(self.results_dir),
+            )
 
         # Check if we're resuming from an existing database
         resuming_run = db_path.exists() and self.db.last_iteration > 0
@@ -1236,6 +1257,8 @@ class ShinkaEvolveRunner:
                         "generating initial program with LLM..."
                     )
                 await self._generate_initial_program()
+
+        self._log_wandb_population_progress()
 
     async def _setup_prompt_evolution(self):
         """Setup prompt evolution database and components."""
@@ -2125,6 +2148,7 @@ class ShinkaEvolveRunner:
                         await self._process_completed_jobs_safely(completed_jobs)
                         old_completed = self.completed_generations
                         await self._update_completed_generations()
+                        self._log_wandb_population_progress()
 
                         if self.verbose:
                             if self.completed_generations != old_completed:
@@ -4021,6 +4045,7 @@ class ShinkaEvolveRunner:
             )
 
             await self._update_completed_generations()
+            self._log_wandb_population_progress()
             self._record_progress()
             self.slot_available.set()
             self._log_program_to_wandb(program)
@@ -4628,6 +4653,7 @@ class ShinkaEvolveRunner:
                 self._mark_surplus_completed_jobs_for_discard(completed_jobs)
                 await self._process_completed_jobs_safely(completed_jobs)
                 await self._update_completed_generations()
+                self._log_wandb_population_progress()
                 self.slot_available.set()
         finally:
             self._completed_jobs_pending = max(
@@ -4934,6 +4960,7 @@ class ShinkaEvolveRunner:
                     if str(job.job_id) in self.submitted_jobs:
                         del self.submitted_jobs[str(job.job_id)]
                     await self._update_completed_generations()
+                    self._log_wandb_population_progress()
                     self._record_progress()
                     self.slot_available.set()
                     logger.info(
@@ -5524,7 +5551,7 @@ class ShinkaEvolveRunner:
                     logger.warning(f"Failed to recompute prompt percentiles: {e}")
 
             # Cleanup database
-            self._finish_wandb_logging()
+            await self._finish_wandb_logging()
             await self.async_db.close_async()
 
             # Cleanup scheduler
@@ -5535,19 +5562,334 @@ class ShinkaEvolveRunner:
 
     def _log_program_to_wandb(self, program: Program) -> None:
         wandb_logger = getattr(self, "wandb_logger", None)
-        if wandb_logger is not None:
-            wandb_logger.log_program(program)
+        if (
+            wandb_logger is not None
+            and getattr(wandb_logger, "active", True)
+            and not is_island_copy(program)
+            and hasattr(wandb_logger, "log_program_payload")
+        ):
+            self._enqueue_wandb_candidate(
+                wandb_logger.log_program_payload,
+                program.id,
+                build_program_log_payload(program),
+            )
 
-    def _finish_wandb_logging(self) -> None:
+    def _log_wandb_population_progress(self) -> None:
+        wandb_logger = getattr(self, "wandb_logger", None)
+        db = getattr(self, "db", None)
+        if (
+            wandb_logger is None
+            or db is None
+            or getattr(wandb_logger, "active", True) is False
+        ):
+            return
+
+        snapshot_task = getattr(self, "_wandb_population_task", None)
+        delay_task = getattr(self, "_wandb_population_delay_task", None)
+        snapshot_running = snapshot_task is not None and not snapshot_task.done()
+        delay_running = delay_task is not None and not delay_task.done()
+        if snapshot_running or delay_running:
+            self._wandb_population_pending = True
+            return
+
+        loop = asyncio.get_running_loop()
+        last_snapshot_at = getattr(
+            self, "_wandb_last_population_snapshot_at", None
+        )
+        interval = getattr(
+            self,
+            "_wandb_population_interval_seconds",
+            _WANDB_POPULATION_INTERVAL_SECONDS,
+        )
+        delay = (
+            0.0
+            if last_snapshot_at is None
+            else max(0.0, interval - (loop.time() - last_snapshot_at))
+        )
+        if delay:
+            self._wandb_population_pending = True
+            self._wandb_population_delay_task = asyncio.create_task(
+                self._run_delayed_wandb_population_snapshot(delay),
+                name="wandb_population_delay",
+            )
+            return
+        self._start_wandb_population_snapshot(wandb_logger, db)
+
+    def _start_wandb_population_snapshot(
+        self, wandb_logger: Any, db: ProgramDatabase
+    ) -> None:
+        try:
+            population_snapshot = self._capture_wandb_population_snapshot(db)
+        except Exception as exc:
+            logger.warning(
+                "Failed to query in-memory W&B population snapshot: %s", exc
+            )
+            return
+        if population_snapshot is None:
+            if not hasattr(wandb_logger, "log_population_progress"):
+                return
+        elif not hasattr(wandb_logger, "log_population_snapshot"):
+            return
+        else:
+            self._wandb_last_population_snapshot_at = (
+                asyncio.get_running_loop().time()
+            )
+
+        self._wandb_population_pending = False
+        self._wandb_population_task = asyncio.create_task(
+            self._run_wandb_population_snapshot(
+                wandb_logger, db, population_snapshot
+            ),
+            name="wandb_population_snapshot",
+        )
+
+    async def _run_delayed_wandb_population_snapshot(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        finally:
+            self._wandb_population_delay_task = None
+        wandb_logger = getattr(self, "wandb_logger", None)
+        db = getattr(self, "db", None)
+        if (
+            wandb_logger is not None
+            and db is not None
+            and getattr(wandb_logger, "active", True)
+        ):
+            self._start_wandb_population_snapshot(wandb_logger, db)
+
+    async def _run_wandb_population_snapshot(
+        self,
+        wandb_logger: Any,
+        db: ProgramDatabase,
+        population_snapshot: Optional[List[Dict[str, Any]]],
+    ) -> None:
+        try:
+            if population_snapshot is None:
+                await self._run_wandb_operation(
+                    self._log_wandb_population_snapshot,
+                    wandb_logger,
+                    db,
+                )
+            else:
+                await self._run_wandb_operation(
+                    wandb_logger.log_population_snapshot,
+                    population_snapshot,
+                )
+        except Exception as exc:
+            logger.warning("Failed to run background W&B snapshot: %s", exc)
+        finally:
+            if population_snapshot is None:
+                self._wandb_last_population_snapshot_at = (
+                    asyncio.get_running_loop().time()
+                )
+            self._wandb_population_task = None
+        if self._wandb_population_pending:
+            self._wandb_population_pending = False
+            self._log_wandb_population_progress()
+
+    async def _wait_for_wandb_population_progress(self) -> None:
+        while (
+            task := getattr(self, "_wandb_population_task", None)
+            or getattr(self, "_wandb_population_delay_task", None)
+        ) is not None:
+            await asyncio.shield(task)
+
+    async def _skip_delayed_wandb_population_progress(self) -> None:
+        delay_task = getattr(self, "_wandb_population_delay_task", None)
+        if delay_task is not None:
+            delay_task.cancel()
+            try:
+                await delay_task
+            except asyncio.CancelledError:
+                pass
+            self._wandb_population_delay_task = None
+        self._wandb_population_pending = False
+        while (task := getattr(self, "_wandb_population_task", None)) is not None:
+            await asyncio.shield(task)
+
+    @staticmethod
+    def _capture_wandb_population_snapshot(
+        db: ProgramDatabase,
+    ) -> Optional[List[Dict[str, Any]]]:
+        config = getattr(db, "config", None)
+        if config is None or getattr(config, "db_path", None):
+            return None
+        return db.get_population_telemetry()
+
+    @staticmethod
+    def _wandb_snapshot_db(db: ProgramDatabase) -> Tuple[ProgramDatabase, bool]:
+        config = getattr(db, "config", None)
+        db_path = getattr(config, "db_path", None)
+        if not db_path:
+            return db, False
+        return ProgramDatabase(config, read_only=True), True
+
+    @classmethod
+    def _log_wandb_population_snapshot(
+        cls, wandb_logger: Any, db: ProgramDatabase
+    ) -> None:
+        snapshot_db, should_close = cls._wandb_snapshot_db(db)
+        try:
+            wandb_logger.log_population_progress(db=snapshot_db)
+        finally:
+            if should_close:
+                snapshot_db.close()
+
+    @classmethod
+    def _log_final_wandb_snapshot(
+        cls,
+        wandb_logger: Any,
+        db: ProgramDatabase,
+        total_proposals_generated: Optional[int],
+        total_cost: Optional[float],
+    ) -> None:
+        snapshot_db, should_close = cls._wandb_snapshot_db(db)
+        try:
+            wandb_logger.log_final(
+                db=snapshot_db,
+                total_proposals_generated=total_proposals_generated,
+                total_api_cost=total_cost,
+                total_cost=total_cost,
+            )
+        finally:
+            if should_close:
+                snapshot_db.close()
+
+    async def _finish_wandb_logging(self) -> None:
         wandb_logger = getattr(self, "wandb_logger", None)
         if wandb_logger is None:
             return
-        wandb_logger.log_final(
-            db=getattr(self, "db", None),
-            total_proposals_generated=getattr(self, "total_proposals_generated", None),
-            total_api_cost=getattr(self, "total_api_cost", None),
-        )
-        wandb_logger.finish()
+        await self._skip_delayed_wandb_population_progress()
+        await self._drain_wandb_candidate_queue()
+        total_cost = getattr(self, "total_api_cost", None)
+        db = getattr(self, "db", None)
+        if db is not None:
+            try:
+                config = getattr(db, "config", None)
+                if config is not None and not getattr(config, "db_path", None):
+                    programs = db.get_all_programs()
+                    await self._run_wandb_operation(
+                        wandb_logger.log_final_programs,
+                        programs,
+                        total_proposals_generated=getattr(
+                            self, "total_proposals_generated", None
+                        ),
+                        total_api_cost=total_cost,
+                        total_cost=total_cost,
+                    )
+                else:
+                    await self._run_wandb_operation(
+                        self._log_final_wandb_snapshot,
+                        wandb_logger,
+                        db,
+                        getattr(self, "total_proposals_generated", None),
+                        total_cost,
+                    )
+            except Exception as exc:
+                logger.warning("Failed to run final W&B snapshot: %s", exc)
+        try:
+            await self._run_wandb_operation(wandb_logger.finish)
+        finally:
+            await self._stop_wandb_candidate_worker()
+            await self._shutdown_wandb_executor()
+
+    def _wandb_thread_pool(self) -> ThreadPoolExecutor:
+        executor = getattr(self, "_wandb_executor", None)
+        if executor is None:
+            executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="shinka-wandb",
+            )
+            self._wandb_executor = executor
+        return executor
+
+    async def _run_wandb_operation(
+        self, callback: Any, *args: Any, **kwargs: Any
+    ) -> Any:
+        loop = asyncio.get_running_loop()
+        operation = partial(callback, *args, **kwargs)
+        return await loop.run_in_executor(self._wandb_thread_pool(), operation)
+
+    def _wandb_candidate_event_queue(self) -> asyncio.Queue:
+        queue = getattr(self, "_wandb_candidate_queue", None)
+        if queue is None:
+            queue = asyncio.Queue(
+                maxsize=getattr(
+                    self,
+                    "_wandb_candidate_queue_size",
+                    _WANDB_CANDIDATE_QUEUE_SIZE,
+                )
+            )
+            self._wandb_candidate_queue = queue
+        return queue
+
+    def _enqueue_wandb_candidate(
+        self, callback: Any, program_id: str, payload: Dict[str, Any]
+    ) -> None:
+        queue = self._wandb_candidate_event_queue()
+        if queue.full():
+            self._wandb_dropped_candidate_events = (
+                getattr(self, "_wandb_dropped_candidate_events", 0) + 1
+            )
+            now = time.monotonic()
+            last_warning = getattr(self, "_wandb_last_drop_warning_at", None)
+            if (
+                last_warning is None
+                or now - last_warning >= _WANDB_DROP_WARNING_INTERVAL_SECONDS
+            ):
+                logger.warning(
+                    "W&B candidate queue full; dropping newest candidate event. "
+                    "Population and final snapshots remain authoritative."
+                )
+                self._wandb_last_drop_warning_at = now
+            return
+        queue.put_nowait((callback, program_id, payload))
+        worker = getattr(self, "_wandb_candidate_worker_task", None)
+        if worker is None or worker.done():
+            self._wandb_candidate_worker_task = asyncio.create_task(
+                self._run_wandb_candidate_worker(),
+                name="wandb_candidate_worker",
+            )
+
+    async def _run_wandb_candidate_worker(self) -> None:
+        queue = self._wandb_candidate_event_queue()
+        while True:
+            operation = await queue.get()
+            try:
+                if operation is _WANDB_CANDIDATE_STOP:
+                    return
+                callback, program_id, payload = operation
+                try:
+                    await self._run_wandb_operation(
+                        callback, program_id, payload
+                    )
+                except Exception as exc:
+                    logger.warning("Failed W&B candidate operation: %s", exc)
+            finally:
+                queue.task_done()
+
+    async def _drain_wandb_candidate_queue(self) -> None:
+        queue = getattr(self, "_wandb_candidate_queue", None)
+        if queue is not None:
+            await queue.join()
+
+    async def _stop_wandb_candidate_worker(self) -> None:
+        worker = getattr(self, "_wandb_candidate_worker_task", None)
+        if worker is None:
+            return
+        queue = self._wandb_candidate_event_queue()
+        queue.put_nowait(_WANDB_CANDIDATE_STOP)
+        await worker
+        self._wandb_candidate_worker_task = None
+
+    async def _shutdown_wandb_executor(self) -> None:
+        executor = getattr(self, "_wandb_executor", None)
+        if executor is None:
+            return
+        self._wandb_executor = None
+        await asyncio.to_thread(executor.shutdown, True)
 
     async def _print_final_summary(self):
         """Print final evolution summary."""

--- a/shinka/database/dbase.py
+++ b/shinka/database/dbase.py
@@ -1645,6 +1645,136 @@ class ProgramDatabase:
         return best_overall
 
     @db_retry()
+    def get_population_telemetry(self) -> List[Dict[str, Any]]:
+        """Return compact per-island aggregates for progress telemetry.
+
+        The query never selects program code, embeddings, evaluation metrics, or
+        full metadata. Final reporting can still use :meth:`get_all_programs`.
+        """
+        if not self.cursor:
+            raise ConnectionError("DB not connected.")
+        self.cursor.execute(
+            """
+            WITH metadata_source AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    combined_score,
+                    COALESCE(metadata, '{}') AS metadata,
+                    REPLACE(
+                        REPLACE(
+                            REPLACE(COALESCE(metadata, '{}'), '-Infinity', 'null'),
+                            'Infinity', 'null'
+                        ),
+                        'NaN', 'null'
+                    ) AS finite_metadata
+                FROM programs
+            ), source AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    combined_score,
+                    CASE
+                        WHEN json_valid(metadata) THEN metadata
+                        WHEN json_valid(finite_metadata) THEN finite_metadata
+                        ELSE '{}'
+                    END AS metadata
+                FROM metadata_source
+            ), raw AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    CASE WHEN combined_score > -1e999 AND combined_score < 1e999
+                        THEN combined_score END AS combined_score,
+                    CASE WHEN
+                        COALESCE(json_extract(metadata, '$._is_island_copy'), 0) = 1
+                        OR COALESCE(json_extract(metadata, '$._spawned_island'), 0) = 1
+                    THEN 1 ELSE 0 END AS is_copy,
+                    COALESCE(
+                        NULLIF(json_extract(metadata, '$.model_name'), ''),
+                        NULLIF(json_extract(metadata, '$.model'), ''),
+                        NULLIF(json_extract(metadata, '$.llm_result.model_name'), ''),
+                        NULLIF(json_extract(metadata, '$.llm_result.model'), '')
+                    ) AS model_name,
+                    COALESCE(
+                        json_extract(metadata, '$.headless_pricing_unknown'), 0
+                    ) AS pricing_unknown,
+                    CASE WHEN json_type(metadata, '$.api_costs') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.api_costs') ELSE 0 END AS api_cost,
+                    CASE WHEN json_type(metadata, '$.embed_cost') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.embed_cost') ELSE 0 END AS embed_cost,
+                    CASE WHEN json_type(metadata, '$.novelty_cost') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.novelty_cost') ELSE 0 END AS novelty_cost,
+                    CASE WHEN json_type(metadata, '$.meta_cost') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.meta_cost') ELSE 0 END AS meta_cost,
+                    CASE WHEN json_type(metadata, '$.sampling_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.sampling_seconds') ELSE 0 END AS sampling_seconds,
+                    CASE WHEN json_type(metadata, '$.evaluation_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.evaluation_seconds') ELSE 0 END AS evaluation_seconds,
+                    CASE WHEN json_type(metadata, '$.postprocess_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.postprocess_seconds') ELSE 0 END AS postprocess_seconds,
+                    CASE WHEN json_type(metadata, '$.pipeline_seconds') IN ('integer', 'real')
+                        THEN json_extract(metadata, '$.pipeline_seconds') ELSE 0 END AS pipeline_seconds
+                FROM source
+            ), telemetry AS (
+                SELECT
+                    island_idx,
+                    correct,
+                    combined_score,
+                    is_copy,
+                    model_name,
+                    CASE WHEN api_cost > -1e999 AND api_cost < 1e999
+                        THEN api_cost ELSE 0 END AS api_cost,
+                    CASE WHEN embed_cost > -1e999 AND embed_cost < 1e999
+                        THEN embed_cost ELSE 0 END AS embed_cost,
+                    CASE WHEN novelty_cost > -1e999 AND novelty_cost < 1e999
+                        THEN novelty_cost ELSE 0 END AS novelty_cost,
+                    CASE WHEN meta_cost > -1e999 AND meta_cost < 1e999
+                        THEN meta_cost ELSE 0 END AS meta_cost,
+                    CASE WHEN sampling_seconds > -1e999 AND sampling_seconds < 1e999
+                        THEN sampling_seconds ELSE 0 END AS sampling_seconds,
+                    CASE WHEN evaluation_seconds > -1e999 AND evaluation_seconds < 1e999
+                        THEN evaluation_seconds ELSE 0 END AS evaluation_seconds,
+                    CASE WHEN postprocess_seconds > -1e999 AND postprocess_seconds < 1e999
+                        THEN postprocess_seconds ELSE 0 END AS postprocess_seconds,
+                    CASE WHEN pipeline_seconds > -1e999 AND pipeline_seconds < 1e999
+                        THEN pipeline_seconds ELSE 0 END AS pipeline_seconds,
+                    CASE WHEN model_name GLOB 'headless/*' AND pricing_unknown = 1
+                        THEN 1 ELSE 0 END AS api_cost_unknown
+                FROM raw
+            )
+            SELECT
+                island_idx,
+                COUNT(*) AS count,
+                SUM(CASE WHEN is_copy = 0 THEN 1 ELSE 0 END) AS evaluated_count,
+                SUM(CASE WHEN correct = 1 THEN 1 ELSE 0 END) AS correct_count,
+                COUNT(combined_score) AS score_count,
+                COALESCE(SUM(combined_score), 0) AS score_sum,
+                MAX(combined_score) AS best_score,
+                MAX(CASE WHEN correct = 1 THEN combined_score END) AS best_correct_score,
+                SUM(CASE WHEN is_copy = 0 AND api_cost_unknown = 0
+                    THEN api_cost ELSE 0 END) AS api_cost,
+                SUM(CASE WHEN is_copy = 0 THEN embed_cost ELSE 0 END) AS embed_cost,
+                SUM(CASE WHEN is_copy = 0 THEN novelty_cost ELSE 0 END) AS novelty_cost,
+                SUM(CASE WHEN is_copy = 0 THEN meta_cost ELSE 0 END) AS meta_cost,
+                SUM(CASE WHEN is_copy = 0 AND api_cost_unknown = 1
+                    THEN 1 ELSE 0 END) AS pricing_unknown_count,
+                SUM(CASE WHEN is_copy = 0 THEN sampling_seconds ELSE 0 END)
+                    AS sampling_seconds,
+                SUM(CASE WHEN is_copy = 0 THEN evaluation_seconds ELSE 0 END)
+                    AS evaluation_seconds,
+                SUM(CASE WHEN is_copy = 0 THEN postprocess_seconds ELSE 0 END)
+                    AS postprocess_seconds,
+                SUM(CASE WHEN is_copy = 0 THEN pipeline_seconds ELSE 0 END)
+                    AS pipeline_seconds
+            FROM telemetry
+            GROUP BY island_idx
+            ORDER BY island_idx
+            """
+        )
+        return [dict(row) for row in self.cursor.fetchall()]
+
+    @db_retry()
     def get_all_programs(self) -> List[Program]:
         """Get all programs from the database."""
         if not self.cursor:

--- a/shinka/telemetry_safety.py
+++ b/shinka/telemetry_safety.py
@@ -1,0 +1,44 @@
+"""Shared metadata-boundary safety helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_SENSITIVE_WORDS = {
+    "auth",
+    "authorization",
+    "cookie",
+    "code",
+    "credential",
+    "credentials",
+    "embedding",
+    "embeddings",
+    "password",
+    "secret",
+    "token",
+}
+_SENSITIVE_COMPOUNDS = {
+    "accesskey",
+    "accesstoken",
+    "apikey",
+    "authheader",
+    "authorizationheader",
+    "authtoken",
+    "clientsecret",
+    "privatekey",
+    "secretaccesskey",
+    "tasksysmsg",
+}
+
+
+def is_sensitive_telemetry_key(value: Any) -> bool:
+    """Recognize sensitive keys across snake, kebab, camel, and acronym case."""
+    text = str(value).strip()
+    text = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", text)
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", text)
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    joined = "".join(words)
+    return bool(set(words) & _SENSITIVE_WORDS) or any(
+        compound in joined for compound in _SENSITIVE_COMPOUNDS
+    )

--- a/shinka/wandb_logging.py
+++ b/shinka/wandb_logging.py
@@ -5,44 +5,114 @@ from __future__ import annotations
 import importlib
 import logging
 import math
-import re
 import uuid
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Optional
 
 from shinka.database import Program, ProgramDatabase
+from shinka.telemetry_safety import is_sensitive_telemetry_key
+from shinka.wandb_metrics import (
+    EVALUATED_COUNT_METRIC,
+    GENERATION_METRIC,
+    INDIVIDUAL_SCORE_METRIC,
+    MAX_METRIC_KEY_LENGTH,
+    MAX_PUBLIC_METRICS,
+    PROGRAM_TABLE_COLUMNS,
+    PROGRAM_TABLE_KEY,
+    build_population_progress_payload,
+    build_population_progress_payload_from_telemetry,
+    build_program_log_payload,
+    build_run_summary,
+    flatten_numeric_metrics,
+    is_island_copy,
+    program_costs,
+    program_table_row,
+)
+
+__all__ = [
+    "EVALUATED_COUNT_METRIC",
+    "GENERATION_METRIC",
+    "INDIVIDUAL_SCORE_METRIC",
+    "MAX_METRIC_KEY_LENGTH",
+    "MAX_PUBLIC_METRICS",
+    "PROGRAM_TABLE_COLUMNS",
+    "PROGRAM_TABLE_KEY",
+    "ShinkaWandbLogger",
+    "build_population_progress_payload",
+    "build_population_progress_payload_from_telemetry",
+    "build_program_log_payload",
+    "build_run_summary",
+    "ensure_wandb_run_id",
+    "flatten_numeric_metrics",
+    "is_island_copy",
+    "program_costs",
+    "program_table_row",
+]
 
 logger = logging.getLogger(__name__)
 
-GENERATION_METRIC = "generation"
-INDIVIDUAL_SCORE_METRIC = "score/individual"
-PROGRAM_TABLE_KEY = "individuals"
 WANDB_RUN_ID_FILENAME = ".wandb_run_id"
-PROGRAM_TABLE_COLUMNS = [
-    "id",
-    "generation",
-    "score",
-    "correct",
-    "parent_id",
-    "island_idx",
-    "in_archive",
-    "patch_type",
-    "model_name",
-    "cost",
-]
-
-_COST_KEYS = {
-    "api": "api_costs",
-    "embedding": "embed_cost",
-    "novelty": "novelty_cost",
-    "meta": "meta_cost",
-}
-_TIMING_KEYS = (
-    "sampling_seconds",
-    "evaluation_seconds",
-    "postprocess_seconds",
-    "pipeline_seconds",
+_REDACTED_VALUE = "<redacted>"
+_EVOLUTION_CONFIG_FIELDS = (
+    "num_generations",
+    "max_patch_resamples",
+    "max_patch_attempts",
+    "job_type",
+    "language",
+    "meta_rec_interval",
+    "meta_max_recommendations",
+    "sample_single_meta_rec",
+    "max_novelty_attempts",
+    "code_embed_sim_threshold",
+    "use_text_feedback",
+    "max_api_costs",
+    "enable_controlled_oversubscription",
+    "proposal_target_mode",
+    "proposal_target_min_samples",
+    "proposal_target_ratio_cap",
+    "proposal_buffer_max",
+    "proposal_target_hard_cap",
+    "proposal_target_ewma_alpha",
+    "evolve_prompts",
+    "prompt_evolution_interval",
+    "prompt_archive_size",
+    "prompt_ucb_exploration_constant",
+    "prompt_epsilon",
+    "prompt_evo_top_k_programs",
+    "prompt_percentile_recompute_interval",
+)
+_DATABASE_CONFIG_FIELDS = (
+    "num_islands",
+    "archive_size",
+    "max_stdout_log_chars",
+    "elite_selection_ratio",
+    "num_archive_inspirations",
+    "num_top_k_inspirations",
+    "migration_interval",
+    "migration_rate",
+    "island_elitism",
+    "enforce_island_separation",
+    "island_selection_strategy",
+    "enable_dynamic_islands",
+    "stagnation_threshold",
+    "island_spawn_strategy",
+    "island_spawn_subtree_size",
+    "parent_selection_strategy",
+    "exploitation_alpha",
+    "exploitation_ratio",
+    "parent_selection_lambda",
+    "num_beams",
+    "archive_selection_strategy",
+)
+_JOB_CONFIG_FIELDS = (
+    "eval_verbose",
+    "numeric_threads_per_job",
+    "partition",
+    "time",
+    "cpus",
+    "gpus",
+    "mem",
 )
 
 
@@ -65,121 +135,6 @@ def ensure_wandb_run_id(
     return run_id
 
 
-def build_program_log_payload(program: Program) -> Dict[str, Any]:
-    """Build one compact W&B history event for an evaluated individual."""
-    metadata = program.metadata or {}
-    costs = program_costs(program)
-    individual_score = _finite_float(program.combined_score)
-    payload: Dict[str, Any] = {
-        GENERATION_METRIC: program.generation,
-        INDIVIDUAL_SCORE_METRIC: individual_score,
-        "individual/id": program.id,
-        "individual/parent_id": program.parent_id,
-        "individual/island_idx": program.island_idx,
-        "individual/correct": bool(program.correct),
-        "individual/in_archive": bool(program.in_archive),
-        "individual/patch_type": metadata.get("patch_type"),
-        "individual/model_name": _program_model_name(program),
-        **{f"cost/{name}": value for name, value in costs.items()},
-    }
-
-    for key in _TIMING_KEYS:
-        value = _finite_float(metadata.get(key))
-        if value is not None:
-            payload[f"timing/{key}"] = value
-
-    for prefix, metrics in (
-        ("public_metrics", program.public_metrics),
-        ("private_metrics", program.private_metrics),
-    ):
-        for key, value in flatten_numeric_metrics(metrics, prefix).items():
-            leaf_name = key.rsplit("/", 1)[-1]
-            if leaf_name in {"score", "combined_score"} and value == individual_score:
-                continue
-            payload[key] = value
-    return {key: value for key, value in payload.items() if value is not None}
-
-
-def flatten_numeric_metrics(
-    data: Any,
-    prefix: str,
-    *,
-    max_depth: int = 3,
-) -> Dict[str, float]:
-    """Flatten only numeric evaluation metrics, excluding bulky text and arrays."""
-    flattened: Dict[str, float] = {}
-
-    def visit(value: Any, parts: List[str], depth: int) -> None:
-        if depth > max_depth:
-            return
-        if isinstance(value, dict):
-            for key, child in value.items():
-                visit(child, [*parts, _metric_segment(key)], depth + 1)
-            return
-        numeric_value = _finite_float(value)
-        if numeric_value is not None:
-            flattened["/".join([prefix, *parts])] = numeric_value
-
-    if isinstance(data, dict):
-        for key, value in data.items():
-            visit(value, [_metric_segment(key)], 1)
-    return flattened
-
-
-def program_costs(program: Program) -> Dict[str, float]:
-    """Return the non-duplicated cost breakdown for one individual."""
-    metadata = program.metadata or {}
-    return {
-        name: _finite_float(metadata.get(metadata_key)) or 0.0
-        for name, metadata_key in _COST_KEYS.items()
-    }
-
-
-def program_table_row(program: Program) -> List[Any]:
-    """Return a compact row; detailed program data remains in the WebUI database."""
-    metadata = program.metadata or {}
-    return [
-        program.id,
-        program.generation,
-        _finite_float(program.combined_score),
-        bool(program.correct),
-        program.parent_id,
-        program.island_idx,
-        bool(program.in_archive),
-        metadata.get("patch_type"),
-        _program_model_name(program),
-        sum(program_costs(program).values()),
-    ]
-
-
-def build_run_summary(
-    programs: Sequence[Program],
-    *,
-    total_proposals_generated: Optional[int] = None,
-    total_api_cost: Optional[float] = None,
-) -> Dict[str, Any]:
-    """Build concise final values for the W&B run summary."""
-    correct_programs = [program for program in programs if program.correct]
-    correct_scores = [
-        score
-        for program in correct_programs
-        if (score := _finite_float(program.combined_score)) is not None
-    ]
-    summary = {
-        "run/program_count": len(programs),
-        "run/correct_rate": (
-            len(correct_programs) / len(programs) if programs else 0.0
-        ),
-        "run/max_generation": max(
-            (program.generation for program in programs), default=0
-        ),
-        "run/best_score": max(correct_scores) if correct_scores else None,
-        "run/total_proposals_generated": total_proposals_generated,
-        "run/total_api_cost": _finite_float(total_api_cost),
-    }
-    return {key: value for key, value in summary.items() if value is not None}
-
-
 class ShinkaWandbLogger:
     """Best-effort W&B sink that leaves database/WebUI logging unchanged."""
 
@@ -188,6 +143,7 @@ class ShinkaWandbLogger:
         self._wandb: Optional[Any] = None
         self._run: Optional[Any] = None
         self._logged_program_ids: set[str] = set()
+        self._last_population_evaluated_count: Optional[int] = None
 
     @property
     def active(self) -> bool:
@@ -229,11 +185,19 @@ class ShinkaWandbLogger:
             )
             evo_config.wandb_run_id = run_id
             config = {
-                "evolution": _json_safe(evo_config),
-                "database": _json_safe(db_config),
-                "job": _json_safe(job_config),
+                "evolution": _safe_config_fields(evo_config, _EVOLUTION_CONFIG_FIELDS),
+                "database": _safe_config_fields(db_config, _DATABASE_CONFIG_FIELDS),
+                "job": _safe_config_fields(job_config, _JOB_CONFIG_FIELDS),
             }
             config.update(extra_config)
+            settings = self._wandb.Settings(
+                console="off",
+                disable_git=True,
+                disable_code=True,
+                x_disable_stats=True,
+                x_disable_machine_info=True,
+                x_save_requirements=False,
+            )
             init_kwargs = {
                 "project": getattr(evo_config, "wandb_project", None)
                 or "shinka-evolve",
@@ -247,6 +211,8 @@ class ShinkaWandbLogger:
                 "dir": getattr(evo_config, "wandb_dir", None) or str(results_dir),
                 "id": run_id,
                 "resume": getattr(evo_config, "wandb_resume", "allow"),
+                "save_code": False,
+                "settings": settings,
                 "config": config,
             }
             self._run = self._wandb.init(
@@ -264,13 +230,57 @@ class ShinkaWandbLogger:
             self.enabled = False
 
     def log_program(self, program: Program) -> None:
-        if not self.active or program.id in self._logged_program_ids:
+        if (
+            not self.active
+            or is_island_copy(program)
+            or program.id in self._logged_program_ids
+        ):
+            return
+        self.log_program_payload(program.id, build_program_log_payload(program))
+
+    def log_program_payload(self, program_id: str, payload: dict[str, Any]) -> None:
+        """Log one prebuilt compact candidate payload."""
+        run = self._run
+        if not self.enabled or run is None or program_id in self._logged_program_ids:
             return
         try:
-            self._run.log(build_program_log_payload(program))
-            self._logged_program_ids.add(program.id)
+            run.log(payload)
+            self._logged_program_ids.add(program_id)
         except Exception as exc:
-            logger.warning("Failed to log individual %s to W&B: %s", program.id, exc)
+            logger.warning("Failed to log individual %s to W&B: %s", program_id, exc)
+
+    def log_population_progress(
+        self,
+        *,
+        db: Optional[ProgramDatabase],
+    ) -> None:
+        """Log a snapshot only when the evaluated population advances."""
+        if not self.enabled or self._run is None or db is None:
+            return
+        try:
+            snapshot = db.get_population_telemetry()
+        except Exception as exc:
+            logger.warning("Failed to query W&B population progress: %s", exc)
+            return
+        self.log_population_snapshot(snapshot)
+
+    def log_population_snapshot(self, snapshot: list[dict[str, Any]]) -> None:
+        """Log a precomputed snapshot on the W&B telemetry worker."""
+        run = self._run
+        if not self.enabled or run is None:
+            return
+        try:
+            payload = build_population_progress_payload_from_telemetry(snapshot)
+            evaluated_count = payload[EVALUATED_COUNT_METRIC]
+            if (
+                self._last_population_evaluated_count is not None
+                and evaluated_count <= self._last_population_evaluated_count
+            ):
+                return
+            run.log(payload)
+            self._last_population_evaluated_count = evaluated_count
+        except Exception as exc:
+            logger.warning("Failed to log W&B population progress: %s", exc)
 
     def log_final(
         self,
@@ -278,25 +288,72 @@ class ShinkaWandbLogger:
         db: Optional[ProgramDatabase],
         total_proposals_generated: Optional[int] = None,
         total_api_cost: Optional[float] = None,
+        total_cost: Optional[float] = None,
     ) -> None:
-        if not self.active or db is None:
+        if not self.enabled or self._run is None or self._wandb is None or db is None:
             return
         try:
             programs = db.get_all_programs()
-            self._run.summary.update(
-                build_run_summary(
-                    programs,
-                    total_proposals_generated=total_proposals_generated,
-                    total_api_cost=total_api_cost,
-                )
+        except Exception as exc:
+            logger.warning("Failed to query final W&B programs: %s", exc)
+            return
+        self.log_final_programs(
+            programs,
+            total_proposals_generated=total_proposals_generated,
+            total_api_cost=total_api_cost,
+            total_cost=total_cost,
+        )
+
+    def log_final_programs(
+        self,
+        programs: list[Program],
+        *,
+        total_proposals_generated: Optional[int] = None,
+        total_api_cost: Optional[float] = None,
+        total_cost: Optional[float] = None,
+    ) -> None:
+        """Log final metrics and table from owner-thread materialized programs."""
+        run = self._run
+        wandb = self._wandb
+        if not self.enabled or run is None or wandb is None:
+            return
+        try:
+            final_summary = build_run_summary(
+                programs,
+                total_proposals_generated=total_proposals_generated,
+                total_api_cost=total_api_cost,
+                total_cost=total_cost,
             )
-            table = self._wandb.Table(
+            final_payload = build_population_progress_payload(programs)
+            final_payload.update(final_summary)
+        except Exception as exc:
+            logger.warning("Failed to prepare final W&B metrics: %s", exc)
+            return
+
+        try:
+            run.log(final_payload)
+        except Exception as exc:
+            logger.warning("Failed to log final W&B history: %s", exc)
+        self._last_population_evaluated_count = final_payload[EVALUATED_COUNT_METRIC]
+
+        try:
+            run.summary.update(final_summary)
+        except Exception as exc:
+            logger.warning("Failed to update final W&B summary: %s", exc)
+
+        try:
+            table = wandb.Table(
                 columns=PROGRAM_TABLE_COLUMNS,
                 data=[program_table_row(program) for program in programs],
             )
-            self._run.log({PROGRAM_TABLE_KEY: table})
         except Exception as exc:
-            logger.warning("Failed to log final W&B summary: %s", exc)
+            logger.warning("Failed to construct final W&B table: %s", exc)
+            return
+
+        try:
+            run.log({PROGRAM_TABLE_KEY: table})
+        except Exception as exc:
+            logger.warning("Failed to log final W&B table: %s", exc)
 
     def finish(self) -> None:
         if self._run is None:
@@ -309,53 +366,38 @@ class ShinkaWandbLogger:
             self._run = None
 
     def _define_metrics(self) -> None:
-        if not hasattr(self._run, "define_metric"):
+        run = self._run
+        if run is None or not hasattr(run, "define_metric"):
             return
-        self._run.define_metric(GENERATION_METRIC)
-        self._run.define_metric(
-            INDIVIDUAL_SCORE_METRIC,
-            step_metric=GENERATION_METRIC,
-        )
+        run.define_metric(GENERATION_METRIC)
+        run.define_metric(EVALUATED_COUNT_METRIC)
+        run.define_metric(INDIVIDUAL_SCORE_METRIC)
+        run.define_metric("run/*")
         for metric_glob in (
+            "population/count",
+            "population/correct_count",
+            "population/correct_rate",
+            "population/best_score",
+            "population/best_correct_score",
+            "population/mean_score",
+            "island/*",
             "cost/*",
             "timing/*",
-            "public_metrics/*",
-            "private_metrics/*",
         ):
-            self._run.define_metric(metric_glob, step_metric=GENERATION_METRIC)
-
-
-def _program_model_name(program: Program) -> Optional[str]:
-    metadata = program.metadata or {}
-    llm_result = metadata.get("llm_result")
-    nested_model = llm_result.get("model") if isinstance(llm_result, dict) else None
-    value = metadata.get("model_name") or metadata.get("model") or nested_model
-    return str(value) if value is not None else None
-
-
-def _finite_float(value: Any) -> Optional[float]:
-    if value is None or isinstance(value, (bool, str, bytes)):
-        return None
-    if hasattr(value, "item") and callable(value.item):
-        try:
-            value = value.item()
-        except Exception:
-            return None
-    if not isinstance(value, (int, float)):
-        return None
-    parsed = float(value)
-    return parsed if math.isfinite(parsed) else None
-
-
-def _metric_segment(value: Any) -> str:
-    segment = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip())
-    return segment.strip("_") or "value"
+            run.define_metric(
+                metric_glob,
+                step_metric=EVALUATED_COUNT_METRIC,
+            )
 
 
 def _json_safe(value: Any) -> Any:
     if is_dataclass(value) and not isinstance(value, type):
         return {
-            field.name: _json_safe(getattr(value, field.name))
+            field.name: (
+                _REDACTED_VALUE
+                if _is_sensitive_config_key(field.name)
+                else _json_safe(getattr(value, field.name))
+            )
             for field in fields(value)
         }
     if isinstance(value, Path):
@@ -368,9 +410,33 @@ def _json_safe(value: Any) -> Any:
         try:
             return _json_safe(value.item())
         except Exception:
-            pass
+            return f"<{type(value).__name__}>"
     if isinstance(value, dict):
-        return {str(key): _json_safe(item) for key, item in value.items()}
+        return {
+            str(key): (
+                _REDACTED_VALUE if _is_sensitive_config_key(key) else _json_safe(item)
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, (list, tuple, set)):
         return [_json_safe(item) for item in value]
-    return repr(value)
+    return f"<{type(value).__name__}>"
+
+
+def _safe_config_fields(value: Any, allowed_fields: tuple[str, ...]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    missing = object()
+    for field_name in allowed_fields:
+        if isinstance(value, dict):
+            field_value = value.get(field_name, missing)
+        else:
+            field_value = getattr(value, field_name, missing)
+        if field_value is missing:
+            continue
+        if field_value is None or isinstance(field_value, (bool, int, float, str)):
+            safe[field_name] = _json_safe(field_value)
+    return safe
+
+
+def _is_sensitive_config_key(value: Any) -> bool:
+    return is_sensitive_telemetry_key(value)

--- a/shinka/wandb_metrics.py
+++ b/shinka/wandb_metrics.py
@@ -1,0 +1,408 @@
+"""Safe metric payloads for the optional W&B integration."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from shinka.database import Program
+from shinka.telemetry_safety import is_sensitive_telemetry_key
+
+GENERATION_METRIC = "generation"
+INDIVIDUAL_SCORE_METRIC = "score/individual"
+EVALUATED_COUNT_METRIC = "population/evaluated_count"
+PROGRAM_TABLE_KEY = "population/final_table"
+MAX_PUBLIC_METRICS = 64
+MAX_METRIC_KEY_LENGTH = 128
+PROGRAM_TABLE_COLUMNS = [
+    "id",
+    "generation",
+    "score",
+    "correct",
+    "parent_id",
+    "island_idx",
+    "is_copy",
+    "in_archive",
+    "patch_type",
+    "model_name",
+    "cost",
+]
+
+_COST_KEYS = {
+    "api": "api_costs",
+    "embed": "embed_cost",
+    "novelty": "novelty_cost",
+    "meta": "meta_cost",
+}
+_HEADLESS_MODEL_PREFIX = "headless/"
+_TIMING_KEYS = (
+    "sampling_seconds",
+    "evaluation_seconds",
+    "postprocess_seconds",
+    "pipeline_seconds",
+)
+
+
+def build_program_log_payload(program: Program) -> Dict[str, Any]:
+    """Build one raw W&B history event for an evaluated individual.
+
+    Individual events use W&B's internal history step. They are candidate
+    scatter data, not the run's canonical progress series.
+    """
+    metadata = program.metadata or {}
+    headless_used = _is_headless_program(program)
+    logged_costs = _reported_program_costs(program)
+    individual_score = _finite_float(program.combined_score)
+    payload: Dict[str, Any] = {
+        GENERATION_METRIC: program.generation,
+        INDIVIDUAL_SCORE_METRIC: individual_score,
+        "individual/id": program.id,
+        "individual/parent_id": program.parent_id,
+        "individual/island_idx": program.island_idx,
+        "individual/is_copy": is_island_copy(program),
+        "individual/correct": bool(program.correct),
+        "individual/in_archive": bool(program.in_archive),
+        "individual/patch_type": metadata.get("patch_type"),
+        "individual/model_name": _program_model_name(program),
+        **{f"individual/cost/{name}": value for name, value in logged_costs.items()},
+    }
+    if headless_used:
+        payload.update(
+            {
+                "headless/usage_status": metadata.get("headless_usage_status"),
+                "headless/usage_unknown": metadata.get("headless_usage_unknown"),
+                "headless/pricing_status": metadata.get("headless_pricing_status"),
+                "headless/pricing_unknown": metadata.get("headless_pricing_unknown"),
+                "headless/cost_basis": metadata.get("headless_cost_basis"),
+                "headless/pricing_source": metadata.get("headless_pricing_source"),
+            }
+        )
+
+    for key in _TIMING_KEYS:
+        value = _finite_float(metadata.get(key))
+        if value is not None:
+            payload[f"individual/timing/{key}"] = value
+
+    for key, value in flatten_numeric_metrics(
+        program.public_metrics,
+        "public_metrics",
+        max_metrics=MAX_PUBLIC_METRICS,
+        max_key_length=MAX_METRIC_KEY_LENGTH,
+    ).items():
+        leaf_name = key.rsplit("/", 1)[-1]
+        if leaf_name in {"score", "combined_score"} and value == individual_score:
+            continue
+        payload[key] = value
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def is_island_copy(program: Program) -> bool:
+    """Return whether a DB row is an administrative copy."""
+    metadata = program.metadata or {}
+    return bool(metadata.get("_is_island_copy") or metadata.get("_spawned_island"))
+
+
+def flatten_numeric_metrics(
+    data: Any,
+    prefix: str,
+    *,
+    max_depth: int = 3,
+    max_metrics: int = MAX_PUBLIC_METRICS,
+    max_key_length: int = MAX_METRIC_KEY_LENGTH,
+) -> Dict[str, float]:
+    """Flatten only numeric evaluation metrics, excluding bulky text and arrays."""
+    flattened: Dict[str, float] = {}
+
+    def visit(value: Any, parts: List[str], depth: int) -> None:
+        if depth > max_depth or len(flattened) >= max_metrics:
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if len(flattened) >= max_metrics:
+                    break
+                if len(str(key)) > max_key_length or _is_sensitive_metric_key(key):
+                    continue
+                visit(child, [*parts, _metric_segment(key)], depth + 1)
+            return
+        numeric_value = _finite_float(value)
+        if numeric_value is not None:
+            metric_key = "/".join([prefix, *parts])
+            if len(metric_key) <= max_key_length:
+                flattened[metric_key] = numeric_value
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if len(flattened) >= max_metrics:
+                break
+            if len(str(key)) > max_key_length or _is_sensitive_metric_key(key):
+                continue
+            visit(value, [_metric_segment(key)], 1)
+    return flattened
+
+
+def program_costs(program: Program) -> Dict[str, float]:
+    """Return the non-duplicated cost breakdown for one individual."""
+    metadata = program.metadata or {}
+    return {
+        name: _finite_float(metadata.get(metadata_key)) or 0.0
+        for name, metadata_key in _COST_KEYS.items()
+    }
+
+
+def program_table_row(program: Program) -> List[Any]:
+    """Return a compact row; detailed program data remains in the WebUI database."""
+    metadata = program.metadata or {}
+    return [
+        program.id,
+        program.generation,
+        _finite_float(program.combined_score),
+        bool(program.correct),
+        program.parent_id,
+        program.island_idx,
+        is_island_copy(program),
+        bool(program.in_archive),
+        metadata.get("patch_type"),
+        _program_model_name(program),
+        0.0
+        if is_island_copy(program)
+        else sum(_reported_program_costs(program).values()),
+    ]
+
+
+def build_population_progress_payload(
+    programs: Sequence[Program],
+    *,
+    evaluated_count: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build cumulative population and island metrics for one snapshot.
+
+    Administrative copies remain visible in population counts, while the
+    evaluation axis, costs, and timings describe unique evaluated programs.
+    """
+    all_programs = list(programs)
+    evaluated_programs = [
+        program for program in all_programs if not is_island_copy(program)
+    ]
+    scores = _scores(all_programs)
+    correct_programs = [program for program in all_programs if program.correct]
+    correct_scores = _scores(correct_programs)
+    costs = {
+        name: sum(
+            program_costs(program)[name]
+            for program in evaluated_programs
+            if not _has_unknown_headless_api_cost(program, name)
+        )
+        for name in _COST_KEYS
+    }
+    unknown_pricing_count = sum(
+        1
+        for program in evaluated_programs
+        if _has_unknown_headless_api_cost(program, "api")
+    )
+    payload: Dict[str, Any] = {
+        EVALUATED_COUNT_METRIC: (
+            len(evaluated_programs)
+            if evaluated_count is None
+            else max(0, int(evaluated_count))
+        ),
+        "population/count": len(all_programs),
+        "population/correct_count": len(correct_programs),
+        "population/correct_rate": (
+            len(correct_programs) / len(all_programs) if all_programs else 0.0
+        ),
+        "population/best_score": max(scores) if scores else None,
+        "population/best_correct_score": (
+            max(correct_scores) if correct_scores else None
+        ),
+        "population/mean_score": sum(scores) / len(scores) if scores else None,
+        "cost/api": costs["api"],
+        "cost/embed": costs["embed"],
+        "cost/novelty": costs["novelty"],
+        "cost/meta": costs["meta"],
+        "cost/total": sum(costs.values()),
+        "cost/pricing_unknown_count": unknown_pricing_count,
+    }
+
+    for key in _TIMING_KEYS:
+        payload[f"timing/{key}_total"] = sum(
+            _finite_float((program.metadata or {}).get(key)) or 0.0
+            for program in evaluated_programs
+        )
+
+    islands: Dict[str, List[Program]] = {}
+    for program in all_programs:
+        island_key = (
+            str(program.island_idx) if program.island_idx is not None else "unknown"
+        )
+        islands.setdefault(island_key, []).append(program)
+    for island_key, island_programs in islands.items():
+        payload.update(_island_payload(island_key, island_programs))
+
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def build_population_progress_payload_from_telemetry(
+    telemetry: Sequence[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """Build population metrics from compact database aggregate rows."""
+    rows = list(telemetry)
+    count = sum(int(row["count"]) for row in rows)
+    evaluated_count = sum(int(row["evaluated_count"]) for row in rows)
+    correct_count = sum(int(row["correct_count"]) for row in rows)
+    score_count = sum(int(row["score_count"]) for row in rows)
+    score_sum = sum(float(row["score_sum"]) for row in rows)
+    costs = {
+        name: sum(float(row[f"{name}_cost"]) for row in rows) for name in _COST_KEYS
+    }
+
+    payload: Dict[str, Any] = {
+        EVALUATED_COUNT_METRIC: evaluated_count,
+        "population/count": count,
+        "population/correct_count": correct_count,
+        "population/correct_rate": correct_count / count if count else 0.0,
+        "population/best_score": _maximum_aggregate(rows, "best_score"),
+        "population/best_correct_score": _maximum_aggregate(rows, "best_correct_score"),
+        "population/mean_score": score_sum / score_count if score_count else None,
+        **{f"cost/{name}": value for name, value in costs.items()},
+        "cost/total": sum(costs.values()),
+        "cost/pricing_unknown_count": sum(
+            int(row["pricing_unknown_count"]) for row in rows
+        ),
+    }
+    for key in _TIMING_KEYS:
+        payload[f"timing/{key}_total"] = sum(float(row[key]) for row in rows)
+    for row in rows:
+        island_key = (
+            str(row["island_idx"]) if row["island_idx"] is not None else "unknown"
+        )
+        island_count = int(row["count"])
+        island_score_count = int(row["score_count"])
+        prefix = f"island/{_metric_segment(island_key)}"
+        payload.update(
+            {
+                f"{prefix}/count": island_count,
+                f"{prefix}/evaluated_count": int(row["evaluated_count"]),
+                f"{prefix}/correct_count": int(row["correct_count"]),
+                f"{prefix}/correct_rate": (
+                    int(row["correct_count"]) / island_count if island_count else 0.0
+                ),
+                f"{prefix}/best_score": _finite_float(row["best_score"]),
+                f"{prefix}/mean_score": (
+                    float(row["score_sum"]) / island_score_count
+                    if island_score_count
+                    else None
+                ),
+            }
+        )
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _maximum_aggregate(rows: Sequence[Mapping[str, Any]], key: str) -> Optional[float]:
+    values = [value for row in rows if (value := _finite_float(row[key])) is not None]
+    return max(values) if values else None
+
+
+def build_run_summary(
+    programs: Sequence[Program],
+    *,
+    total_proposals_generated: Optional[int] = None,
+    total_api_cost: Optional[float] = None,
+    total_cost: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Build concise final values for the W&B run summary."""
+    population = build_population_progress_payload(programs)
+    correct_scores = _scores([program for program in programs if program.correct])
+    summary = {
+        "run/program_count": len(programs),
+        "run/evaluated_count": population[EVALUATED_COUNT_METRIC],
+        "run/correct_rate": population["population/correct_rate"],
+        "run/max_generation": max(
+            (program.generation for program in programs), default=0
+        ),
+        "run/best_score": max(correct_scores) if correct_scores else None,
+        "run/total_proposals_generated": total_proposals_generated,
+        "run/total_api_cost": _finite_float(total_api_cost),
+        "run/total_cost": _finite_float(
+            total_cost if total_cost is not None else total_api_cost
+        ),
+    }
+    return {key: value for key, value in summary.items() if value is not None}
+
+
+def _island_payload(island_key: str, programs: Sequence[Program]) -> Dict[str, Any]:
+    scores = _scores(programs)
+    correct_count = sum(1 for program in programs if program.correct)
+    prefix = f"island/{_metric_segment(island_key)}"
+    return {
+        f"{prefix}/count": len(programs),
+        f"{prefix}/evaluated_count": sum(
+            1 for program in programs if not is_island_copy(program)
+        ),
+        f"{prefix}/correct_count": correct_count,
+        f"{prefix}/correct_rate": correct_count / len(programs) if programs else 0.0,
+        f"{prefix}/best_score": max(scores) if scores else None,
+        f"{prefix}/mean_score": sum(scores) / len(scores) if scores else None,
+    }
+
+
+def _scores(programs: Sequence[Program]) -> List[float]:
+    return [
+        score
+        for program in programs
+        if (score := _finite_float(program.combined_score)) is not None
+    ]
+
+
+def _has_unknown_headless_api_cost(program: Program, cost_name: str) -> bool:
+    return (
+        cost_name == "api"
+        and _is_headless_program(program)
+        and (program.metadata or {}).get("headless_pricing_unknown") is True
+    )
+
+
+def _reported_program_costs(program: Program) -> Dict[str, float]:
+    return {
+        name: value
+        for name, value in program_costs(program).items()
+        if not _has_unknown_headless_api_cost(program, name)
+    }
+
+
+def _program_model_name(program: Program) -> Optional[str]:
+    metadata = program.metadata or {}
+    llm_result = metadata.get("llm_result")
+    nested_model = None
+    if isinstance(llm_result, dict):
+        nested_model = llm_result.get("model_name") or llm_result.get("model")
+    value = metadata.get("model_name") or metadata.get("model") or nested_model
+    return str(value) if value is not None else None
+
+
+def _is_headless_program(program: Program) -> bool:
+    model_name = _program_model_name(program)
+    return model_name is not None and model_name.startswith(_HEADLESS_MODEL_PREFIX)
+
+
+def _finite_float(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, (bool, str, bytes)):
+        return None
+    if hasattr(value, "item") and callable(value.item):
+        try:
+            value = value.item()
+        except Exception:
+            return None
+    if not isinstance(value, (int, float)):
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def _metric_segment(value: Any) -> str:
+    segment = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip())
+    return segment.strip("_") or "value"
+
+
+def _is_sensitive_metric_key(value: Any) -> bool:
+    return is_sensitive_telemetry_key(value)

--- a/tests/test_async_runner_recovery.py
+++ b/tests/test_async_runner_recovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ from shinka.core.async_runner import (
     ShinkaEvolveRunner,
 )
 from shinka.core.runtime_slots import LogicalSlotPool
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
 
 
 class _FakeAsyncDB:
@@ -1541,6 +1543,13 @@ def test_job_monitor_processes_completed_jobs_inline():
         runner._retry_failed_db_jobs = lambda: asyncio.sleep(0, result=None)
         runner._record_progress = lambda: None
         runner._mark_surplus_completed_jobs_for_discard = lambda jobs: None
+        lifecycle = []
+
+        async def update_completed_generations():
+            lifecycle.append("updated")
+
+        runner._update_completed_generations = update_completed_generations
+        runner._log_wandb_population_progress = lambda: lifecycle.append("wandb")
 
         batch_started = asyncio.Event()
         allow_finish = asyncio.Event()
@@ -1581,5 +1590,70 @@ def test_job_monitor_processes_completed_jobs_inline():
         runner.should_stop.set()
         allow_finish.set()
         await asyncio.wait_for(monitor_task, timeout=0.2)
+
+        assert lifecycle == ["updated", "wandb"]
+
+    asyncio.run(_run())
+
+
+def test_wandb_population_snapshots_are_offloaded_and_coalesced():
+    async def _run():
+        runner = _build_runner()
+        runner._wandb_population_interval_seconds = 0.0
+        first_started = asyncio.Event()
+        release_first = threading.Event()
+        loop_thread = threading.get_ident()
+        call_threads = []
+        active = 0
+        max_active = 0
+
+        class Logger:
+            def log_population_progress(self, *, db):
+                nonlocal active, max_active
+                call_threads.append(threading.get_ident())
+                active += 1
+                max_active = max(max_active, active)
+                if len(call_threads) == 1:
+                    loop.call_soon_threadsafe(first_started.set)
+                    release_first.wait(timeout=1)
+                active -= 1
+
+        loop = asyncio.get_running_loop()
+        runner.wandb_logger = Logger()
+        runner._log_wandb_population_progress()
+        await asyncio.wait_for(first_started.wait(), timeout=0.2)
+
+        runner._log_wandb_population_progress()
+        runner._log_wandb_population_progress()
+        await asyncio.sleep(0)
+        release_first.set()
+        await runner._wait_for_wandb_population_progress()
+
+        assert len(call_threads) == 2
+        assert all(thread_id != loop_thread for thread_id in call_threads)
+        assert max_active == 1
+
+    asyncio.run(_run())
+
+
+def test_wandb_population_snapshot_uses_worker_owned_database_connection(tmp_path):
+    async def _run():
+        db = ProgramDatabase(
+            DatabaseConfig(db_path=str(tmp_path / "programs.sqlite"))
+        )
+        db.add(Program(id="program", code="pass"), defer_maintenance=True)
+        observed_ids = []
+
+        class Logger:
+            def log_population_progress(self, *, db):
+                observed_ids.extend(program.id for program in db.get_all_programs())
+
+        runner = _build_runner(db=db)
+        runner.wandb_logger = Logger()
+        runner._log_wandb_population_progress()
+        await runner._wait_for_wandb_population_progress()
+        db.close()
+
+        assert observed_ids == ["program"]
 
     asyncio.run(_run())

--- a/tests/test_wandb_database.py
+++ b/tests/test_wandb_database.py
@@ -1,0 +1,339 @@
+import threading
+from types import SimpleNamespace
+
+from shinka.core.async_runner import ShinkaEvolveRunner
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.wandb_logging import ShinkaWandbLogger
+from shinka.wandb_metrics import (
+    build_population_progress_payload,
+    build_population_progress_payload_from_telemetry,
+)
+from wandb_test_utils import make_db
+
+
+def test_population_progress_uses_aggregate_query_without_heavy_fields(
+    tmp_path, monkeypatch
+):
+    db, _, _ = make_db(tmp_path)
+    statements = []
+    db.conn.set_trace_callback(statements.append)
+    monkeypatch.setattr(
+        db,
+        "get_all_programs",
+        lambda: (_ for _ in ()).throw(AssertionError("full rows were materialized")),
+    )
+    logged = []
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(log=logged.append)
+
+    logger.log_population_progress(db=db)
+
+    select = next(
+        statement for statement in statements if "WITH metadata_source AS" in statement
+    )
+    assert " code" not in select.lower()
+    assert "embedding" not in select.lower()
+    assert "private_metrics" not in select.lower()
+    assert "public_metrics" not in select.lower()
+    assert logged[0]["population/count"] == 2
+    assert logged[0]["population/evaluated_count"] == 2
+
+
+def test_population_aggregate_matches_full_program_metric_semantics(tmp_path):
+    db, _, _ = make_db(tmp_path)
+    db.add(
+        Program(
+            id="copy",
+            code="pass",
+            combined_score=1.0,
+            correct=True,
+            island_idx=2,
+            metadata={"_is_island_copy": True, "api_costs": 99.0},
+        ),
+        defer_maintenance=True,
+    )
+    db.add(
+        Program(
+            id="non-finite",
+            code="pass",
+            combined_score=float("inf"),
+            metadata={
+                "api_costs": 2.0,
+                "meta_cost": float("inf"),
+                "pipeline_seconds": float("inf"),
+            },
+        ),
+        defer_maintenance=True,
+    )
+    db.add(
+        Program(
+            id="uppercase-headless",
+            code="pass",
+            metadata={
+                "model_name": "HEADLESS/codex",
+                "headless_pricing_unknown": True,
+                "api_costs": 12.0,
+            },
+        ),
+        defer_maintenance=True,
+    )
+
+    aggregate_payload = build_population_progress_payload_from_telemetry(
+        db.get_population_telemetry()
+    )
+    full_payload = build_population_progress_payload(db.get_all_programs())
+
+    assert aggregate_payload == full_payload
+
+
+def _make_runner(db, logger):
+    runner = object.__new__(ShinkaEvolveRunner)
+    runner.db = db
+    runner.wandb_logger = logger
+    runner.total_api_cost = 0.5
+    runner.total_proposals_generated = 3
+    runner._wandb_population_task = None
+    runner._wandb_population_delay_task = None
+    runner._wandb_population_pending = False
+    runner._wandb_last_population_snapshot_at = None
+    runner._wandb_population_interval_seconds = 5.0
+    runner._wandb_executor = None
+    runner._wandb_candidate_queue = None
+    runner._wandb_candidate_worker_task = None
+    runner._wandb_dropped_candidate_events = 0
+    runner._wandb_last_drop_warning_at = None
+    return runner
+
+
+def test_in_memory_snapshots_read_sqlite_on_owner_thread():
+    async def run():
+        owner_thread = threading.get_ident()
+        db = ProgramDatabase(DatabaseConfig())
+        db.add(Program(id="program", code="pass"), defer_maintenance=True)
+        observed = []
+
+        class Logger:
+            active = True
+
+            def log_population_snapshot(self, snapshot):
+                observed.append(("population", snapshot, threading.get_ident()))
+
+            def log_final_programs(self, programs, **kwargs):
+                observed.append(
+                    (
+                        "final",
+                        [program.id for program in programs],
+                        threading.get_ident(),
+                    )
+                )
+
+            def finish(self):
+                observed.append(("finish", None, threading.get_ident()))
+
+        runner = _make_runner(db, Logger())
+        runner._log_wandb_population_progress()
+        await runner._finish_wandb_logging()
+        db.close()
+
+        assert observed[0][0] == "population"
+        assert observed[0][1][0]["count"] == 1
+        assert observed[1][0:2] == ("final", ["program"])
+        assert all(thread_id != owner_thread for _, _, thread_id in observed)
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_wandb_sdk_operations_share_one_nonblocking_worker():
+    async def run():
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        owner_thread = threading.get_ident()
+        first_started = asyncio.Event()
+        release_first = threading.Event()
+        operation_lock = threading.Lock()
+        calls = []
+
+        class Database:
+            config = SimpleNamespace(db_path=None)
+
+            def get_population_telemetry(self):
+                assert threading.get_ident() == owner_thread
+                return []
+
+            def get_all_programs(self):
+                assert threading.get_ident() == owner_thread
+                return []
+
+        class Logger:
+            active = True
+
+            def _record(self, name, *, wait=False):
+                assert operation_lock.acquire(blocking=False), "overlapping W&B call"
+                try:
+                    calls.append((name, threading.get_ident()))
+                    if wait:
+                        loop.call_soon_threadsafe(first_started.set)
+                        release_first.wait(timeout=1)
+                finally:
+                    operation_lock.release()
+
+            def log_program_payload(self, program_id, payload):
+                self._record("candidate", wait=True)
+
+            def log_population_snapshot(self, snapshot):
+                self._record("population")
+
+            def log_final_programs(self, programs, **kwargs):
+                self._record("final")
+
+            def finish(self):
+                self._record("finish")
+
+        runner = _make_runner(Database(), Logger())
+        runner._log_program_to_wandb(Program(id="candidate", code="pass"))
+        await asyncio.wait_for(first_started.wait(), timeout=0.2)
+        runner._log_wandb_population_progress()
+        finish_task = asyncio.create_task(runner._finish_wandb_logging())
+        await asyncio.sleep(0)
+        release_first.set()
+        await finish_task
+
+        assert [name for name, _ in calls] == [
+            "candidate",
+            "population",
+            "final",
+            "finish",
+        ]
+        worker_threads = {thread_id for _, thread_id in calls}
+        assert len(worker_threads) == 1
+        assert owner_thread not in worker_threads
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_wandb_candidate_queue_is_bounded_compact_and_rate_limited(caplog):
+    async def run():
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        first_started = asyncio.Event()
+        release_first = threading.Event()
+        logged_ids = []
+
+        class Logger:
+            active = True
+
+            def log_program_payload(self, program_id, payload):
+                logged_ids.append(program_id)
+                if len(logged_ids) == 1:
+                    loop.call_soon_threadsafe(first_started.set)
+                    release_first.wait(timeout=1)
+
+        runner = _make_runner(SimpleNamespace(), Logger())
+        runner._wandb_candidate_queue_size = 2
+        runner._log_program_to_wandb(
+            Program(id="first", code="unique-private-code-first")
+        )
+        await asyncio.wait_for(first_started.wait(), timeout=0.2)
+
+        for program_id in ("second", "third", "fourth", "fifth"):
+            runner._log_program_to_wandb(
+                Program(id=program_id, code=f"unique-private-code-{program_id}")
+            )
+
+        queue = runner._wandb_candidate_queue
+        assert queue.maxsize == 2
+        assert queue.qsize() == 2
+        assert "unique-private-code" not in repr(list(queue._queue))
+        assert "Program(" not in repr(list(queue._queue))
+        assert runner._wandb_dropped_candidate_events == 2
+        assert caplog.text.count("W&B candidate queue full") == 1
+
+        release_first.set()
+        await runner._drain_wandb_candidate_queue()
+        await runner._stop_wandb_candidate_worker()
+        await runner._shutdown_wandb_executor()
+
+        assert logged_ids == ["first", "second", "third"]
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_wandb_population_queries_are_time_throttled_and_final_skips_delay():
+    async def run():
+        import asyncio
+
+        query_count = 0
+
+        class Database:
+            config = SimpleNamespace(db_path=None)
+
+            def get_population_telemetry(self):
+                nonlocal query_count
+                query_count += 1
+                return []
+
+            def get_all_programs(self):
+                return []
+
+        class Logger:
+            active = True
+
+            def log_population_snapshot(self, snapshot):
+                pass
+
+            def log_final_programs(self, programs, **kwargs):
+                pass
+
+            def finish(self):
+                pass
+
+        runner = _make_runner(Database(), Logger())
+        runner._wandb_population_interval_seconds = 60.0
+        runner._log_wandb_population_progress()
+        await runner._wait_for_wandb_population_progress()
+
+        runner._log_wandb_population_progress()
+        runner._log_wandb_population_progress()
+        runner._log_wandb_population_progress()
+        await asyncio.sleep(0)
+
+        assert query_count == 1
+        assert runner._wandb_population_delay_task is not None
+
+        await runner._finish_wandb_logging()
+
+        assert query_count == 1
+        assert runner._wandb_population_delay_task is None
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+def test_in_memory_population_query_failure_is_non_fatal(caplog):
+    class Database:
+        config = SimpleNamespace(db_path=None)
+
+        def get_population_telemetry(self):
+            raise RuntimeError("telemetry query failed")
+
+    logger = SimpleNamespace(active=True, log_population_snapshot=lambda snapshot: None)
+    runner = _make_runner(Database(), logger)
+
+    async def run():
+        runner._log_wandb_population_progress()
+
+    import asyncio
+
+    asyncio.run(run())
+
+    assert runner._wandb_population_task is None
+    assert "Failed to query in-memory W&B population snapshot" in caplog.text

--- a/tests/test_wandb_logging.py
+++ b/tests/test_wandb_logging.py
@@ -4,63 +4,17 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from shinka.core.config import EvolutionConfig
-from shinka.database import DatabaseConfig, Program, ProgramDatabase
+from shinka.database import DatabaseConfig, Program
+from shinka.launch.scheduler import LocalJobConfig
 from shinka.wandb_logging import (
+    EVALUATED_COUNT_METRIC,
     INDIVIDUAL_SCORE_METRIC,
     PROGRAM_TABLE_COLUMNS,
     PROGRAM_TABLE_KEY,
     ShinkaWandbLogger,
-    build_program_log_payload,
-    build_run_summary,
     ensure_wandb_run_id,
 )
-
-
-def _make_db(tmp_path):
-    db = ProgramDatabase(DatabaseConfig(db_path=str(tmp_path / "programs.sqlite")))
-    first = Program(
-        id="p0",
-        code="print(0)",
-        generation=0,
-        correct=True,
-        combined_score=1.0,
-        public_metrics={
-            "score": 1.0,
-            "nested": {"accuracy": 0.5},
-            "bulky_text": "not a chart metric",
-        },
-        private_metrics={"hidden": 2.0},
-        metadata={
-            "api_costs": 0.10,
-            "embed_cost": 0.01,
-            "novelty_cost": 0.02,
-            "meta_cost": 0.03,
-            "patch_type": "init",
-            "pipeline_seconds": 2.0,
-            "evaluation_seconds": 1.5,
-            "model_name": "test-model",
-        },
-    )
-    second = Program(
-        id="p1",
-        code="print(1)",
-        generation=1,
-        parent_id="p0",
-        correct=False,
-        combined_score=0.25,
-        public_metrics={"score": 0.25},
-        metadata={
-            "api_costs": 0.20,
-            "embed_cost": 0.02,
-            "novelty_cost": 0.03,
-            "meta_cost": 0.04,
-            "patch_type": "diff",
-            "llm_result": {"model": "fallback-model"},
-        },
-    )
-    db.add(first, defer_maintenance=True)
-    db.add(second, defer_maintenance=True)
-    return db, first, second
+from wandb_test_utils import make_db
 
 
 def test_wandb_logging_is_opt_in_and_does_not_configure_webui():
@@ -83,50 +37,6 @@ def test_wandb_run_id_is_reused_and_can_be_overridden(tmp_path):
     )
 
 
-def test_program_payload_logs_one_compact_event_per_individual(tmp_path):
-    _, _, second = _make_db(tmp_path)
-
-    payload = build_program_log_payload(second)
-
-    assert payload["generation"] == 1
-    assert payload[INDIVIDUAL_SCORE_METRIC] == 0.25
-    assert payload["individual/model_name"] == "fallback-model"
-    assert "public_metrics/score" not in payload
-    assert payload["cost/api"] == pytest.approx(0.20)
-    assert "program/combined_score" not in payload
-    assert not any(key.startswith("metadata/") for key in payload)
-    assert not any("latest" in key for key in payload)
-
-
-def test_program_payload_skips_bulky_values_and_duplicate_timing(tmp_path):
-    _, first, _ = _make_db(tmp_path)
-
-    payload = build_program_log_payload(first)
-
-    assert payload["public_metrics/nested/accuracy"] == 0.5
-    assert payload["private_metrics/hidden"] == 2.0
-    assert "public_metrics/bulky_text" not in payload
-    assert payload["timing/pipeline_seconds"] == 2.0
-    assert "metadata/pipeline_seconds" not in payload
-
-
-def test_run_summary_uses_correct_programs_for_best_score(tmp_path):
-    db, _, _ = _make_db(tmp_path)
-
-    summary = build_run_summary(
-        db.get_all_programs(),
-        total_proposals_generated=2,
-        total_api_cost=0.5,
-    )
-
-    assert summary["run/program_count"] == 2
-    assert summary["run/correct_rate"] == 0.5
-    assert summary["run/best_score"] == 1.0
-    assert summary["run/max_generation"] == 1
-    assert summary["run/total_proposals_generated"] == 2
-    assert summary["run/total_api_cost"] == 0.5
-
-
 def test_invalid_wandb_config_is_non_fatal(tmp_path, monkeypatch, caplog):
     fake_wandb = ModuleType("wandb")
     fake_wandb.init = lambda **kwargs: pytest.fail("wandb.init should not be called")
@@ -144,8 +54,119 @@ def test_invalid_wandb_config_is_non_fatal(tmp_path, monkeypatch, caplog):
     assert "Failed to initialize W&B logging" in caplog.text
 
 
+def test_wandb_history_failure_is_non_fatal_and_retryable(tmp_path, caplog):
+    _, first, _ = make_db(tmp_path)
+
+    class FlakyRun:
+        def __init__(self):
+            self.calls = 0
+
+        def log(self, _payload):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("temporary telemetry failure")
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = FlakyRun()
+
+    logger.log_program(first)
+    logger.log_program(first)
+
+    assert logger._run.calls == 2
+    assert "Failed to log individual p0 to W&B" in caplog.text
+
+
+@pytest.mark.parametrize("copy_marker", ["_is_island_copy", "_spawned_island"])
+def test_wandb_history_skips_administrative_copies(copy_marker):
+    logged_payloads = []
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(log=logged_payloads.append)
+    copy = Program(id="copy", code="pass", metadata={copy_marker: True})
+
+    logger.log_program(copy)
+
+    assert logged_payloads == []
+
+
+def test_final_history_failure_does_not_suppress_summary_or_table(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    logged = []
+
+    class Run:
+        summary = {}
+
+        def log(self, payload):
+            if not logged:
+                logged.append("history-failed")
+                raise RuntimeError("history")
+            logged.append(payload)
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = Run()
+    logger._wandb = SimpleNamespace(Table=lambda **kwargs: SimpleNamespace(**kwargs))
+
+    logger.log_final(db=db, total_api_cost=0.4, total_cost=0.5)
+
+    assert logger._run.summary["run/total_api_cost"] == 0.4
+    assert PROGRAM_TABLE_KEY in logged[-1]
+    assert "final W&B history" in caplog.text
+
+
+def test_final_summary_failure_does_not_suppress_table(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    logged = []
+
+    class BrokenSummary(dict):
+        def update(self, values):
+            raise RuntimeError("summary")
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(summary=BrokenSummary(), log=logged.append)
+    logger._wandb = SimpleNamespace(Table=lambda **kwargs: SimpleNamespace(**kwargs))
+
+    logger.log_final(db=db, total_api_cost=0.4)
+
+    assert PROGRAM_TABLE_KEY in logged[-1]
+    assert "final W&B summary" in caplog.text
+
+
+def test_final_table_construction_failure_keeps_history_and_summary(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    logged = []
+    summary = {}
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(summary=summary, log=logged.append)
+    logger._wandb = SimpleNamespace(
+        Table=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("table"))
+    )
+
+    logger.log_final(db=db, total_api_cost=0.4)
+
+    assert logged[0]["run/total_api_cost"] == 0.4
+    assert summary["run/total_api_cost"] == 0.4
+    assert "final W&B table" in caplog.text
+
+
+def test_final_table_log_failure_is_non_fatal(tmp_path, caplog):
+    db, _, _ = make_db(tmp_path)
+    summary = {}
+
+    def log(payload):
+        if PROGRAM_TABLE_KEY in payload:
+            raise RuntimeError("table log")
+
+    logger = ShinkaWandbLogger(enabled=True)
+    logger._run = SimpleNamespace(summary=summary, log=log)
+    logger._wandb = SimpleNamespace(Table=lambda **kwargs: SimpleNamespace(**kwargs))
+
+    logger.log_final(db=db, total_api_cost=0.4)
+
+    assert summary["run/total_api_cost"] == 0.4
+    assert "log final W&B table" in caplog.text
+
+
 def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
-    db, first, second = _make_db(tmp_path)
+    db, first, second = make_db(tmp_path)
     logged_payloads = []
     init_kwargs = {}
 
@@ -169,6 +190,10 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
             self.columns = columns
             self.data = data
 
+    class FakeSettings:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
     fake_run = FakeRun()
     fake_wandb = ModuleType("wandb")
 
@@ -178,44 +203,91 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
 
     fake_wandb.init = fake_init
     fake_wandb.Table = FakeTable
+    fake_wandb.Settings = FakeSettings
     monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
 
     evo_config = EvolutionConfig(
         wandb_project="project",
         wandb_name="name",
         wandb_mode="offline",
+        task_sys_msg="private task instructions",
+        wandb_config={
+            "nested": {
+                "api_key": "wandb-extra-secret",
+                "apiKey": "camel-api-secret",
+                "accessToken": "camel-access-secret",
+                "clientSecret": "camel-client-secret",
+                "AuthorizationHeader": "camel-authorization-secret",
+                "aws_secret_access_key": "aws-secret",
+                "Authorization": "Bearer auth-secret",
+                "safe_value": 2,
+            }
+        },
     )
     logger = ShinkaWandbLogger(enabled=True)
     logger.start(
         evo_config=evo_config,
         db_config=SimpleNamespace(),
-        job_config=SimpleNamespace(),
+        job_config=LocalJobConfig(
+            extra_cmd_args={"access_token": "job-secret", "workers": 2}
+        ),
         results_dir=tmp_path,
     )
     logger.log_program(first)
     logger.log_program(first)
     logger.log_program(second)
+    logger.log_population_progress(db=db)
+    logger.log_population_progress(db=db)
     logger.log_final(
         db=db,
         total_proposals_generated=2,
-        total_api_cost=0.5,
+        total_cost=0.5,
     )
     logger.finish()
 
     assert init_kwargs["project"] == "project"
     assert init_kwargs["mode"] == "offline"
+    assert init_kwargs["save_code"] is False
+    assert init_kwargs["settings"].kwargs == {
+        "console": "off",
+        "disable_git": True,
+        "disable_code": True,
+        "x_disable_stats": True,
+        "x_disable_machine_info": True,
+        "x_save_requirements": False,
+    }
     assert init_kwargs["id"]
     assert init_kwargs["resume"] == "allow"
     assert (tmp_path / ".wandb_run_id").read_text(encoding="utf-8").strip() == (
         init_kwargs["id"]
     )
-    assert init_kwargs["config"]["evolution"]["wandb_run_id"] == init_kwargs["id"]
+    assert "private task instructions" not in repr(init_kwargs["config"])
+    assert "wandb-extra-secret" not in repr(init_kwargs["config"])
+    assert "camel-api-secret" not in repr(init_kwargs["config"])
+    assert "camel-access-secret" not in repr(init_kwargs["config"])
+    assert "camel-client-secret" not in repr(init_kwargs["config"])
+    assert "camel-authorization-secret" not in repr(init_kwargs["config"])
+    assert "aws-secret" not in repr(init_kwargs["config"])
+    assert "auth-secret" not in repr(init_kwargs["config"])
+    assert "job-secret" not in repr(init_kwargs["config"])
+    assert init_kwargs["config"]["nested"]["safe_value"] == 2
+    assert "task_sys_msg" not in init_kwargs["config"]["evolution"]
+    assert "init_program_path" not in init_kwargs["config"]["evolution"]
+    assert "llm_kwargs" not in init_kwargs["config"]["evolution"]
+    assert "db_path" not in init_kwargs["config"]["database"]
+    assert "extra_cmd_args" not in init_kwargs["config"]["job"]
     assert fake_run.finished is True
     assert [payload[INDIVIDUAL_SCORE_METRIC] for payload in logged_payloads[:2]] == [
         1.0,
         0.25,
     ]
-    assert len(logged_payloads) == 3
+    assert len(logged_payloads) == 5
+    assert logged_payloads[2][EVALUATED_COUNT_METRIC] == 2
+    assert logged_payloads[3][EVALUATED_COUNT_METRIC] == 2
+    assert logged_payloads[3]["cost/embed"] == pytest.approx(0.03)
+    assert logged_payloads[3]["cost/total"] == pytest.approx(0.35)
+    assert logged_payloads[3]["run/evaluated_count"] == 2
+    assert logged_payloads[3]["run/total_cost"] == 0.5
     table = logged_payloads[-1][PROGRAM_TABLE_KEY]
     assert isinstance(table, FakeTable)
     assert table.columns == PROGRAM_TABLE_COLUMNS
@@ -223,10 +295,16 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
     assert "code" not in table.columns
     assert "embedding" not in table.columns
     assert fake_run.summary["run/best_score"] == 1.0
+    assert fake_run.summary["run/evaluated_count"] == 2
+    assert fake_run.summary["run/total_cost"] == 0.5
     score_definition = next(
         item for item in fake_run.defined if item[0] == (INDIVIDUAL_SCORE_METRIC,)
     )
-    assert score_definition[1] == {"step_metric": "generation"}
+    assert score_definition[1] == {}
+    population_definition = next(
+        item for item in fake_run.defined if item[0] == ("population/count",)
+    )
+    assert population_definition[1] == {"step_metric": EVALUATED_COUNT_METRIC}
 
     first_run_id = init_kwargs["id"]
     resumed_config = EvolutionConfig(
@@ -252,7 +330,7 @@ def test_wandb_logger_dry_run_and_resume_use_fake_wandb(tmp_path, monkeypatch):
 def test_wandb_online_logging_with_authenticated_sdk(tmp_path, monkeypatch, caplog):
     import wandb
 
-    db, first, second = _make_db(tmp_path)
+    db, first, second = make_db(tmp_path)
     monkeypatch.delenv("WANDB_MODE", raising=False)
     wandb.login(verify=True)
 
@@ -278,7 +356,7 @@ def test_wandb_online_logging_with_authenticated_sdk(tmp_path, monkeypatch, capl
         logger.log_final(
             db=db,
             total_proposals_generated=2,
-            total_api_cost=0.5,
+            total_cost=0.5,
         )
     finally:
         logger.finish()

--- a/tests/test_wandb_metrics.py
+++ b/tests/test_wandb_metrics.py
@@ -1,0 +1,198 @@
+import pytest
+
+from shinka.database import Program
+from shinka.wandb_logging import (
+    EVALUATED_COUNT_METRIC,
+    INDIVIDUAL_SCORE_METRIC,
+    MAX_METRIC_KEY_LENGTH,
+    MAX_PUBLIC_METRICS,
+    PROGRAM_TABLE_COLUMNS,
+    build_population_progress_payload,
+    build_program_log_payload,
+    build_run_summary,
+    program_table_row,
+)
+from wandb_test_utils import make_db
+
+
+def test_program_payload_logs_one_compact_event_per_individual(tmp_path):
+    _, _, second = make_db(tmp_path)
+
+    payload = build_program_log_payload(second)
+
+    assert payload["generation"] == 1
+    assert payload[INDIVIDUAL_SCORE_METRIC] == 0.25
+    assert payload["individual/model_name"] == "fallback-model"
+    assert payload["individual/is_copy"] is False
+    assert "public_metrics/score" not in payload
+    assert payload["individual/cost/api"] == pytest.approx(0.20)
+    assert not any(key.startswith("headless/") for key in payload)
+    assert "cost/api" not in payload
+    assert "program/combined_score" not in payload
+    assert not any(key.startswith("metadata/") for key in payload)
+    assert not any("latest" in key for key in payload)
+    assert "print(1)" not in repr(payload)
+    assert "[1.0, 2.0]" not in repr(payload)
+
+
+def test_program_payload_skips_bulky_values_and_duplicate_timing(tmp_path):
+    _, first, _ = make_db(tmp_path)
+
+    payload = build_program_log_payload(first)
+
+    assert payload["public_metrics/nested/accuracy"] == 0.5
+    assert "private_metrics/hidden" not in payload
+    assert "public_metrics/bulky_text" not in payload
+    assert payload["individual/timing/pipeline_seconds"] == 2.0
+    assert payload["headless/usage_status"] == "reported"
+    assert payload["headless/usage_unknown"] is False
+    assert payload["headless/pricing_status"] == "missing"
+    assert payload["headless/pricing_unknown"] is True
+    assert "headless/cost_basis" not in payload
+    assert "individual/cost/api" not in payload
+    assert "metadata/pipeline_seconds" not in payload
+    assert "must-not-leak" not in repr(payload)
+
+
+@pytest.mark.parametrize("copy_marker", ["_is_island_copy", "_spawned_island"])
+def test_population_progress_counts_copies_but_excludes_their_costs(
+    tmp_path, copy_marker
+):
+    db, _, _ = make_db(tmp_path)
+    copy = Program(
+        id="copy-1",
+        code="# Copy\n",
+        generation=0,
+        correct=True,
+        combined_score=1.0,
+        island_idx=1,
+        metadata={copy_marker: True, "embed_cost": 9.0},
+    )
+    db.add(copy, defer_maintenance=True)
+
+    payload = build_population_progress_payload(db.get_all_programs())
+
+    assert payload[EVALUATED_COUNT_METRIC] == 2
+    assert payload["population/count"] == 3
+    assert payload["population/correct_count"] == 2
+    assert payload["population/best_score"] == 1.0
+    assert payload["cost/embed"] == pytest.approx(0.03)
+    assert payload["cost/total"] == pytest.approx(0.35)
+    assert payload["island/0/evaluated_count"] == 2
+    assert payload["island/1/evaluated_count"] == 0
+    assert payload["island/1/count"] == 1
+    assert program_table_row(copy)[PROGRAM_TABLE_COLUMNS.index("cost")] == 0.0
+
+
+def test_actual_headless_unknown_pricing_suppresses_only_api_cost():
+    program = Program(
+        id="headless",
+        code="pass",
+        metadata={
+            "model_name": "headless/codex",
+            "headless_pricing_unknown": True,
+            "api_costs": 12.0,
+            "embed_cost": 0.2,
+        },
+    )
+
+    individual = build_program_log_payload(program)
+    population = build_population_progress_payload([program])
+
+    assert "individual/cost/api" not in individual
+    assert individual["individual/cost/embed"] == pytest.approx(0.2)
+    assert population["cost/api"] == 0.0
+    assert population["cost/embed"] == pytest.approx(0.2)
+    assert population["cost/pricing_unknown_count"] == 1
+    assert program_table_row(program)[PROGRAM_TABLE_COLUMNS.index("cost")] == 0.2
+
+
+def test_stale_headless_prompt_path_does_not_suppress_api_cost():
+    program = Program(
+        id="headless-path",
+        code="pass",
+        metadata={
+            "model_name": "codex",
+            "headless_prompt_path": "/redacted/prompt.md",
+            "headless_pricing_unknown": True,
+            "api_costs": 12.0,
+        },
+    )
+
+    payload = build_program_log_payload(program)
+
+    assert payload["individual/cost/api"] == 12.0
+    assert "/redacted/prompt.md" not in repr(payload)
+
+
+def test_program_payload_bounds_public_metrics_and_omits_private_metrics():
+    public_metrics = {f"metric_{idx}": idx for idx in range(MAX_PUBLIC_METRICS + 10)}
+    public_metrics["x" * (MAX_METRIC_KEY_LENGTH + 1)] = 1.0
+    public_metrics["aws_secret_access_key"] = 2.0
+    program = Program(
+        id="bounded",
+        code="pass",
+        public_metrics=public_metrics,
+        private_metrics={"hidden_score": 99.0},
+    )
+
+    payload = build_program_log_payload(program)
+    logged_public = {
+        key: value
+        for key, value in payload.items()
+        if key.startswith("public_metrics/")
+    }
+
+    assert len(logged_public) == MAX_PUBLIC_METRICS
+    assert all(len(key) <= MAX_METRIC_KEY_LENGTH for key in logged_public)
+    assert not any(key.startswith("private_metrics/") for key in payload)
+    assert "aws_secret_access_key" not in repr(payload)
+
+
+@pytest.mark.parametrize(
+    "sensitive_key",
+    ["apiKey", "accessToken", "clientSecret", "AuthorizationHeader"],
+)
+def test_program_payload_omits_compound_sensitive_metric_keys(sensitive_key):
+    program = Program(
+        id="sensitive-metric",
+        code="pass",
+        public_metrics={sensitive_key: 123.0, "safeScore": 0.5},
+    )
+
+    payload = build_program_log_payload(program)
+
+    assert sensitive_key not in repr(payload)
+    assert payload["public_metrics/safeScore"] == 0.5
+
+
+def test_run_summary_uses_correct_programs_for_best_score(tmp_path):
+    db, _, _ = make_db(tmp_path)
+
+    summary = build_run_summary(
+        db.get_all_programs(),
+        total_proposals_generated=2,
+        total_cost=0.5,
+    )
+
+    assert summary["run/program_count"] == 2
+    assert summary["run/correct_rate"] == 0.5
+    assert summary["run/best_score"] == 1.0
+    assert summary["run/max_generation"] == 1
+    assert summary["run/total_proposals_generated"] == 2
+    assert summary["run/evaluated_count"] == 2
+    assert summary["run/total_cost"] == 0.5
+
+
+def test_run_summary_preserves_legacy_api_cost_and_prefers_explicit_total(tmp_path):
+    db, _, _ = make_db(tmp_path)
+
+    explicit = build_run_summary(
+        db.get_all_programs(), total_api_cost=0.4, total_cost=0.7
+    )
+    legacy_only = build_run_summary(db.get_all_programs(), total_api_cost=0.4)
+
+    assert explicit["run/total_api_cost"] == 0.4
+    assert explicit["run/total_cost"] == 0.7
+    assert legacy_only["run/total_api_cost"] == 0.4
+    assert legacy_only["run/total_cost"] == 0.4

--- a/tests/wandb_test_utils.py
+++ b/tests/wandb_test_utils.py
@@ -1,0 +1,63 @@
+from shinka.database import DatabaseConfig, Program, ProgramDatabase
+
+
+def make_programs():
+    first = Program(
+        id="p0",
+        code="print(0)",
+        generation=0,
+        correct=True,
+        combined_score=1.0,
+        public_metrics={
+            "score": 1.0,
+            "nested": {"accuracy": 0.5},
+            "bulky_text": "not a chart metric",
+        },
+        private_metrics={"hidden": 2.0},
+        metadata={
+            "api_costs": 0.10,
+            "embed_cost": 0.01,
+            "novelty_cost": 0.02,
+            "meta_cost": 0.03,
+            "patch_type": "init",
+            "pipeline_seconds": 2.0,
+            "evaluation_seconds": 1.5,
+            "model_name": "headless/test-agent",
+            "headless_usage_status": "reported",
+            "headless_usage_unknown": False,
+            "headless_pricing_status": "missing",
+            "headless_pricing_unknown": True,
+            "headless_cost_basis": None,
+            "headless_pricing_source": None,
+            "secret_token": "must-not-leak",
+        },
+    )
+    second = Program(
+        id="p1",
+        code="print(1)",
+        generation=1,
+        parent_id="p0",
+        correct=False,
+        combined_score=0.25,
+        public_metrics={"score": 0.25},
+        metadata={
+            "api_costs": 0.20,
+            "embed_cost": 0.02,
+            "novelty_cost": 0.03,
+            "meta_cost": 0.04,
+            "patch_type": "diff",
+            "llm_result": {"model": "fallback-model"},
+            "headless_usage_status": "stale",
+            "headless_pricing_unknown": True,
+            "embedding": [1.0, 2.0],
+        },
+    )
+    return first, second
+
+
+def make_db(tmp_path):
+    db = ProgramDatabase(DatabaseConfig(db_path=str(tmp_path / "programs.sqlite")))
+    first, second = make_programs()
+    db.add(first, defer_maintenance=True)
+    db.add(second, defer_maintenance=True)
+    return db, first, second


### PR DESCRIPTION
## Summary
- Log candidate scores as raw history while publishing monotonic population and per-island snapshots on population/evaluated_count.
- Separate administrative island copies from evaluated candidates for counts, costs, and timing.
- Add cumulative cost/timing metrics, final run history and summary values, and a compact population/final_table.
- Serialize every W&B SDK call on one worker; bound candidate backlog to compact payloads; throttle and coalesce aggregate progress scans.
- Restrict automatic telemetry to allowlisted scalar configuration, redact secret-like explicit extension keys, omit private metrics, and disable W&B console/Git/code/machine/requirements capture.
- Require wandb>=0.19 for the privacy settings used by this integration.

## Compatibility and rollback
- Existing total_api_cost argument and run/total_api_cost key remain supported; run/total_cost is additive.
- Database schema and stored results are unchanged. W&B remains optional and best-effort.
- Rollback is the single commit cc5c6fa; disabling W&B also restores the pre-integration runtime path.

## Automated verification
Commit: cc5c6fa on main 094900e. Range-diff against the reviewed implementation is unchanged.

- Focused W&B/model/database/runner/island suite: 341 passed, 1 secret-only deselected.
- Full non-secret suite: 788 passed, 7 skipped, 2 deselected; 53% coverage.
- Ruff, scoped Mypy, MkDocs strict, and git diff check: passed.
- Independent code and security/reliability reviews: clean after fixes.
- Real W&B 0.28.2 offline artifact: six history records, final summary, and one three-row population/final_table.
- Artifact inspection: no program code, embeddings, private metrics, or GEMINI_API_KEY bytes.
- SQLite quick_check: ok; foreign-key violations: 0.
- Playwright WebUI inspection: loaded three programs, two generations, two islands, costs, best score, tree, and program table; all application requests returned successfully. The only console message is the existing Plotly v1 CDN deprecation notice.

## Credential-backed Circle Packing comparison
Shared settings: 2 generations; one evaluation, proposal, and DB worker; local jobs; gemini-3.6-flash; gemini-embedding-001; temperature 0.2; LOW thinking; 4096 max tokens; $0.50 cap.

Baseline main 094900e:
- Results: /tmp/shinka-phase1-live-20260816/baseline-main-094900e
- Completed/evaluated: 2/2; correct/incorrect: 1/1; job failures: 0.
- Best correct score: 0.9597642169962064.
- Runtime: 29.06s; API plus embedding cost: $0.0125.
- Warnings: clustering skipped for the expected three-row minimum; meta summary not configured.

PR branch cc5c6fa with W&B offline:
- Results: /tmp/shinka-phase1-live-20260816/pr177-final-cc5c6fa
- Completed/evaluated: 2/2; correct/incorrect: 2/0; job failures: 0.
- Best correct score: 2.6197428545232175.
- Runtime: 44.66s; API plus embedding cost: $0.0095.
- Warnings: same expected clustering/meta-summary notices; no telemetry, database, scheduler, or provider failures.
- The runtime difference is explained by the generated candidate evaluation: 25.37s on the branch versus 7.93s on baseline. Sampling was comparable (12.76s versus 15.83s); the branch produced a correct, higher-scoring SLSQP candidate.

Exact branch command:

    uv run --env-file /home/katya/projects/ShinkaEvolve/.env shinka_run --task-dir examples/circle_packing --results_dir /tmp/shinka-phase1-live-20260816/pr177-final-cc5c6fa --num_generations 2 --max-evaluation-jobs 1 --max-proposal-jobs 1 --max-db-workers 1 --set evo.job_type=local --set 'evo.llm_models=["gemini-3.6-flash"]' --set evo.embedding_model=gemini-embedding-001 --set 'evo.llm_kwargs={"temperatures":0.2,"max_tokens":4096,"reasoning_efforts":"low"}' --set evo.max_api_costs=0.5 --set evo.enable_wandb_logging=true --set evo.wandb_mode=offline --set evo.wandb_project=shinka-phase1-validation --set evo.wandb_name=phase1-pr177-cc5c6fa

Baseline used the same command and settings with its baseline results directory and enable_wandb_logging=false. No credential value was printed, uploaded, or persisted.