### PR TITLE
fix(llm): key anthropic response parsing on block type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ All notable changes to `shinka-evolve` are documented in this file.
 
 ### Fixed
 
+- Fixed Anthropic response parsing to dispatch by content-block type, avoiding
+  crashes and truncated output for redacted, thinking-only, and multi-block
+  responses in PR #188. Thanks @Atharva-Kanherkar.
 - Fixed Anthropic and DeepSeek token/cost accounting parity across synchronous
   and asynchronous queries, including thinking-token decomposition and safe
   zero-cost fallback for models missing from the pricing catalog. Runtime

--- a/shinka/llm/providers/anthropic.py
+++ b/shinka/llm/providers/anthropic.py
@@ -41,6 +41,26 @@ def get_anthropic_costs(response, model):
     }
 
 
+def split_content_blocks(response):
+    """Split response blocks into visible text and thinking, keyed on block type.
+
+    Anthropic returns a list of typed blocks (text, thinking, redacted_thinking,
+    tool_use, ...) whose attributes differ per type, and the ordering and count
+    are not guaranteed. Unknown types are skipped.
+    """
+    text_parts = []
+    thought_parts = []
+    for block in response.content:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text_parts.append(block.text)
+        elif block_type == "thinking":
+            thought_parts.append(block.thinking)
+        elif block_type == "redacted_thinking":
+            thought_parts.append(getattr(block, "data", ""))
+    return "\n".join(text_parts), "\n".join(thought_parts)
+
+
 def backoff_handler(details):
     exc = details.get("exception")
     if exc:
@@ -91,13 +111,7 @@ def query_anthropic(
             messages=new_msg_history,
             **kwargs,
         )
-        # Separate thinking from non-thinking content
-        if len(response.content) == 1:
-            thought = ""
-            content = response.content[0].text
-        else:
-            thought = response.content[0].thinking
-            content = response.content[1].text
+        content, thought = split_content_blocks(response)
     else:
         raise NotImplementedError("Structured output not supported for Anthropic.")
     new_msg_history.append(
@@ -169,13 +183,7 @@ async def query_anthropic_async(
             messages=new_msg_history,
             **kwargs,
         )
-        # Separate thinking from non-thinking content
-        if len(response.content) == 1:
-            thought = ""
-            content = response.content[0].text
-        else:
-            thought = response.content[0].thinking
-            content = response.content[1].text
+        content, thought = split_content_blocks(response)
     else:
         raise NotImplementedError("Structured output not supported for Anthropic.")
     new_msg_history.append(

--- a/tests/test_anthropic_accounting.py
+++ b/tests/test_anthropic_accounting.py
@@ -1,7 +1,9 @@
-"""Regression tests for Anthropic pricing fallback parity."""
+"""Regression tests for Anthropic pricing parity and response block parsing."""
 
 import asyncio
 from types import SimpleNamespace
+
+import pytest
 
 import shinka.llm.providers.anthropic as anthropic_provider
 from shinka.llm.providers.anthropic import (
@@ -22,7 +24,7 @@ def _response(
         else SimpleNamespace(thinking_tokens=thinking_tokens)
     )
     return SimpleNamespace(
-        content=[SimpleNamespace(text="ok")],
+        content=[SimpleNamespace(type="text", text="ok")],
         usage=SimpleNamespace(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -107,3 +109,96 @@ def test_sync_and_async_share_thinking_accounting():
 
     assert sync_result.output_tokens == async_result.output_tokens == 13
     assert sync_result.thinking_tokens == async_result.thinking_tokens == 7
+
+
+def _blocks_response(blocks):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type=name, **attrs) for name, attrs in blocks],
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=20,
+            output_tokens_details=None,
+        ),
+    )
+
+
+CONTENT_BLOCK_CASES = [
+    pytest.param([("text", {"text": "a"})], "a", "", id="text-only"),
+    pytest.param(
+        [("thinking", {"thinking": "t"}), ("text", {"text": "a"})],
+        "a",
+        "t",
+        id="thinking-then-text",
+    ),
+    pytest.param(
+        [
+            ("thinking", {"thinking": "t"}),
+            ("redacted_thinking", {"data": "e"}),
+            ("text", {"text": "a"}),
+        ],
+        "a",
+        "t\ne",
+        id="redacted-thinking-in-the-middle",
+    ),
+    pytest.param(
+        [("redacted_thinking", {"data": "e"}), ("text", {"text": "a"})],
+        "a",
+        "e",
+        id="redacted-thinking-first",
+    ),
+    pytest.param([("thinking", {"thinking": "t"})], "", "t", id="thinking-only"),
+    pytest.param(
+        [
+            ("thinking", {"thinking": "t"}),
+            ("text", {"text": "p1"}),
+            ("text", {"text": "p2"}),
+        ],
+        "p1\np2",
+        "t",
+        id="several-text-blocks",
+    ),
+    pytest.param(
+        [("text", {"text": "a"}), ("tool_use", {"id": "u1", "name": "f", "input": {}})],
+        "a",
+        "",
+        id="unhandled-block-type-is-skipped",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "blocks, expected_content, expected_thought", CONTENT_BLOCK_CASES
+)
+def test_content_blocks_are_split_by_type(blocks, expected_content, expected_thought):
+    result = query_anthropic(
+        _Client(_blocks_response(blocks)),
+        "anthropic/not-in-catalog",
+        "msg",
+        "sys",
+        [],
+        None,
+    )
+
+    assert result.content == expected_content
+    assert result.thought == expected_thought
+
+
+@pytest.mark.parametrize(
+    "blocks, expected_content, expected_thought", CONTENT_BLOCK_CASES
+)
+def test_async_content_blocks_are_split_by_type(
+    blocks, expected_content, expected_thought
+):
+    result = asyncio.run(
+        query_anthropic_async(
+            _Client(_blocks_response(blocks), asynchronous=True),
+            "anthropic/not-in-catalog",
+            "msg",
+            "sys",
+            [],
+            None,
+        )
+    )
+
+    assert result.content == expected_content
+    assert result.thought == expected_thought


### PR DESCRIPTION
## Summary

- `query_anthropic` and `query_anthropic_async` derived `content` and `thought` from positional indices (`response.content[0].thinking`, `response.content[1].text`), which assumes every multi-block response is exactly `[thinking, text]`. Both call sites now go through one `split_content_blocks` helper that accumulates parts by inspecting each block's `type`.
- Added regression coverage for the block shapes that previously raised or truncated, run against both query paths.

## Why

`response.content` is a list of typed blocks whose attributes differ per type, and neither the ordering nor the count is guaranteed. Extended thinking is enabled for Anthropic and Bedrock reasoning models in `shinka/llm/kwargs.py`, and models reporting `requires_reasoning` have the effort forced up from `disabled` to `low`, so multi-block responses occur in normal operation.

Three concrete failures:

1. `redacted_thinking` blocks carry `data` and have neither `thinking` nor `text`, so `[thinking, redacted_thinking, text]` and `[redacted_thinking, text]` both raised `AttributeError`.
2. A response that stops inside the thinking block leaves a single thinking block, so the `len(...) == 1` branch read `.text` off it and raised `AttributeError`.
3. `[thinking, text, text]` did not raise; it returned block 1 and discarded every later text block, so the recorded answer was silently truncated.

The crashes were worse than an ordinary exception because extraction runs inside the `backoff.on_exception` decorator, whose retry tuple is `(APIConnectionError, APIStatusError, RateLimitError, APITimeoutError)`. `AttributeError` is not in it, so the query aborted on first occurrence and the generation was lost rather than retried.

The multi-block branch had no test coverage: every response built in `tests/test_anthropic_accounting.py` had a single text block, exercising only the `len(...) == 1` path.

## Linked issue or context

Fixes #187.

## Testing

- Commands run:
  - `uv run ruff check tests --exclude tests/file.py`
  - `uv run mypy --follow-imports=skip --ignore-missing-imports tests/test_*.py tests/conftest.py`
  - `uv run --with pytest-cov pytest -q -m "not requires_secrets and not models_dev_live" --cov=shinka --cov-report=term-missing`
- Optional secret-backed tests: not run, no provider credentials configured in this environment. The change is confined to parsing an already-returned response object, and the added tests stub the client the same way the existing tests in that module do.
- Results:
  - `ruff check`: all checks passed. `ruff format --check` also clean on both touched files.
  - `mypy`: success, no issues found in 75 source files.
  - `pytest`: 894 passed, 2 deselected.
  - `tests/test_anthropic_accounting.py`: 18 passed.
  - Confirmed the new tests are meaningful rather than tautological: with the provider reverted to its previous version, 10 of them fail (the 5 broken shapes across both paths) while the 2 already-working shapes and the 4 pre-existing accounting tests still pass. With the fix, all 18 pass.

## Risks and compatibility

- No API or signature change. `split_content_blocks` is additive and both existing call sites keep returning the same `(content, thought)` pair.
- The intended `[thinking, text]` shape returns byte-identical output to before, so normal runs are unaffected.
- Multiple text blocks now join with a newline instead of silently dropping all but the first. That is a behaviour change, in the direction of not losing model output.
- Block types the helper does not recognise, including `tool_use` and any future type, are skipped rather than raising. This repository does not currently send `tools`, so no `tool_use` block is expected today; skipping is defensive so a later change cannot reintroduce the crash.
- Cost accounting (`get_anthropic_costs`), the `new_msg_history` assistant entry, and the structured-output branch are untouched.

## Core evolution pipeline evidence

Not applicable. This does not touch parent selection, mutation or edit generation, archive updates, prompt evolution, novelty logic, evaluation scheduling, proposal oversubscription, or island behaviour. It is confined to parsing one provider's response payload.

## Docs and UI

- No docs change needed; no user-facing configuration, CLI output, or WebUI behaviour changes.
- No UI change, so no screenshots.
