### PR TITLE
fix(edit): validate Rust patches with stable rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Set up stable Rust formatter
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt
+          rustup default stable
+          rustfmt --version
+
       - name: Install project
         run: uv sync --dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed Rust candidate validation on stable toolchains by replacing the
+  nightly-only parser flag with isolated, non-mutating `rustfmt` syntax checks
+  in PR #179. Thanks @Atharva-Kanherkar.
 - Fixed Azure OpenAI LLM client construction to use the v1 base URL contract,
   avoiding doubled `/openai/v1/openai` request paths and 404 responses reported
   in issue #147.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ shinka = [
 dev = [
     "pytest>=6.0",
     "pytest-cov",
-    "ruff",
+    "ruff==0.15.6",
     "mypy",
     "black",
     "isort",

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -5,6 +5,7 @@ Provides async versions of patch application and validation.
 
 import asyncio
 import logging
+import shutil
 import tempfile
 from typing import Tuple, Optional
 from pathlib import Path
@@ -110,7 +111,10 @@ async def apply_patch_async(
 
 
 async def validate_code_async(
-    code_path: str, language: str = "python", timeout: int = 30
+    code_path: str,
+    language: str = "python",
+    timeout: int = 30,
+    rust_edition: str = "2015",
 ) -> Tuple[bool, Optional[str]]:
     """Async code validation using subprocess.
 
@@ -118,6 +122,7 @@ async def validate_code_async(
         code_path: Path to code file to validate
         language: Programming language
         timeout: Timeout for validation in seconds
+        rust_edition: Rust edition used when validating Rust source
 
     Returns:
         Tuple of (is_valid, error_message)
@@ -138,26 +143,41 @@ async def validate_code_async(
             )
 
         elif language == "rust":
-            # Use rustc for Rust syntax checking.
+            # Use rustfmt for Rust syntax checking.
             #
             # `-Zparse-only` is gated to the nightly channel: on a stable
             # toolchain rustc rejects the flag and exits non-zero before it
             # parses anything, so every candidate would be reported invalid.
-            # `--emit=dep-info` is the closest stable equivalent that still
-            # skips type checking, so a program with a type error is accepted
-            # here exactly as it was under `-Zparse-only`. The edition is
-            # pinned so the accepted syntax does not shift with the toolchain
-            # default, and dep-info output is written to a temporary directory
-            # instead of the working directory.
-            with tempfile.TemporaryDirectory(prefix="shinka-rustc-") as out_dir:
+            # Stable rustc has no parse-only equivalent. In particular,
+            # `--emit=dep-info` performs name resolution and expands built-in
+            # macros, which both rejects valid dependency-backed code and lets
+            # generated code read host files via `include_str!`. rustfmt parses
+            # the token stream without type checking or macro expansion.
+            # `skip_children` prevents `mod` declarations (including `#[path]`
+            # overrides) from making rustfmt read other host files. A clean
+            # config prevents a project rustfmt.toml from disabling parsing.
+            # Stdout mode also guarantees validation never rewrites the source.
+            if shutil.which("rustfmt") is None:
+                return (
+                    False,
+                    (
+                        "Rust validation requires rustfmt on PATH. Install it with "
+                        "`rustup component add rustfmt`."
+                    ),
+                )
+            with tempfile.TemporaryDirectory(prefix="shinka-rustfmt-") as config_dir:
+                config_path = Path(config_dir) / "rustfmt.toml"
+                config_path.touch()
                 return await _run_validation_subprocess(
-                    "rustc",
+                    "rustfmt",
+                    "--config-path",
+                    str(config_path),
+                    "--emit",
+                    "stdout",
                     "--edition",
-                    "2021",
-                    "--crate-type=lib",
-                    "--emit=dep-info",
-                    "--out-dir",
-                    out_dir,
+                    rust_edition,
+                    "--config",
+                    "skip_children=true",
                     code_path,
                     timeout=timeout,
                 )

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -5,6 +5,7 @@ Provides async versions of patch application and validation.
 
 import asyncio
 import logging
+import tempfile
 from typing import Tuple, Optional
 from pathlib import Path
 from .apply_diff import apply_diff_patch
@@ -137,14 +138,29 @@ async def validate_code_async(
             )
 
         elif language == "rust":
-            # Use rustc for Rust syntax checking
-            return await _run_validation_subprocess(
-                "rustc",
-                "--crate-type=lib",
-                "-Zparse-only",
-                code_path,
-                timeout=timeout,
-            )
+            # Use rustc for Rust syntax checking.
+            #
+            # `-Zparse-only` is gated to the nightly channel: on a stable
+            # toolchain rustc rejects the flag and exits non-zero before it
+            # parses anything, so every candidate would be reported invalid.
+            # `--emit=dep-info` is the closest stable equivalent that still
+            # skips type checking, so a program with a type error is accepted
+            # here exactly as it was under `-Zparse-only`. The edition is
+            # pinned so the accepted syntax does not shift with the toolchain
+            # default, and dep-info output is written to a temporary directory
+            # instead of the working directory.
+            with tempfile.TemporaryDirectory(prefix="shinka-rustc-") as out_dir:
+                return await _run_validation_subprocess(
+                    "rustc",
+                    "--edition",
+                    "2021",
+                    "--crate-type=lib",
+                    "--emit=dep-info",
+                    "--out-dir",
+                    out_dir,
+                    code_path,
+                    timeout=timeout,
+                )
         elif language == "swift":
             # Use swiftc for Swift compilation check
             return await _run_validation_subprocess(

--- a/shinka/edit/async_apply.py
+++ b/shinka/edit/async_apply.py
@@ -32,22 +32,36 @@ async def _run_validation_subprocess(
     """Run a validator subprocess and normalize timeout/error handling."""
     proc = await asyncio.create_subprocess_exec(
         *args,
-        stdout=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
     )
+    communication = asyncio.create_task(proc.communicate())
 
     try:
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        _, stderr = await asyncio.wait_for(
+            asyncio.shield(communication), timeout=timeout
+        )
     except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
+        _kill_validation_process(proc)
+        await communication
         return False, f"Validation timeout after {timeout}s"
+    except asyncio.CancelledError:
+        _kill_validation_process(proc)
+        await asyncio.shield(communication)
+        raise
 
     if proc.returncode == 0:
         return True, None
 
     error_msg = stderr.decode() if stderr else "Unknown compilation error"
     return False, error_msg
+
+
+def _kill_validation_process(proc: asyncio.subprocess.Process) -> None:
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
 
 
 async def apply_patch_async(
@@ -178,6 +192,7 @@ async def validate_code_async(
                     rust_edition,
                     "--config",
                     "skip_children=true",
+                    "--",
                     code_path,
                     timeout=timeout,
                 )

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -20,8 +20,10 @@ class _FakeProcess:
         self._stderr = stderr
         self.kill_called = False
         self.wait_called = False
+        self.communicate_calls = 0
 
     async def communicate(self) -> tuple[bytes, bytes]:
+        self.communicate_calls += 1
         return self._stdout, self._stderr
 
     def kill(self) -> None:
@@ -63,7 +65,7 @@ def test_run_validation_subprocess_success(monkeypatch: pytest.MonkeyPatch) -> N
     assert is_valid is True
     assert error is None
     assert recorded["args"] == ("python", "-m", "py_compile", "candidate.py")
-    assert recorded["stdout"] == asyncio.subprocess.PIPE
+    assert recorded["stdout"] == asyncio.subprocess.DEVNULL
     assert recorded["stderr"] == asyncio.subprocess.PIPE
 
 
@@ -125,7 +127,41 @@ def test_run_validation_subprocess_timeout_kills_process(
     assert is_valid is False
     assert error == "Validation timeout after 3s"
     assert proc.kill_called is True
-    assert proc.wait_called is True
+    assert proc.communicate_calls == 1
+
+
+def test_run_validation_subprocess_cancellation_kills_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc = _FakeProcess()
+
+    async def fake_create_subprocess_exec(
+        *args: str,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> _FakeProcess:
+        return proc
+
+    async def fake_wait_for(awaitable: object, timeout: int) -> object:
+        del awaitable, timeout
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        async_apply.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(async_apply.asyncio, "wait_for", fake_wait_for)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            async_apply._run_validation_subprocess(
+                "rustfmt", "candidate.rs", timeout=3
+            )
+        )
+
+    assert proc.kill_called is True
+    assert proc.communicate_calls == 1
 
 
 def test_validate_code_async_python_delegates_to_helper(
@@ -194,6 +230,7 @@ def test_validate_code_async_rust_delegates_to_rustfmt(
     args = recorded["args"]
     assert isinstance(args, tuple)
     assert args[0] == "rustfmt"
+    assert args[-2] == "--"
     assert args[-1] == str(tmp_path / "candidate.rs")
     assert "--config-path" in args
     assert "--emit" in args
@@ -307,6 +344,24 @@ def test_validate_code_async_rust_rejects_broken_program_on_real_rustfmt(
     assert is_valid is False
     assert error is not None
     assert "nightly" not in error
+    assert "error" in error.lower()
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_rejects_option_shaped_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    candidate = Path("--version")
+    candidate.write_text("pub fn broken( -> {\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is False
+    assert error is not None
     assert "error" in error.lower()
 
 

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -158,11 +158,11 @@ def test_validate_code_async_python_delegates_to_helper(
     assert recorded["timeout"] == 11
 
 
-def test_validate_code_async_rust_delegates_to_rustc(
+def test_validate_code_async_rust_delegates_to_rustfmt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Rust validation must stay on stable-channel rustc flags.
+    """Rust validation must use stable, non-mutating rustfmt flags.
 
     `-Zparse-only` is nightly-only, so a stable toolchain rejects the flag
     before parsing and reports every candidate invalid.
@@ -172,8 +172,13 @@ def test_validate_code_async_rust_delegates_to_rustc(
     async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
         recorded["args"] = args
         recorded["timeout"] = timeout
+        config_path = Path(args[args.index("--config-path") + 1])
+        recorded["config_path"] = config_path
+        recorded["config_existed"] = config_path.is_file()
+        recorded["config_contents"] = config_path.read_text(encoding="utf-8")
         return True, None
 
+    monkeypatch.setattr(async_apply.shutil, "which", lambda _name: "/usr/bin/rustfmt")
     monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
 
     is_valid, error = asyncio.run(
@@ -188,53 +193,80 @@ def test_validate_code_async_rust_delegates_to_rustc(
 
     args = recorded["args"]
     assert isinstance(args, tuple)
-    assert args[0] == "rustc"
+    assert args[0] == "rustfmt"
     assert args[-1] == str(tmp_path / "candidate.rs")
+    assert "--config-path" in args
+    assert "--emit" in args
+    assert args[args.index("--emit") + 1] == "stdout"
     assert "--edition" in args
-    assert args[args.index("--edition") + 1] == "2021"
-    assert "--crate-type=lib" in args
-    assert "--emit=dep-info" in args
-    assert "--out-dir" in args
-    # No nightly-gated flag may be reintroduced: any `-Z` option makes stable
-    # rustc exit before it parses the candidate.
+    assert args[args.index("--edition") + 1] == "2015"
+    assert "--config" in args
+    assert args[args.index("--config") + 1] == "skip_children=true"
+    # No nightly-gated flag may be reintroduced: stable Rust tooling rejects
+    # `-Z` options before it parses the candidate.
     assert not any(arg.startswith("-Z") for arg in args)
+    assert recorded["config_existed"] is True
+    assert recorded["config_contents"] == ""
+    config_path = recorded["config_path"]
+    assert isinstance(config_path, Path)
+    assert config_path.exists() is False
 
 
-def test_validate_code_async_rust_discards_dep_info_output(
+def test_validate_code_async_rust_reports_missing_rustfmt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """dep-info output goes to a temporary directory that is then removed.
+    """A minimal Rust toolchain gets an actionable dependency error."""
 
-    Without an explicit `--out-dir` rustc writes the dependency file into the
-    working directory, which would leave artifacts beside the evolved program.
-    """
-    observed: dict[str, object] = {}
+    async def fail_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        raise AssertionError(f"unexpected validator invocation: {args}")
 
-    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
-        out_dir = Path(args[args.index("--out-dir") + 1])
-        observed["out_dir"] = out_dir
-        observed["existed_during_call"] = out_dir.is_dir()
-        return True, None
+    monkeypatch.setattr(async_apply.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fail_helper)
 
-    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
-
-    asyncio.run(
+    is_valid, error = asyncio.run(
         async_apply.validate_code_async(
             str(tmp_path / "candidate.rs"), language="rust", timeout=5
         )
     )
 
-    out_dir = observed["out_dir"]
-    assert isinstance(out_dir, Path)
-    assert observed["existed_during_call"] is True
-    assert out_dir.is_dir() is False
-    assert out_dir != tmp_path
-    assert list(tmp_path.iterdir()) == []
+    assert is_valid is False
+    assert error == (
+        "Rust validation requires rustfmt on PATH. Install it with "
+        "`rustup component add rustfmt`."
+    )
 
 
-@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
-def test_validate_code_async_rust_accepts_valid_program_on_real_rustc(
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_does_not_read_host_files(
+    tmp_path: Path,
+) -> None:
+    """Syntax validation must not read files through macros or modules."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("host-secret-must-not-leak !!!", encoding="utf-8")
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text(
+        f'#[path = r"{secret}"]\n'
+        "mod secret;\n"
+        f'compile_error!(include_str!(r"{secret}"));\n',
+        encoding="utf-8",
+    )
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is True, error
+    assert error is None
+    assert candidate.read_text(encoding="utf-8") == (
+        f'#[path = r"{secret}"]\n'
+        "mod secret;\n"
+        f'compile_error!(include_str!(r"{secret}"));\n'
+    )
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_accepts_valid_program_on_real_rustfmt(
     tmp_path: Path,
 ) -> None:
     """End-to-end guard against the nightly-flag regression."""
@@ -260,8 +292,8 @@ def test_validate_code_async_rust_accepts_valid_program_on_real_rustc(
     assert error is None
 
 
-@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
-def test_validate_code_async_rust_rejects_broken_program_on_real_rustc(
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_rejects_broken_program_on_real_rustfmt(
     tmp_path: Path,
 ) -> None:
     """A syntax error must be reported as a rust error, not a flag error."""
@@ -276,6 +308,67 @@ def test_validate_code_async_rust_rejects_broken_program_on_real_rustc(
     assert error is not None
     assert "nightly" not in error
     assert "error" in error.lower()
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_ignores_project_config_that_disables_parsing(
+    tmp_path: Path,
+) -> None:
+    """An ambient rustfmt.toml cannot make malformed Rust pass validation."""
+    (tmp_path / "rustfmt.toml").write_text(
+        "disable_all_formatting = true\n",
+        encoding="utf-8",
+    )
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text("pub fn broken( -> {\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is False
+    assert error is not None
+    assert "error" in error.lower()
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_accepts_type_errors(
+    tmp_path: Path,
+) -> None:
+    """Validation remains syntax-only and does not run the type checker."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text(
+        'pub fn wrong_type() -> u32 { "not a number" }\n',
+        encoding="utf-8",
+    )
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is True, error
+    assert error is None
+
+
+@pytest.mark.skipif(shutil.which("rustfmt") is None, reason="rustfmt is not installed")
+def test_validate_code_async_rust_honors_configured_edition(
+    tmp_path: Path,
+) -> None:
+    """Projects can override the default for edition-sensitive syntax."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text("pub async fn modern() {}\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(
+            str(candidate),
+            language="rust",
+            timeout=60,
+            rust_edition="2021",
+        )
+    )
+
+    assert is_valid is True, error
+    assert error is None
 
 
 def test_validate_code_async_fortran_delegates_to_gfortran(

--- a/tests/test_async_apply.py
+++ b/tests/test_async_apply.py
@@ -1,4 +1,5 @@
 import asyncio
+import shutil
 from pathlib import Path
 
 import pytest
@@ -155,6 +156,126 @@ def test_validate_code_async_python_delegates_to_helper(
         str(tmp_path / "candidate.py"),
     )
     assert recorded["timeout"] == 11
+
+
+def test_validate_code_async_rust_delegates_to_rustc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Rust validation must stay on stable-channel rustc flags.
+
+    `-Zparse-only` is nightly-only, so a stable toolchain rejects the flag
+    before parsing and reports every candidate invalid.
+    """
+    recorded: dict[str, object] = {}
+
+    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        recorded["args"] = args
+        recorded["timeout"] = timeout
+        return True, None
+
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(
+            str(tmp_path / "candidate.rs"), language="rust", timeout=23
+        )
+    )
+
+    assert is_valid is True
+    assert error is None
+    assert recorded["timeout"] == 23
+
+    args = recorded["args"]
+    assert isinstance(args, tuple)
+    assert args[0] == "rustc"
+    assert args[-1] == str(tmp_path / "candidate.rs")
+    assert "--edition" in args
+    assert args[args.index("--edition") + 1] == "2021"
+    assert "--crate-type=lib" in args
+    assert "--emit=dep-info" in args
+    assert "--out-dir" in args
+    # No nightly-gated flag may be reintroduced: any `-Z` option makes stable
+    # rustc exit before it parses the candidate.
+    assert not any(arg.startswith("-Z") for arg in args)
+
+
+def test_validate_code_async_rust_discards_dep_info_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """dep-info output goes to a temporary directory that is then removed.
+
+    Without an explicit `--out-dir` rustc writes the dependency file into the
+    working directory, which would leave artifacts beside the evolved program.
+    """
+    observed: dict[str, object] = {}
+
+    async def fake_helper(*args: str, timeout: int) -> tuple[bool, str | None]:
+        out_dir = Path(args[args.index("--out-dir") + 1])
+        observed["out_dir"] = out_dir
+        observed["existed_during_call"] = out_dir.is_dir()
+        return True, None
+
+    monkeypatch.setattr(async_apply, "_run_validation_subprocess", fake_helper)
+
+    asyncio.run(
+        async_apply.validate_code_async(
+            str(tmp_path / "candidate.rs"), language="rust", timeout=5
+        )
+    )
+
+    out_dir = observed["out_dir"]
+    assert isinstance(out_dir, Path)
+    assert observed["existed_during_call"] is True
+    assert out_dir.is_dir() is False
+    assert out_dir != tmp_path
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
+def test_validate_code_async_rust_accepts_valid_program_on_real_rustc(
+    tmp_path: Path,
+) -> None:
+    """End-to-end guard against the nightly-flag regression."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text(
+        "pub fn collatz_steps(n: u64) -> u32 {\n"
+        "    let mut steps = 0u32;\n"
+        "    let mut value = n;\n"
+        "    while value != 1 {\n"
+        "        value = if value % 2 == 0 { value / 2 } else { 3 * value + 1 };\n"
+        "        steps += 1;\n"
+        "    }\n"
+        "    steps\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is True, error
+    assert error is None
+
+
+@pytest.mark.skipif(shutil.which("rustc") is None, reason="rustc is not installed")
+def test_validate_code_async_rust_rejects_broken_program_on_real_rustc(
+    tmp_path: Path,
+) -> None:
+    """A syntax error must be reported as a rust error, not a flag error."""
+    candidate = tmp_path / "candidate.rs"
+    candidate.write_text("pub fn broken( -> { let mut\n", encoding="utf-8")
+
+    is_valid, error = asyncio.run(
+        async_apply.validate_code_async(str(candidate), language="rust", timeout=60)
+    )
+
+    assert is_valid is False
+    assert error is not None
+    assert "nightly" not in error
+    assert "error" in error.lower()
 
 
 def test_validate_code_async_fortran_delegates_to_gfortran(

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -12,6 +11,17 @@ def test_public_ci_excludes_secret_backed_tests() -> None:
     workflow = _read(".github/workflows/ci.yml")
 
     assert 'pytest -q -m "not requires_secrets and not models_dev_live"' in workflow
+
+
+def test_public_ci_installs_stable_rustfmt() -> None:
+    workflow = _read(".github/workflows/ci.yml")
+
+    assert (
+        "rustup toolchain install stable --profile minimal --component rustfmt"
+        in workflow
+    )
+    assert "rustup default stable" in workflow
+    assert "rustfmt --version" in workflow
 
 
 def test_integration_workflow_exists_for_secret_backed_tests() -> None:


### PR DESCRIPTION
## Summary

- replace nightly-only `rustc -Zparse-only` with stable `rustfmt --emit stdout` syntax validation
- preserve the Rust 2015 default while allowing callers to select another edition with `rust_edition`
- isolate validation from project `rustfmt.toml` files, child modules, option-shaped paths, and host-file macro expansion
- discard unused validator stdout and reap subprocesses on timeout or cancellation
- provision stable `rustfmt` in CI and pin Ruff 0.15.6 so the current public gate remains reproducible
- add contributor credit in `CHANGELOG.md`

## Why

Fixes #178. Stable `rustc` rejects `-Zparse-only` before parsing, so every Rust candidate was previously marked invalid. `rustfmt` parses malformed syntax without type checking or macro expansion, which preserves the intended syntax-only contract without requiring nightly Rust.

Security review additionally found that an option-shaped relative filename could be interpreted as a rustfmt flag; the validator now inserts `--` before the candidate path. The subprocess helper also avoids buffering formatted source and guarantees cleanup during cancellation.

## Testing

- GitHub CI run 31954929382: 734 passed, 2 deselected; Ruff, Mypy, coverage, and stable Rust 1.9.0 rustfmt setup passed
- local deterministic suite: 727 passed, 7 rustfmt-dependent tests skipped because this host has no Rust toolchain
- diff coverage: 92%
- focused security/reliability review swarm: no unresolved findings
- `git diff --check`: passed

## Compatibility and rollback

- Rust validation now requires `rustfmt` on `PATH`; the error points minimal-toolchain users to `rustup component add rustfmt`.
- The default edition remains 2015, matching the previous implicit `rustc` behavior. Callers may pass `rust_edition="2018"`, `"2021"`, or `"2024"`.
- Other language validators keep their existing behavior; their unused stdout is now discarded.
- Rollback is a normal revert of this PR; no persisted data or migration is involved.
