### PR TITLE
feat(llm): add Gemini 3.7 Flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Added
 
+- Added native Google Gemini 3.7 Flash support at its introductory 2026 price.
 - Added native Google Gemini 3.6 Flash support with current pricing and
   level-based thinking controls. Thanks @anantgar.
 - Added optional Weights & Biases logging with resumable run IDs, per-individual

--- a/shinka/llm/constants.py
+++ b/shinka/llm/constants.py
@@ -29,6 +29,7 @@ BACKOFF_MAX_TIME = _env_int(
 GEMINI_THINKING_LEVEL_MODELS = frozenset(
     {
         "gemini-3.6-flash",
+        "gemini-3.7-flash",
     }
 )
 GEMINI_THINKING_LEVEL_BY_EFFORT = {

--- a/shinka/llm/providers/pricing.csv
+++ b/shinka/llm/providers/pricing.csv
@@ -54,6 +54,7 @@ deepseek-chat,deepseek,0.14,0.28,,,,False,0,0
 deepseek-reasoner,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-flash,deepseek,0.14,0.28,,,,True,0,0
 deepseek-v4-pro,deepseek,0.435,0.87,,,,True,0,0
+gemini-3.7-flash,google,0.75,3.75,,,,True,0,0
 gemini-3.6-flash,google,0.75,3.75,,,,True,0,0
 gemini-3.5-flash,google,1.5,9.0,,,,True,0,0
 gemini-3-flash-preview,google,0.5,3.0,,,,True,0,0

--- a/shinka/tools/pricing/models_dev_overlay.json
+++ b/shinka/tools/pricing/models_dev_overlay.json
@@ -84,6 +84,14 @@
   "llm_overrides": [
     {
       "provider": "google",
+      "model_name": "gemini-3.7-flash",
+      "input_price": 0.75,
+      "output_price": 3.75,
+      "is_reasoning": true,
+      "think_temp_fixed": false
+    },
+    {
+      "provider": "google",
       "model_name": "gemini-3.6-flash",
       "input_price": 0.75,
       "output_price": 3.75,

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -110,7 +110,7 @@ def test_build_gemini_thinking_level_config_rejects_unknown_level():
         gemini.build_gemini_thinking_level_config("NOT_A_LEVEL")
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 def test_latest_gemini_generation_config_omits_unsupported_fields(
     monkeypatch,
     model_name: str,

--- a/tests/test_llm_kwargs.py
+++ b/tests/test_llm_kwargs.py
@@ -48,7 +48,7 @@ def test_gpt5_mini_pricing_metadata_enables_reasoning_kwargs_without_temperature
     assert kwargs["reasoning"] == {"effort": "minimal", "summary": "auto"}
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_level"),
     [
@@ -78,7 +78,7 @@ def test_latest_gemini_flash_maps_reasoning_effort_to_thinking_level(
     }
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 def test_latest_gemini_flash_disabled_reasoning_omits_thinking_controls(
     model_name: str,
 ):

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -59,7 +59,7 @@ def test_claude_opus_keeps_standard_pricing_across_context_window(
 
 @pytest.mark.parametrize(
     "model_name",
-    ["gemini-3.6-flash"],
+    ["gemini-3.6-flash", "gemini-3.7-flash"],
 )
 def test_latest_gemini_flash_pricing_is_registered(model_name: str):
     resolved = resolve_model_backend(model_name)

--- a/tests/test_pricing_csv_generation.py
+++ b/tests/test_pricing_csv_generation.py
@@ -164,7 +164,7 @@ def test_generate_embedding_rows_maps_azure_alias_and_manual_google_entry():
     ]
 
 
-@pytest.mark.parametrize("model_name", ["gemini-3.6-flash"])
+@pytest.mark.parametrize("model_name", ["gemini-3.6-flash", "gemini-3.7-flash"])
 def test_generate_latest_gemini_flash_from_manual_overlay(model_name: str):
     rows = generate_llm_rows(
         _payload(),


### PR DESCRIPTION
## Summary

- Add native Google gemini-3.7-flash catalog and parameter coverage after #171.
- Register the official introductory 2026 price: $0.75 input and $3.75 output per million tokens.
- Reuse Gemini 3.6 level-based thinking and unsupported-parameter policy.

## Verification

Commit: 8584950, rebased on main db2bc40 after #171 merged.

- Native credential-backed gemini-3.7-flash request through Shinka: exact OK response in the initial gate; token and calculated cost accounting populated.
- Fresh post-rebase live request: one candidate; 12 prompt, 1 candidate, 59 thinking tokens.
- Focused provider/resolver/pricing/packaging suite: 132 passed.
- Full non-secret suite: 762 passed, 7 skipped, 2 deselected; 52% coverage.
- Ruff and Mypy: clean.
- No credential value was logged or persisted.
- Deterministic pricing tests pass. The optional live models.dev regeneration check currently reports inherited main target openai/gpt-5.1-codex absent upstream; this is unrelated to the Gemini 3.7 delta.

## Compatibility and rollback

Gemini 3.7 uses the same native Google thinking-level and parameter-omission contract as Gemini 3.6. Revert commit 8584950 to remove only the 3.7 catalog/pricing addition. Static promotional pricing must be rechecked on 2027-01-01.