### PR TITLE
fix(edit): keep EVOLVE-BLOCK-END marker on its own line for insertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed diff insertions (empty SEARCH blocks) splicing the payload directly
+  against the EVOLVE-BLOCK-END marker, which corrupted the marker line, let
+  consecutive insertions merge code lines into invalid programs, and caused
+  marker validation to reject every insertion patch for block-comment
+  languages such as Wolfram.
 - Fixed Gemini retry handling so unsupported structured-output requests fail
   immediately, synchronous retries are paced, and sync/async calls share the
   same default thinking budget.

--- a/shinka/edit/apply_diff.py
+++ b/shinka/edit/apply_diff.py
@@ -623,7 +623,13 @@ def apply_search_replace(
                 msg = _create_no_evolve_block_error(new_text, "insertion")
                 raise PatchError(msg)
             a, b = mutable[-1]
-            new_text = new_text[:b] + replace + new_text[b:]
+            # `b` points at the END marker itself and `replace` has no
+            # trailing newline (stripped above), so splicing at `b` would
+            # glue the marker onto the payload's last line. Insert at the
+            # start of the marker's line instead and keep the marker intact.
+            line_start = new_text.rfind("\n", 0, b) + 1
+            insertion = replace if replace.endswith("\n") else replace + "\n"
+            new_text = new_text[:line_start] + insertion + new_text[line_start:]
             num_applied += 1
             continue
 

--- a/tests/test_edit_base.py
+++ b/tests/test_edit_base.py
@@ -847,6 +847,122 @@ def func():
     assert "y = 2" in updated_content
 
 
+def test_insertion_keeps_end_marker_on_own_line():
+    """Insertion must not glue the payload onto the EVOLVE-BLOCK-END marker."""
+    original_content = """# EVOLVE-BLOCK-START
+def f(x):
+    return x
+# EVOLVE-BLOCK-END"""
+
+    patch_str = """<<<<<<< SEARCH
+
+=======
+def g(x):
+    return x * 2
+>>>>>>> REPLACE"""
+
+    result = apply_diff_patch(
+        patch_str=patch_str,
+        original_str=original_content,
+        language="python",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert num_applied == 1
+    assert error is None
+    assert "    return x * 2\n# EVOLVE-BLOCK-END" in updated_content
+    assert updated_content.splitlines()[-1] == "# EVOLVE-BLOCK-END"
+
+
+def test_insertion_preserves_indented_end_marker():
+    """Insertion before an indented END marker keeps the marker's own line."""
+    original_content = """def outer():
+    # EVOLVE-BLOCK-START
+    x = 1
+    # EVOLVE-BLOCK-END
+    return x"""
+
+    patch_str = """<<<<<<< SEARCH
+
+=======
+    y = 2
+>>>>>>> REPLACE"""
+
+    result = apply_diff_patch(
+        patch_str=patch_str,
+        original_str=original_content,
+        language="python",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert num_applied == 1
+    assert error is None
+    assert "    y = 2\n    # EVOLVE-BLOCK-END" in updated_content
+
+
+def test_consecutive_insertions_stay_valid_python():
+    """Compounding insertions across generations must not merge code lines."""
+    import ast
+
+    original_content = """# EVOLVE-BLOCK-START
+def f(x):
+    return x
+# EVOLVE-BLOCK-END"""
+
+    def insertion_patch(payload):
+        return f"""<<<<<<< SEARCH
+
+=======
+{payload}
+>>>>>>> REPLACE"""
+
+    first, num_first, _, first_error, _, _ = apply_diff_patch(
+        patch_str=insertion_patch("y = 2"),
+        original_str=original_content,
+        language="python",
+        verbose=False,
+    )
+    second, num_second, _, second_error, _, _ = apply_diff_patch(
+        patch_str=insertion_patch("z = 3"),
+        original_str=first,
+        language="python",
+        verbose=False,
+    )
+
+    assert num_first == 1 and first_error is None
+    assert num_second == 1 and second_error is None
+    assert "y = 2\nz = 3\n# EVOLVE-BLOCK-END" in second
+    ast.parse(second)  # previously produced "y = 2z = 3# EVOLVE-BLOCK-END"
+
+
+def test_insertion_accepted_for_block_comment_language():
+    """Wolfram insertions were rejected by marker validation when the payload
+    was glued onto the (* EVOLVE-BLOCK-END *) marker line."""
+    original_content = """(* EVOLVE-BLOCK-START *)
+f[x_] := x
+(* EVOLVE-BLOCK-END *)"""
+
+    patch_str = """<<<<<<< SEARCH
+
+=======
+g[x_] := x^3
+>>>>>>> REPLACE"""
+
+    result = apply_diff_patch(
+        patch_str=patch_str,
+        original_str=original_content,
+        language="wolfram",
+        verbose=False,
+    )
+    updated_content, num_applied, output_path, error, patch_txt, diff_path = result
+
+    assert num_applied == 1
+    assert error is None
+    assert "g[x_] := x^3\n(* EVOLVE-BLOCK-END *)" in updated_content
+
+
 # ============================================================================
 # Tests for Enhanced Error Messages
 # ============================================================================


### PR DESCRIPTION
Fixes #183.

## What

Empty-`SEARCH` insertion blocks in `apply_search_replace` spliced the payload at the `EVOLVE-BLOCK-END` marker's match position after the payload's trailing newline had been stripped, gluing the marker onto the last inserted line:

```
def f(x):
    return x
y = 2# EVOLVE-BLOCK-END
```

- For Python and C-style languages the patch reported success and the corruption persisted into the database; a second insertion on such a program merges code lines (`y = 2z = 3# EVOLVE-BLOCK-END`) and produces a syntax error that gets blamed on the LLM proposal.
- For block-comment languages (Wolfram; same marker class as HTML/Markdown) the post-apply marker validation rejected **every** insertion diff with `malformed EVOLVE-BLOCK-END marker`.

The bug also reproduces on the `fix/correctness-concurrency` branch from PR #150, so this does not overlap with the pending split PRs.

## Fix

Insert at the start of the END marker's line and restore the payload's trailing newline, so the marker keeps its own line and indentation:

```python
line_start = new_text.rfind("\n", 0, b) + 1
insertion = replace if replace.endswith("\n") else replace + "\n"
new_text = new_text[:line_start] + insertion + new_text[line_start:]
```

Inserting at the line start (rather than at `b`, which points at the marker's comment prefix) also keeps an indented END marker's indentation intact instead of transferring it to the payload.

## Tests

Four regression tests in `tests/test_edit_base.py`:

- `test_insertion_keeps_end_marker_on_own_line` (marker stays on its own line)
- `test_insertion_preserves_indented_end_marker` (indented markers keep their indentation)
- `test_consecutive_insertions_stay_valid_python` (compounding insertions still `ast.parse`; previously produced `y = 2z = 3# EVOLVE-BLOCK-END`)
- `test_insertion_accepted_for_block_comment_language` (Wolfram insertions apply instead of being rejected)

All four fail on `main` without the fix.

Validation per CONTRIBUTING:

- `uv run pytest -q -m "not requires_secrets"`: **823 passed, 1 deselected**
- `uv run ruff check tests --exclude tests/file.py`: passed
- `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_edit_base.py`: passed

Also adds a CHANGELOG entry under TBD / Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
