### PR TITLE
test(llm): isolate Gemini backend environment

### DIFF
--- a/tests/test_llm_client_backends.py
+++ b/tests/test_llm_client_backends.py
@@ -152,6 +152,7 @@ def test_get_client_llm_azure_responses_request_uses_v1_url(monkeypatch):
 
 
 def test_get_client_llm_gemini_sets_timeout(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     captured_kwargs = {}
     fake_client = object()
 
@@ -178,6 +179,7 @@ def test_get_client_llm_gemini_sets_timeout(monkeypatch):
 
 
 def test_get_async_client_llm_gemini_sets_timeout(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     captured_kwargs = {}
     fake_client = object()
 


### PR DESCRIPTION
## What changed
- Clear GEMINI_API_KEY inside the two constructor tests that assert absent-key behavior.

## Why
The post-merge gate for #164 exposed that these tests inherited a developer .env credential. GitHub CI passed only because that environment is absent there.

## Verification
- Focused regressions: 2 passed with GEMINI_API_KEY present in the repository environment
- Ruff: passed
- Mypy: passed