### PR TITLE
build: allow compatible httpx releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Changed
 
+- Relaxed the exact HTTPX dependency pin to a `>=0.27` compatibility lower
+  bound in issue #180. Thanks @htmai-880.
 - Removed the automatic Claude Code Review pull-request workflow.
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "aiofiles",
     "google-genai",
     "psutil",
-    "httpx==0.27"
+    "httpx>=0.27"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -76,6 +76,12 @@ def test_project_metadata_targets_pypi_release():
     }
 
 
+def test_httpx_dependency_allows_compatible_updates() -> None:
+    dependencies = _read_pyproject()["project"]["dependencies"]
+
+    assert "httpx>=0.27" in dependencies
+
+
 def test_readme_documents_package_install():
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- replace the exact `httpx==0.27` pin with the compatible lower bound `httpx>=0.27`
- add a packaging regression for the public dependency contract
- credit issue reporter `@htmai-880` in the changelog

## Why

Fixes #180. ShinkaEvolve uses HTTPX APIs that remain supported in 0.28, so the exact 0.27 pin unnecessarily prevented installation alongside newer compatible releases.

The repository intentionally ignores `uv.lock` because it is published as a library. A fresh local resolution selected HTTPX 0.28.1; package consumers and CI will continue resolving the newest stable version allowed by their full dependency graph.

## Testing

- resolved and installed `httpx==0.28.1`
- `uv pip check` — 115 packages compatible
- focused packaging/catalog/startup/client tests — 52 passed
- live models.dev network contract — 1 passed
- full deterministic gate — Ruff passed; Mypy passed; 728 passed, 7 rustfmt-dependent tests skipped locally, 2 deselected
- built wheel metadata contains `Requires-Dist: httpx>=0.27`
- dependency/reliability review swarm — no material findings
- `pip-audit` — no HTTPX finding; existing Pillow advisories remain outside this dependency-only change

## Compatibility and rollback

- Runtime APIs and catalog behavior are unchanged.
- OpenAI and Anthropic currently constrain HTTPX below 1.0, and the resolved graph is consistent.
- Rollback is a normal revert to the exact 0.27 requirement; there is no data migration.
